### PR TITLE
Modify RS time extraction to handle observed date string variation

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -48,7 +48,7 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lates
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy matplotlib h5py scikit-image && \
      /opt/conda/bin/conda install -y -c pytorch cudatoolkit=10.0 "pytorch=1.2.0=py3.6_cuda10.0.130_cudnn7.6.2_0" torchvision=0.4.0 && \
      /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
      /opt/conda/bin/conda clean -ya

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -64,7 +64,7 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lates
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy matplotlib h5py scikit-image && \
      /opt/conda/bin/conda install -y -c pytorch cpuonly "pytorch=1.2.0=py3.6_cpu_0" torchvision=0.4.0=py36_cpu && \
      /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
      /opt/conda/bin/conda clean -ya

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -64,7 +64,7 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lates
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil numpy scipy matplotlib h5py scikit-image && \
      /opt/conda/bin/conda install -y -c pytorch cpuonly "pytorch=1.2.0=py3.6_cpu_0" torchvision=0.4.0=py36_cpu && \
      /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
      /opt/conda/bin/conda clean -ya

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -64,7 +64,7 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lates
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil numpy scipy scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy scikit-image && \
      /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -64,7 +64,7 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lates
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy scipy scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil numpy scipy scikit-image && \
      /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH

--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import datetime
+import dateutil.parser
 import argparse
 import yaml
 
@@ -16,31 +17,12 @@ def get_recon_all_stage_duration(line, previous_datetime_str):
     :return: str stage_duration: stage duration in seconds
     """
 
-    current_datetime_str = extract_datetime_str(line)
-    current_date_time = datetime.datetime.strptime(current_datetime_str, '%b %d %Y %H:%M:%S')
-    previous_date_time = datetime.datetime.strptime(previous_datetime_str, '%b %d %Y %H:%M:%S')
+    current_datetime_str = ' '.join(line.split(' ')[-6:])
+    current_date_time = dateutil.parser.parse(current_datetime_str)
+    previous_date_time = dateutil.parser.parse(previous_datetime_str)
     stage_duration = (current_date_time - previous_date_time).total_seconds()
 
     return stage_duration
-
-def extract_datetime_str(line):
-    """
-    Construct string containing recon-all stage date and time from a log string,
-    for easier parsing with datetime functions.
-    (Example: "#@# STAGE_NAME Sun Nov 14 12:31:34 UTC 2021" --> "Nov 14 2021 12:31:34")
-
-    :param str line: line in recon-surf.log containing recon-all stage info.
-        This must be of the form:
-        #@# STAGE_NAME Fri Nov 26 15:51:40 UTC 2021
-
-    :return: str datetime_str: extracted datetime string
-    """
-    datetime_str = line.split(' ')[-5] + ' ' + \
-                   line.split(' ')[-4] + ' ' + \
-                   line.split(' ')[-1] + ' ' + \
-                   line.split(' ')[-3]
-
-    return datetime_str
 
 
 if __name__ == "__main__":
@@ -158,7 +140,7 @@ if __name__ == "__main__":
 
                         stage_name = ' '.join(lines[j].split(' ')[:-6][1:])
                         previous_stage_start_time = lines[j].split(' ')[-3]
-                        previous_datetime_str = extract_datetime_str(lines[j])
+                        previous_datetime_str = ' '.join(lines[j].split(' ')[-6:])
 
                     ## Lines containing 'Ended' are used to find the end time of the last stage:
                     if 'Ended' in lines[j]:

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ nibabel==2.5.1
 numpy==1.17.4
 scikit-image==0.15.0
 scipy==1.3.1
+python-dateutil==2.8.2
 
 # Lapy installation from git
 git+https://github.com/Deep-MI/LaPy.git#egg=lapy

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ numpy==1.17.4
 scikit-image==0.15.0
 scipy==1.3.1
 python-dateutil==2.8.2
+pyyaml==5.4.1
 
 # Lapy installation from git
 git+https://github.com/Deep-MI/LaPy.git#egg=lapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,10 @@ pillow==8.3.2
     #   torchvision
 pyparsing==2.4.7
     # via matplotlib
-python-dateutil==2.8.1
-    # via matplotlib
+python-dateutil==2.8.2
+    # via
+    #   -r requirements.in
+    #   matplotlib
 pywavelets==1.1.1
     # via scikit-image
 scikit-image==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,8 @@ python-dateutil==2.8.2
     #   matplotlib
 pywavelets==1.1.1
     # via scikit-image
+pyyaml==5.4.1
+    # via -r requirements.in
 scikit-image==0.15.0
     # via -r requirements.in
 scipy==1.3.1


### PR DESCRIPTION
## Summary

This introduces a minor modification to `extract_recon_surf_time_info.py` to handle cases where a `recon-all` stage log entry in `recon-surf.log` has a slightly different date-time string format (single-digit for day integer).

The modification depends on the `dateutil` python module, which has been explicitly added as a dependency (in conda install commands in relevant dockerfiles, and in the `requirements.in` and compiled `requirements.txt` files).

Similarly, the `pyyaml` module dependency has been added (in case it is not installed in the environment).


## Problem Description

In `extract_recon_surf_time_info.py`, the `extract_datetime_str()` was implemented to construct a string out of the `recon-all` stage logs in `recon-surf.log` (see example below) which can then be interpreted with the `strptime()` function of the native `datetime` library. The purpose is to compute stage durations by subtracting time points.

This worked reliably as long as the string format was exactly as in the following example.

`recon-all` stage log entry example:
```
#--------------------------------------
#@# Merge ASeg Mon Nov 22 15:58:42 UTC 2021
```

However, `recon-surf.log` was later observed to produce a string like the following, in which there is an extra space after the month substring (presumably due to a single-digit day integer, i.e. " 7" instead of "07"):
```
#--------------------------------------
#@# Merge ASeg Tue Dec  7 14:52:23 UTC 2021
```

This leads to an error:
```
Traceback (most recent call last):
  File "/fastsurfer/recon_surf/utils/extract_recon_surf_time_info.py", line 144, in <module>
    stage_duration = get_recon_all_stage_duration(lines[j], previous_datetime_str)
  File "/fastsurfer/recon_surf/utils/extract_recon_surf_time_info.py", line 20, in get_recon_all_stage_duration
    current_date_time = datetime.datetime.strptime(current_datetime_str, '%b %d %Y %H:%M:%S')
  File "/opt/conda/lib/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/opt/conda/lib/python3.6/_strptime.py", line 362, in _strptime
    (data_string, format))
ValueError: time data ' 7 2021 14:52:23' does not match format '%b %d %Y %H:%M:%S'
```

## Solution

This can be avoided by utilizing the third-party library: `dateutil`, which contains a parsing function that is robust to this variation in space characters.

With the string from the second example above, `dateutil.parser.parse()` returns the correction interpretation:
```
datetime.datetime(2021, 12, 7, 14, 52, 23, tzinfo=tzutc())
```
This also has the advantage of eliminating the need for the `extract_datetime_str()` function, since `dateutil.parser.parse()` can interpret the string from `recon-surf.log` as-is.
