### PR TITLE
Saving conformed input in FastSurferCNN to use in recon-surf

### DIFF
--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -55,7 +55,8 @@ def options_parse():
     parser = optparse.OptionParser(version='$Id: conform.py,v 1.0 2019/07/19 10:52:08 mreuter Exp $',
                                    usage=HELPTEXT)
     parser.add_option('--input', '-i', dest='input', help=h_input)
-    parser.add_option('--output', '-o', dest='output', help=h_output)
+    parser.add_option('--output', '-o', dest='output', help=h_output,
+                      default='./conformed_img.mgz')
     parser.add_option('--order', dest='order', help=h_order, type="int", default=1)
     parser.add_option('--check_only', dest='check_only', default=False, action='store_true',
                       help='If True, only checks if the input image is conformed')
@@ -63,8 +64,8 @@ def options_parse():
                       help='Specifies whether the input is a seg image. If true, '
                            'the check for conformance disregards the uint8 dtype criteria')
     (fin_options, args) = parser.parse_args()
-    if fin_options.input is None or fin_options.output is None:
-        sys.exit('ERROR: Please specify input and output images')
+    if fin_options.input is None:
+        sys.exit('ERROR: Please specify input image')
     return fin_options
 
 

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -63,6 +63,8 @@ def options_parse():
     parser.add_option('--seg_input', dest='seg_input', default=False, action='store_true',
                       help='Specifies whether the input is a seg image. If true, '
                            'the check for conformance disregards the uint8 dtype criteria')
+    parser.add_option('--verbose', dest='verbose', default=False, action='store_true',
+                      help='If verbose, more specific messages are printed')
     (fin_options, args) = parser.parse_args()
     if fin_options.input is None:
         sys.exit('ERROR: Please specify input image')
@@ -256,7 +258,7 @@ def conform(img, order=1):
     return new_img
 
 
-def is_conform(img, eps=1e-06, check_dtype=True):
+def is_conform(img, eps=1e-06, check_dtype=True, verbose=True):
     """
     Function to check if an image is already conformed or not (Dimensions: 256x256x256, Voxel size: 1x1x1, and
     LIA orientation.
@@ -299,9 +301,11 @@ def is_conform(img, eps=1e-06, check_dtype=True):
     if all(criteria.values()):
         return True
     else:
-        print('The input image is not conformed. A conformed image must satisfy the following criteria:')
-        for condition, value in criteria.items():
-            print(' - {:<30} {}'.format(condition+':', value))
+        print('The input image is not conformed.')
+        if verbose:
+            print('A conformed image must satisfy the following criteria:')
+            for condition, value in criteria.items():
+                print(' - {:<30} {}'.format(condition+':', value))
         return False
 
 
@@ -369,9 +373,9 @@ if __name__ == "__main__":
         sys.exit('ERROR: Multiple input frames (' + format(image.shape[3]) + ') not supported!')
 
     if not options.seg_input:
-        image_is_conformed = is_conform(image, check_dtype=True)
+        image_is_conformed = is_conform(image, check_dtype=True, verbose=options.verbose)
     else:
-        image_is_conformed = is_conform(image, check_dtype=False)
+        image_is_conformed = is_conform(image, check_dtype=False, verbose=options.verbose)
 
     if image_is_conformed:
         print("Input " + format(options.input) + " is already conformed! Exiting.\n")

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -250,7 +250,7 @@ def conform(img, order=1):
     return new_img
 
 
-def is_conform(img, eps=1e-06):
+def is_conform(img, eps=1e-06, check_dtype=True):
     """
     Function to check if an image is already conformed or not (Dimensions: 256x256x256, Voxel size: 1x1x1, and
     LIA orientation.
@@ -279,6 +279,10 @@ def is_conform(img, eps=1e-06):
     iaffine = img.affine[0:3, 0:3] + [[1, 0, 0], [0, 0, -1], [0, 1, 0]]
 
     if np.max(np.abs(iaffine)) > 0.0 + eps:
+        return False
+
+    # check dtype uchar
+    if check_dtype and img.get_data_dtype() != 'uint8':
         return False
 
     return True

--- a/FastSurferCNN/eval.py
+++ b/FastSurferCNN/eval.py
@@ -88,6 +88,8 @@ def options_parse():
                         help='name under which segmentation will be saved. Default: aparc.DKTatlas+aseg.deep.mgz. '
                              'If a separate subfolder is desired (e.g. FS conform, add it to the name: '
                              'mri/aparc.DKTatlas+aseg.deep.mgz)')
+    parser.add_argument('--conformed_input', '--conformed_input', dest='conformed_input', default='conformed_input.mgz',
+                        help='Name under which the conformed input image will be saved. Default: conformed_input.mgz.')
     parser.add_argument('--order', dest='order', type=int, default=1,
                         help="order of interpolation (0=nearest,1=linear(default),2=quadratic,3=cubic)")
 
@@ -265,6 +267,11 @@ def fastsurfercnn(img_filename, save_as, use_cuda, gpu_small, logger, args):
     logger.info("Reading volume {}".format(img_filename))
 
     header_info, affine_info, orig_data = load_and_conform_image(img_filename, interpol=1, logger=logger)
