### PR TITLE
Fix: RS time extraction; handling failed spherically_project case

### DIFF
--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
     timestamp_feature = '@#@FSTIME'
     recon_all_stage_feature = '#@# '
-    cmd_line_filter_phrases = ['done', 'Done', 'successful', 'finished without error', 'cmdline' ,'Running command']
+    cmd_line_filter_phrases = ['done', 'Done', 'successful', 'finished without error', 'cmdline' ,'Running command', 'failed']
     filtered_cmds = ['ln ', 'rm ']
 
     if args.output_file_path == '':


### PR DESCRIPTION
## Summary

This PR applies a minor fix to `extract_recon_surf_time_info.py` to handle a special case in which `spherically_project_wrapper.py` fails. This previously caused an incorrect extraction of the command name ('Command' instead of 'python3.6 spherically_project_wrapper.py').

The fix for this is to simply include the string 'failed' in the `cmd_line_filter_phrases` list in `extract_recon_surf_time_info.py`.


## Description

The aforementioned special case occurs when `python3.6 spherically_project_wrapper.py` fails:
```
Command python3.6 /fastsurfer/recon_surf/spherically_project.py -i /X/surf/lh.smoothwm.nofix -o /X/surf/lh.qsphere.nofix failed.
```

Subsequently, `recon-surf` falls back on the `recon-all` command:
```
Running fallback command: recon-all -s X -hemi lh -qsphere -no-isrunning
```

In this case, the logic in `extract_recon_surf_time_info.py` would lead to extracting the last-run command's name from the "failed" line, which includes the word "Command".

Therefore, the output in the `recon-surf_times.yaml` files looks as follows:
```
- Creating-surfaces-lh---qsphere:
  - cmd: Command python3.6 /fastsurfer/recon_surf/spherically_project.py -i /X/surf/lh.smoothwm.nofix -o /X/surf/lh.qsphere.nofix failed.
    start: '10:23:28'
    stop: '10:26:17'
    duration_m: 2.82
```

## Solution

This can be rectified by adding the string 'failed ' to the `cmd_line_filter_phrases` list in `extract_recon_surf_time_info.py`, to avoid picking up these lines for command name extraction.

The output in the `recon-surf_times.yaml` file is therefore corrected:

```
- Creating-surfaces-lh---qsphere:
  - cmd: python3.6 /fastsurfer/recon_surf/spherically_project_wrapper.py --hemi lh --sdir /X/surf --subject XXXX --threads=1 --py python3.6 --binpath /fastsurfer/recon_surf/
    start: '10:23:28'
    stop: '10:26:17'
    duration_m: 2.82
```

This fix has been tested with the full pipeline multiple times.

**NOTE**: The fact that `spherically_project_wrapper.py` internally falls back on the `recon-all` command is not reflected in the extracted  `recon-surf_times.yaml`. Although a duration of 2.82 m is reported above under command `spherically_project_wrapper.py`, this was actually spent running `recon-all ... -qsphere ...`.

