### PR TITLE
FIX: guide sphere reg with FastSurferCNN precentral

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -668,8 +668,31 @@ if [ "$fsaparc" == "1" ] || [ "$fssurfreg" == "1" ] ; then
   echo "echo \" \"" |& tee -a $CMDF
 
   # Surface registration for cross-subject correspondance (registration to fsaverage)
-  cmd="recon-all -s $subject -hemi $hemi -sphere -surfreg -no-isrunning $fsthreads"
+  cmd="recon-all -s $subject -hemi $hemi -sphere -no-isrunning $fsthreads"
   RunIt "$cmd" $LF "$CMDF"
+  
+  # (mr) FIX: sometimes FreeSurfer Sphere Reg. fails and moves pre and post central 
+  # one gyrus too far posterior, FastSurferCNN's image-based segmentation does not 
+  # seem to do this, so we initialize the spherical registration with the better 
+  # label from FastSurferCNN, this replaces recon-al -surfreg
+  # 1. extract label 24 = precentral from FastSurferCNN mapped annotation
+  cmd="mri_annotation2label --subject $subject --hemi $hemi --label 24 --labelbase ${hemi}.mapped --annotation aparc.mapped"
+  RunIt "$cmd" $LF "$CMDF"
+  # 2. guide spherical registration to align label 24 to precentral in the atlas
+  cmd="mris_register -curv \
+       -L ${hemi}.mapped-024.label \
+       $FREESURFER_HOME/average/${hemi}.DKTaparc.atlas.acfb40.noaparc.i12.2016-08-02.gcs precentral \
+       $SUBJECTS_DIR/$subject/surf/${hemi}.sphere \
+       $FREESURFER_HOME/average/${hemi}.folding.atlas.acfb40.noaparc.i12.2016-08-02.tif \
+       $SUBJECTS_DIR/$subject/surf/${hemi}.sphere.reg"
+  RunIt "$cmd" $LF "$CMDF"
+  # command to generate new aparc to check if registration was OK
+  # run only for debugging
+  #cmd="mris_ca_label -l $SUBJECTS_DIR/$subject/label/${hemi}.cortex.label \
+  #     -aseg $SUBJECTS_DIR/$sid/mri/aseg.presurf.mgz \
+  #     -seed 1234 $sid $hemi $SUBJECTS_DIR/$sid/surf/${hemi}.sphere.reg \
+  #     $SUBJECTS_DIR/$sid/label/${hemi}.aparc.DKTatlas-guided.annot"
+  
 fi
 
 


### PR DESCRIPTION
This PR adds code to guide the FreeSurfer spherical atlas registration (mris_register) to place the pre-central cortex to where FastSurferCNN thinks it should be. 

The problem is that FreeSurfer sometimes places the pre and post-central gyri too far anterior during its spherical registration. This even happend in  FreeSurfer 7.2. for OASIS subject OAS1_0111 where the gyri placement differs even between the two test-retest images MR1 and MR2 (see attached image). Our pipeline recon-surf inherits these registration failures from FreeSurfer, when --surfreg is used, e.g. for cortical group analysis. 

OAS1_0111 MR2 and MR1 as processed with FreeSurfer 7.2:
<img width="1357" alt="Screenshot 2022-02-23 at 11 51 51" src="https://user-images.githubusercontent.com/8526484/157754805-ca5b29d1-9813-452f-9f22-c1f0e637cce6.png">

We noticed, however, that FastSurferCNN's image-based segmentation gets the position of pre-central correct in all cases (we checked OASIS1 so far). Therefore, we can improve the registration by guiding it to try to match FastSurferCNN's pre-central to the one of FreeSurfer's atlas. This fix should improve any type of downstream group analysis on cortical maps, where the vertex-wise correspondence is needed. It (should) only affect processing where the --fsaparc or --surfreg flags are used.

E.g. this case  shows OAS1_0067_MR1 Freesurfer 7.2 left and FastSurferCNN segmentation projected to the cortex on the right:
![OAS1_0067_MR1_fs72_vs_fastsurfer_prerelease_aparc_overlay](https://user-images.githubusercontent.com/8526484/157755085-67f46c0c-ef55-4990-a003-01777a8d1d2c.png)
Also here FreeSurfer (left) pushes the central gyri to far back, while FastSurferCNN seems to get it right. 


This fix needs to go into testing and can be added either to our upcoming 1.0 release or kept back for 1.1 . 