+
+    # Save conformed input image to use in recon-surf later
+    conformed_orig_img = nib.MGHImage(orig_data, affine_info, header_info)
+    conformed_orig_img.to_filename(args.conformed_input)
+    logger.info("Saving conformed original image to {}".format(args.conformed_input))
 
     # Set up model for axial and coronal networks
     params_network = {'num_channels': args.num_channels, 'num_filters': args.num_filters,

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -413,10 +413,10 @@ echo "================== Creating orig and rawavg from input ===================
 echo " " |& tee -a $LF
 
 # check for input conformance
-cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only"
+cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only --verbose"
 RunIt "$cmd" $LF
 
-cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $seg --check_only --seg_input"
+cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $seg --check_only --seg_input --verbose"
 RunIt "$cmd" $LF
 
 # create orig.mgz and aparc+aseg.orig.mgz (copy of segmentation)

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -412,8 +412,15 @@ echo " " |& tee -a $LF
 echo "================== Creating orig and rawavg from input =========================" |& tee -a $LF
 echo " " |& tee -a $LF
 
+# check for input conformance
+cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only"
+RunIt "$cmd" $LF
+
+cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $seg --check_only --seg_input"
+RunIt "$cmd" $LF
+
 # create orig.mgz and aparc+aseg.orig.mgz (copy of segmentation)
-cmd="mri_convert -c $t1 $mdir/orig.mgz"
+cmd="mri_convert $t1 $mdir/orig.mgz"
 RunIt "$cmd" $LF
 
 cmd="mri_convert $seg $mdir/aparc+aseg.orig.mgz"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -273,6 +273,11 @@ if [ -z "$seg" ]
     seg="${sd}/${subject}/mri/aparc.DKTatlas+aseg.deep.mgz"
 fi
 
+if [ -z "$conformed_input" ]
+  then
+    conformed_input="${sd}/${subject}/mri/conformed_orig.mgz"
+fi
+
 if [ -z "$seg_log" ]
  then
     seg_log="${sd}/${subject}/scripts/deep-seg.log"
@@ -319,7 +324,7 @@ if [ "$surf_only" == "0" ]; then
   echo "" |& tee -a $seg_log
 
   pushd $fastsurfercnndir
-  cmd="$python eval.py --in_name $t1 --out_name $seg --order $order --network_sagittal_path $weights_sag --network_axial_path $weights_ax --network_coronal_path $weights_cor --batch_size $batch_size --simple_run $clean_seg --run_viewagg_on $viewagg $cuda"
+  cmd="$python eval.py --in_name $t1 --out_name $seg --conformed_input $conformed_input --order $order --network_sagittal_path $weights_sag --network_axial_path $weights_ax --network_coronal_path $weights_cor --batch_size $batch_size --simple_run $clean_seg --run_viewagg_on $viewagg $cuda"
   echo $cmd |& tee -a $seg_log
   $cmd |& tee -a $seg_log
   if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
@@ -330,7 +335,7 @@ if [ "$seg_only" == "0" ]; then
   # ============= Running recon-surf (surfaces, thickness etc.) ===============
   # use recon-surf to create surface models based on the FastSurferCNN segmentation.
   pushd $reconsurfdir
-  cmd="./recon-surf.sh --sid $subject --sd $sd --t1 $t1 --seg $seg $seg_cc $vol_segstats $fstess $fsqsphere $fsaparc $fssurfreg $doParallel --threads $threads --py $python $vcheck $vfst1"
+  cmd="./recon-surf.sh --sid $subject --sd $sd --t1 $conformed_input --seg $seg $seg_cc $vol_segstats $fstess $fsqsphere $fsaparc $fssurfreg $doParallel --threads $threads --py $python $vcheck $vfst1"
   $cmd
   if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   popd


### PR DESCRIPTION
## Description

This PR adds saving of the conformed image used as input to the FastSurferCNN network, so that it can later be used in `recon-surf.sh`. 

Previously, `mri_convert  -c` was used in `recon-surf.sh` to create `orig.mgz` from the input image. If the input image was not conformed to 256 beforehand, this caused a mismatch between the image and output segmentation (leading to issues as in  https://github.com/Deep-MI/FastSurfer/issues/45).

The modification ensures that the mismatch does not occur by always passing in the saved conformed input image to `recon-surf.sh` (through `run_fastsurfer.sh` by default).
The `conform.py` script is used to check whether both input image and segmentation are conformed in `recon_surf.sh` (for the latter, the UCHAR criterion is disregarded). If either is not, `recon_surf.sh` will fail. This check is necessary to validate inputs that are not produced by FastSurferCNN, for example.
The script has been slightly modified to enable this behaviour.

### Changes

Here's a brief summary of the changes:
 - `is_conform` also checks whether `dtype` of input is UCHAR (`uint8`)
 - `is_conform` can display specifically which conformance criteria were violated (controlled by verbosity flag: off by default in the script, but on by default in `recon_surf.sh`); see example output below
 - `is_conform` has a `check_dtype` flag, which is off when the input image is a segmentation
 - `conform.py` has `check_only` (only check if the input image is conformed) and `seg_input` (consider the input image a segmentation, and set `check_dtype` to `True`) flags, and returns appropriate error codes
 - `eval.py` writes out the conformed input image
 - `run_fastsurfer.sh` specifies `conformed_input`, the path of the to-be conformed input image (default: `/mri/conformed_orig.mgz`)
 - `run_fastsurfer.sh` passes in `conformed_input` to the `t1` argument of `recon-surf.sh` by default
 - `recon_surf.sh` uses `conform.py` to check for conformance of `t1` and `seg`

### `is_conform` verbose output example

An example of a non-conformed input image being used as input to `conform.py`, with flags `check_only` and `verbose`:

```
Reading input: ./001.mgz ...
The input image is not conformed.
A conformed image must satisfy the following criteria:
 - Dimensions 256x256x256:        False
 - Voxel size 1x1x1:              False
 - Orientation LIA:               False
 - Dtype uint8:                   False
check_only flag provided. Exiting without conforming input image.
```