### PR TITLE
Fix: RS time extraction; recon-all stage name for date string variation

### DIFF
--- a/recon_surf/utils/README.md
+++ b/recon_surf/utils/README.md
@@ -24,6 +24,6 @@ Entries are grouped according to the section in `recon_surf.sh` in which the com
 The following will extract recon_surf command time information from `123456/scripts/recon-surf.log` and save it in `123456/scripts/recon-surf_times.yaml` (with durations in minutes).
 
 ```
-python3 extract_recon_surf_time_info.py --in_file_path 123456/scripts/recon-surf.log --time_units m
+python3 extract_recon_surf_time_info.py --input_file_path 123456/scripts/recon-surf.log --time_units m
 ```
 

--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -17,7 +17,7 @@ def get_recon_all_stage_duration(line, previous_datetime_str):
     :return: str stage_duration: stage duration in seconds
     """
 
-    current_datetime_str = ' '.join(line.split(' ')[-6:])
+    current_datetime_str = ' '.join(line.split()[-6:])
     current_date_time = dateutil.parser.parse(current_datetime_str)
     previous_date_time = dateutil.parser.parse(previous_datetime_str)
     stage_duration = (current_date_time - previous_date_time).total_seconds()
@@ -77,15 +77,15 @@ if __name__ == "__main__":
             ## Parse out cmd name, start time, and duration:
             entry_dict = {}
 
-            cmd_name = line.split(' ')[3] + ' '
+            cmd_name = line.split()[2] + ' '
             if cmd_name in filtered_cmds:
                 continue
-            date_time_str = line.split(' ')[2]
+            date_time_str = line.split()[1]
             start_time = date_time_str[11:]
 
             start_date_time = datetime.datetime.strptime(date_time_str, '%Y:%m:%d:%H:%M:%S')
-            assert line.split(' ')[6] == 'e'
-            cmd_duration = float(line.split(' ')[7])
+            assert line.split()[5] == 'e'
+            cmd_duration = float(line.split()[6])
 
             end_date_time = (start_date_time + datetime.timedelta(0, float(cmd_duration)))
             end_date_time_str = end_date_time.strftime('%Y:%m:%d:%H:%M:%S')
@@ -118,11 +118,11 @@ if __name__ == "__main__":
                 first_stage = True
 
                 for j in range(cmd_line_index, i):
-                    if recon_all_stage_feature in lines[j] and len(lines[j].split(' ')) > 5:
+                    if recon_all_stage_feature in lines[j] and len(lines[j].split()) > 5:
                         ## the second condition avoids lines such as "#@# 241395 lh 227149"
 
                         if not first_stage:
-                            current_stage_start_time = lines[j].split(' ')[-3]
+                            current_stage_start_time = lines[j].split()[-3]
                             stage_duration = get_recon_all_stage_duration(lines[j], previous_datetime_str)
 
                             stage_dict = {}
@@ -138,13 +138,13 @@ if __name__ == "__main__":
                         else:
                             first_stage = False
 
-                        stage_name = ' '.join(lines[j].split(' ')[:-6][1:])
-                        previous_stage_start_time = lines[j].split(' ')[-3]
-                        previous_datetime_str = ' '.join(lines[j].split(' ')[-6:])
+                        stage_name = ' '.join(lines[j].split()[:-6][1:])
+                        previous_stage_start_time = lines[j].split()[-3]
+                        previous_datetime_str = ' '.join(lines[j].split()[-6:])
 
                     ## Lines containing 'Ended' are used to find the end time of the last stage:
                     if 'Ended' in lines[j]:
-                        current_stage_start_time = lines[j].split(' ')[-3]
+                        current_stage_start_time = lines[j].split()[-3]
                         stage_duration = get_recon_all_stage_duration(lines[j], previous_datetime_str)
 
                         stage_dict = {}


### PR DESCRIPTION
## Summary

This PR applies a fix to `extract_recon_surf_time_info.py` to handle a variation in Freesurfer command date-time strings as represented in `recon-surf.log`, particularly when single-digit day integers are represented by ' X' instead of 'XX'. In this case, `recon-all` stage names are extracted with an extra appended string.

This is fixed by improving the string parsing behaviour within the script to be robust to variations in the number of whitespace characters separating segments of date-time strings.

In addition, this includes correcting a typo in `utils/README.md`; `in_file_path` had been referred to, instead of the correct argument name `input_file_path`.

## Description

Consider a `recon-surf.log` entry for a `recon-all` command such as the following:
```
#@# ASeg Stats Sat Jan  1 03:57:53 UTC 2022
```

This would previously lead to an erroneous extraction of the `stage_name` in the resultant `recon-surf_times.yaml` file, where the name includes a segment of the associated date-time string:
```
  - cmd: recon-all -s XXXX -segstats	
    start: 03:57:52	
    stop: 04:00:24	
    duration_m: 2.54	
    stages:	
    - stage_name: ASeg Stats Sat	
      start: 03:57:53
```

## Solution

Previously, various strings were explicitly split at single white spaces (for e.g.: `string.split(' ')`) within the script, since this originally produced consistently correct outputs. To now account for this case, the splitting function was modified to work for arbitrary numbers of white space characters within any string (which is natively enabled by the `split` function by not specifying an argument: `string.split()`.

This modification and adapting the script accordingly leads to the intended behaviour and output:
```
  - cmd: recon-all -s X -segstats
    start: 03:57:52
    stop: 04:00:24
    duration_m: 2.54
    stages:
    - stage_name: ASeg Stats
      start: 03:57:53
```

Note that this also makes string parsing generally more robust to possible mistakes in the number of white space characters within parsed strings.