### PR TITLE
Specifying Miniconda version in Dockerfile install

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     	--exclude='freesurfer/lib/qt'
 
 # Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 
 # Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \

--- a/Docker/Dockerfile_FastSurferCNN
+++ b/Docker/Dockerfile_FastSurferCNN
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          rm -rf /var/lib/apt/lists/*
 	 
 # Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \

--- a/Docker/Dockerfile_FastSurferCNN_CPU
+++ b/Docker/Dockerfile_FastSurferCNN_CPU
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          rm -rf /var/lib/apt/lists/*
 
 # Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 
 # Install miniconda and needed python packages (for recon-surf)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \


### PR DESCRIPTION
## Description

This PR modifies the installation of Miniconda in all Dockerfiles, such that version 4.10.3 is specifically installed instead of the latest: `Miniconda3-py37_4.10.3-Linux-x86_64.sh` instead of `Miniconda3-latest-Linux-x86_64.sh`.

As of yesterday, the latest script was set to install the new 4.11.0 version. This Miniconda version fails to install the versions of conda packages specified in the Dockerfiles due to unsolvable conflicts.

(See the following for the output of the install command showing the conflicts: [failed_fastsurfer_conda_install_trace.txt](https://github.com/Deep-MI/FastSurfer/files/8079975/failed_fastsurfer_conda_install_trace.txt))

Switching to the specific, currently supported Miniconda version avoids this problem.
