### PR TITLE
Update recon-surf to FreeSurfer 7.2

### DIFF
--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -21,6 +21,9 @@ import optparse
 import numpy as np
 import sys
 import SimpleITK as sitk
+import nibabel as nib
+import image_io as iio
+
 
 HELPTEXT = """
 
@@ -261,7 +264,8 @@ if __name__ == "__main__":
 
     # read image (only nii supported) and convert to float32
     print("\nreading {}".format(options.invol))
-    itkimage = sitk.ReadImage(options.invol, sitk.sitkFloat32)
+    #itkimage = sitk.ReadImage(options.invol, sitk.sitkFloat32)
+    itkimage, header = iio.readITKimage(options.invol, sitk.sitkFloat32, with_header=True)
 
     # if talaraich is passed
     talorig = None
@@ -271,7 +275,8 @@ if __name__ == "__main__":
 
     # read mask (as uchar)
     if options.mask:
-        itkmask = sitk.ReadImage(options.mask, sitk.sitkUInt8)
+        #itkmask = sitk.ReadImage(options.mask, sitk.sitkUInt8)
+        itkmask = iio.readITKimage(options.mask, sitk.sitkUInt8)
     else:
         itkmask=None
 
@@ -288,7 +293,8 @@ if __name__ == "__main__":
 
     # write image
     print("writing: {}".format(options.outvol))
-    sitk.WriteImage(itkcorrected, options.outvol)
+    #sitk.WriteImage(itkcorrected, options.outvol)
+    iio.writeITKimage(itkcorrected,options.outvol, header)
     
     sys.exit(0)
 

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -186,7 +186,7 @@ def normalizeWM (itkimage, itkmask=None, radius=50, centroid=None, targetWM=110)
     #  warning do not use otsu mask as it is cropping low-intensity values
     if mask_passed:
         ball = ball*itkmask
-    #sitk.WriteImage(ball, "ball.nii.gz")
+    sitk.WriteImage(ball, "ball.nii.gz")
 
     # get 1 and 90 percentiles of intensities in ball
     aimg = sitk.GetArrayFromImage(itkimage)

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import optparse
+import numpy as np
+import sys
+import SimpleITK as sitk
+
+HELPTEXT = """
+
+Script to call SITK N4 Bias Correction
+
+USAGE:
+N4_bias_correct  --invol <img.nii> --outvol <corrected.nii> OPTIONS
+
+
+Dependencies:
+    Python 3.6
+
+    SimpleITK https://simpleitk.org/ (v2.1.1)
+
+
+N4 Bias Correction:
+
+The input image will be N4 bias corrected. Optimally you would pass a brainmask via
+--mask. If no mask is given, all 0 values will be masked to speed-up correction and
+avoid influence of flat zero regions on the bias field. 
+
+
+WM Normalization and UCHAR:
+
+Unless --skipwm is passed the output will be converted to UCHAR.
+For this a ball of radius 50 voxels at the center of the image is used to find the
+1st and 90th percentile of intensities in the brain. This region is then mapped to
+3 .. 110, so that (WM) will be around 110.
+
+There are different options how the center is found:
+- If a mask (e.g. brainmask) is passed, the centroid of the mask will be used and 
+  the ball will be masked to crop non-brain tissue.
+- If no mask is passed, the OTSU method is used to find a brain mask and centroid. 
+  Note, that the ball will not be cropped and may contain non-brain tissue.
+- If a talairach.xfm transform is passed, we use the origin of the Talairach space
+  as center for the ball. If additionally a mask was passed, the ball will be 
+  masked to crop non-brain tissue. 
+
+
+
+Original Author: Martin Reuter
+Date: Mar-18-2022
+"""
+
+h_invol    = 'path to input.nii.gz'
+h_outvol   = 'path to corrected.nii.gz'
+h_mask     = 'optional: path to mask.nii.gz'
+h_shrink   = '<int> shrink factor, default: 4'
+h_levels   = '<int> number of fitting levels, default: 4'
+h_numiter  = '<int> number of iterations per level, default: 4'
+h_thres    = '<float> convergence threshold, default: 0.0'
+h_skipwm   = 'skip normalize WM to 110 (for UCHAR scale)'
+h_tal      = '<sting> file name of talairach.xfm if using this for finding origin'
+h_threads  = '<int> number of threads, default: 1'
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id: N4_bias_correct.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--in',      dest='invol',   help=h_invol)
+    parser.add_option('--out',     dest='outvol',  help=h_outvol)
+    parser.add_option('--mask',    dest='mask',    help=h_mask,    default=None)
+    parser.add_option('--shrink',  dest='shrink',  help=h_shrink,  default=4,     type="int")
+    parser.add_option('--levels',  dest='levels',  help=h_levels,  default=4,     type="int")
+    parser.add_option('--numiter', dest='numiter', help=h_numiter, default=50,    type="int")
+    parser.add_option('--thres',   dest='thres',   help=h_thres,   default=0.0,   type="float")
+    parser.add_option('--skipwm',  dest='skipwm',  help=h_skipwm,  default=False, action="store_true")
+    parser.add_option('--tal',     dest='tal',     help=h_tal,     default=None)
+    parser.add_option('--threads', dest='threads', help=h_threads, default=1,     type="int")
+    (options, args) = parser.parse_args()
+
+    if options.invol is None or options.outvol is None:
+        sys.exit('\nERROR: Please specify --in input.nii --out output.nii as nifti\n   or use --help to see all options.\n')
+
+    return options
+
+
+def N4correctITK(itkimage, itkmask=None, shrink=4, levels=4, numiter=50, thres=0.0, rescale=True):
+
+    if not itkmask:
+        itkmask = itkimage>0
+        itkmask.CopyInformation(itkimage)
+        print("- mask: default (>0)")
+    else:
+        # binarize mask
+        itkmask = itkmask>0
+
+    itkorig = itkimage
+    
+    # subsample image
+    if shrink > 1:
+        itkimage = sitk.Shrink(itkimage, [shrink] * itkimage.GetDimension())
+        itkmask  = sitk.Shrink(itkmask,  [shrink] * itkimage.GetDimension())
+
+    # init corrector
+    corrector = sitk.N4BiasFieldCorrectionImageFilter()
+    corrector.SetMaximumNumberOfIterations([numiter] * levels)
+    corrector.SetConvergenceThreshold(thres)
+
+    # bias correct image
+    corrector.Execute(itkimage, itkmask)
+
+    # we need to apply bias field to original input
+    log_bias_field = corrector.GetLogBiasFieldAsImage(itkorig)
+    itkcorrected = itkorig / sitk.Exp( log_bias_field )
+
+    # normalize to average input intensity
+    if rescale:
+        stats = sitk.StatisticsImageFilter()
+        stats.Execute(itkcorrected)
+        m1 = stats.GetMean()
+        stats.Execute(itkorig)
+        m0 = stats.GetMean()
+        print("- rescale")
+        print("   mean input: {:.4f} , mean corrected {:.4f} , image rescale: {:.4f}".format(m0,m1,m0/m1))
+        itkcorrected = itkcorrected * (m0/m1)
+    
+    itkcorrected = sitk.Cast(itkcorrected,sitk.sitkFloat32)
+    return itkcorrected
+
+
+def normalizeWM (itkimage, itkmask=None, radius=50, centroid=None, targetWM=110):
+    #print("\nnormalizeWM:")
+    
+    mask_passed = True
+    if not itkmask:
+        itkmask = sitk.OtsuThreshold(itkimage, 0, 1, 200)
+        print("- mask: default (otsu)")
+        #itkmask = itkimage>0
+        #print("- mask: default (>0)")
+        itkmask.CopyInformation(itkimage)
+        mask_passed = False
+    else:
+        # binarize mask
+        itkmask = itkmask>0
+    
+    if not centroid:
+        # extract centroid from mask
+        label_stats = sitk.LabelShapeStatisticsImageFilter()
+        label_stats.Execute(itkmask)
+        #centroid_world = label_stats.GetCenterGravity(1)
+        centroid_world = label_stats.GetCentroid(1)
+        #print("centroid pyhsical: {}".format(centroid_world))
+        #centroidf = itkmask.TransformPhysicalPointToContinuousIndex(centroid_world)
+        #print("centroid voxel: {}".format(centroidf))
+        centroid  = itkmask.TransformPhysicalPointToIndex(centroid_world)
+
+    print("- centroid: {}".format(centroid))
+    
+    # create mask from ball around centroid with radius
+    # create a spherical gaussian blob
+    gaussian = sitk.GaussianSource(sitk.sitkUInt8,
+        size = itkimage.GetSize(),
+        sigma = [radius,radius,radius],
+        mean = centroid,
+        spacing = itkimage.GetSpacing())
+    # threshold to create a binary ball
+    gaussian.CopyInformation(itkimage)
+    #sitk.WriteImage(gaussian, "gaussian.nii.gz")
+    ball = sitk.BinaryThreshold(gaussian, 150.0, 255.0, 1, 0)
+    # make sure to crop non-brain regions (if masked was passed)
+    #  warning do not use otsu mask as it is cropping low-intensity values
+    if mask_passed:
+        ball = ball*itkmask
+    #sitk.WriteImage(ball, "ball.nii.gz")
+
+    # get 1 and 90 percentiles of intensities in ball
+    aimg = sitk.GetArrayFromImage(itkimage)
+    amask = sitk.GetArrayFromImage(ball)
+    mask = np.extract(amask,aimg)
+    percentile90 = np.percentile(mask,90)
+    percentile01 = np.percentile(mask, 1)
+    print("- percentile01: {}\n- percentile90: {}".format(percentile01,percentile90))
+
+    # compute intensity transformation
+    m = (targetWM - 2.55) / (percentile90 - percentile01) 
+    b = targetWM - m * percentile90 
+    print("- m: {:.4f}  b: {:.4f}".format(m,b))
+
+    normed = sitk.Cast(sitk.Clamp(sitk.Cast(itkimage,sitk.sitkFloat32) * m + b,upperBound=255,lowerBound=0),sitk.sitkUInt8)
+    #sitk.WriteImage(normed, "normed.nii.gz")
+
+    return normed
+    
+
+def readTalairachXFM(fname):
+    with open(fname) as f:
+        lines = f.readlines()
+    f.close()
+    counter = 0
+    tal = []
+    for line in lines:
+        counter += 1 
+        firstword = line.split(sep="_",maxsplit=1)[0].lower()
+        if firstword == "linear":
+            taltxt = np.char.replace(lines[counter:counter+3],';',' ')
+            tal = np.genfromtxt(taltxt)
+            tal = np.vstack([tal, [0,0,0,1]])
+            #tal = np.loadtxt(fname,skiprows=counter,delimiter=)
+      
+    print(" tal: {}".format(tal))  
+    return tal
+
+
+def getTalOriginVox(tal,image):
+    talinv = np.linalg.inv(tal)
+    tal_origin = np.array(talinv[0:3,3]).ravel()
+    #print("Tal Physical Origin: {}".format(tal_origin))
+    vox_origin = image.TransformPhysicalPointToIndex(tal_origin)
+    print("Tal Voxel Origin: {}".format(vox_origin))
+    return vox_origin
+
+
+if __name__ == "__main__":
+
+    # Command Line options are error checking done here
+    options = options_parse()
+
+    print()
+    print("N4 Bias Correction Parameters:")
+    print()
+    print("- input volume: {}".format(options.invol))
+    print("- output volume: {}".format(options.outvol))
+    if options.mask:
+        print("- mask: {}".format(options.mask))
+    else:
+        print("- mask: default (>0)")
+    print("- shrink factor: {}".format(options.shrink))
+    print("- number fitting levels: {}".format(options.levels))
+    print("- number iterations: {}".format(options.numiter))
+    print("- convergence threshold: {}".format(options.thres))
+    print("- skipwm: {}".format(bool(options.skipwm)))
+    print("- threads: {}".format(options.threads))
+
+    # set number of threads
+    sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(options.threads)
+
+    # read image (only nii supported) and convert to float32
+    print("\nreading {}".format(options.invol))
+    itkimage = sitk.ReadImage(options.invol, sitk.sitkFloat32)
+
+    # if talaraich is passed
+    talorig = None
+    if options.tal:
+        taltrans = readTalairachXFM(options.tal)
+        talorig = getTalOriginVox(taltrans,itkimage)
+
+    # read mask (as uchar)
+    if options.mask:
+        itkmask = sitk.ReadImage(options.mask, sitk.sitkUInt8)
+    else:
+        itkmask=None
+
+    # call N4 correct
+    print("\nexecuting N4 correction ...")
+    itkcorrected = N4correctITK(itkimage, itkmask, options.shrink, options.levels, options.numiter, options.thres, rescale=options.skipwm)
+    
+    if not options.skipwm:
+        print("\nnormalize WM to 110")
+        itkcorrected = normalizeWM (itkcorrected,itkmask,centroid=talorig)
+        print("\nconverting to UCHAR")
+        itkcorrected = sitk.Cast(sitk.Clamp(itkcorrected,lowerBound=0,upperBound=255),sitk.sitkUInt8)
+
+
+    # write image
+    print("writing: {}".format(options.outvol))
+    sitk.WriteImage(itkcorrected, options.outvol)
+    
+    sys.exit(0)
+
+
+
+
+

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -175,7 +175,7 @@ def normalizeWM (itkimage, itkmask=None, radius=50, centroid=None, targetWM=110)
     # create a spherical gaussian blob
     gaussian = sitk.GaussianSource(sitk.sitkUInt8,
         size = itkimage.GetSize(),
-        sigma = [radius,radius,radius],
+        sigma = [radius-1,radius-1,radius-1],
         mean = centroid,
         spacing = itkimage.GetSpacing())
     # threshold to create a binary ball
@@ -186,7 +186,7 @@ def normalizeWM (itkimage, itkmask=None, radius=50, centroid=None, targetWM=110)
     #  warning do not use otsu mask as it is cropping low-intensity values
     if mask_passed:
         ball = ball*itkmask
-    sitk.WriteImage(ball, "ball.nii.gz")
+    #sitk.WriteImage(ball, "ball.nii.gz")
 
     # get 1 and 90 percentiles of intensities in ball
     aimg = sitk.GetArrayFromImage(itkimage)
@@ -194,7 +194,7 @@ def normalizeWM (itkimage, itkmask=None, radius=50, centroid=None, targetWM=110)
     mask = np.extract(amask,aimg)
     percentile90 = np.percentile(mask,90)
     percentile01 = np.percentile(mask, 1)
-    print("- percentile01: {}\n- percentile90: {}".format(percentile01,percentile90))
+    print("-  1st percentile: {}\n- 90th percentile: {}".format(percentile01,percentile90))
 
     # compute intensity transformation
     m = (targetWM - 2.55) / (percentile90 - percentile01) 

--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import numpy as np
+import sys
+import SimpleITK as sitk
+import nibabel as nib
+from nibabel.freesurfer.mghformat import MGHHeader
+
+
+def mgh_from_sitk(sitk_img, orig_mgh_header=None):
+    if orig_mgh_header:
+        h1 = MGHHeader.from_header(orig_mgh_header)
+    else:
+        h1 = MGHHeader()
+    # get voxels sizes and set zooms (=delta in h1 header)
+    spacing = sitk_img.GetSpacing()
+    h1.set_zooms(np.asarray(spacing))
+    # Get direction cosines from sitk image, reshape to 3x3 Matrix
+    direction = np.asarray(sitk_img.GetDirection()).reshape(3, 3, order="F") * [-1, -1, 1]
+    h1["Mdc"] = direction
+    # compute affine
+    origin = np.asarray(sitk_img.GetOrigin()).reshape(3, 1) * [[-1], [-1], [1]]
+    affine = np.vstack([np.hstack([h1['Mdc'].T * h1["delta"], origin]), [0, 0, 0, 1]])
+    # get dims and calculate and set new image center in world coords
+    dims = np.array(sitk_img.GetSize())
+    if dims.size == 3: 
+        dims = np.hstack((dims, [1]))
+    h1['dims'] = dims
+    h1['Pxyz_c'] = affine.dot(np.hstack((dims[:3] / 2.0, [1])))[:3]
+    # swap axes as data is stored differently between sITK and Nibabel
+    data = np.swapaxes(sitk.GetArrayFromImage(sitk_img),0,2)
+    # assemble MGHImage from header, image data and affine
+    mgh_img = nib.MGHImage(data, affine, h1)
+    return mgh_img
+    
+    
+def sitk_from_mgh(img):
+    # reorder data as structure differs between nibabel and sITK:
+    data = np.swapaxes(np.asanyarray(img.dataobj),0,2)
+    # sitk can only create image with system native endianness 
+    if not data.dtype.isnative:
+        data = data.byteswap().newbyteorder()
+    # create image from array
+    img_sitk = sitk.GetImageFromArray(data)
+    # Get direction from MDC, need to change sign of dim 0 and 1
+    direction = img.header["Mdc"] * [-1, -1, 1]
+    img_sitk.SetDirection(direction.ravel(order="F"))
+    # set voxel sizes
+    img_sitk.SetSpacing(np.array(img.header.get_zooms()).tolist())    
+    # Get origin from affine, needs to change sign of dim 0 and 1
+    origin = img.affine[:3, 3:] * [[-1], [-1], [1]]
+    img_sitk.SetOrigin(origin.ravel())
+    return img_sitk
+    
+
+def readITKimage(filename, vox_type = None, with_header=False):
+    # If image is nifti image
+    header = None
+    if filename[-7:] == ".nii.gz" or filename[-4:] == ".nii":
+        print("read Nifti image via sITK ...")
+        if vox_type:
+            itkimage = sitk.ReadImage(filename, vox_type)
+        else:
+            itkimage = sitk.ReadImage(filename)
+    # if image is mgz
+    elif filename[-4:] == ".mgz":
+        print("read MGZ (FreeSurfer) image via nibabel...")
+        image = nib.load(filename)
+        header = image.header
+        itkimage = sitk_from_mgh(image)
+        if vox_type:
+            itkimage = sitk.Cast(itkimage,vox_type)
+    else:
+        sys.exit("read ERROR: {} image type not supported (only: .mgz, .nii, .nii.gz).\n".format(filename))
+    if with_header:
+        return itkimage, header
+    else:
+        return itkimage
+
+
+def writeITKimage(img, filename, header=None):
+    # If image is nifti image
+    if filename[-7:] == ".nii.gz" or filename[-4:] == ".nii":
+        print("write Nifti image via sITK...")
+        sitk.WriteImage(img, filename)
+    # if image is mgz
+    elif filename[-4:] == ".mgz":
+        print("write MGZ (FreeSurfer) image via nibabel...")
+        mgh_image = mgh_from_sitk(img, header)
+        nib.save(mgh_image, filename)
+    else:
+        sys.exit("write ERROR: {} image type not supported (only: .mgz, .nii, .nii.gz).\n".format(filename))
+
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("\nError: pass input and output file names!\n")
+        sys.exit(1)
+    img, hdr = readITKimage(sys.argv[1], with_header=True)
+    writeITKimage(img, sys.argv[2], hdr)
+    sys.exit(0)
+

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -269,9 +269,9 @@ fi
 
 if [ -z "$FREESURFER_HOME" ]
 then
-  echo "Did not find \$FREESURFER_HOME. A working version of FreeSurfer v7.2 is needed to run recon-surf locally."
+  echo "Did not find \$FREESURFER_HOME. A working version of FreeSurfer $FS_VERSION_SUPPORT is needed to run recon-surf locally."
   echo "Make sure to export and source FreeSurfer before running recon-surf.sh: "
-  echo "export FREESURFER_HOME=/path/to/your/local/fs72"
+  echo "export FREESURFER_HOME=/path/to/your/local/freesurfer"
   echo "source \$FREESURFER_HOME/SetUpFreeSurfer.sh"
   exit 1;
 fi
@@ -281,9 +281,9 @@ then
   if grep -q -v ${FS_VERSION_SUPPORT} $FREESURFER_HOME/build-stamp.txt
   then
     echo "ERROR: You are trying to run recon-surf with FreeSurfer version $(cat $FREESURFER_HOME/build-stamp.txt)."
-    echo "We are currently supporting FreeSurfer 6 Stable releases and FreeSurfer 7."
+    echo "We are currently supporting only FreeSurfer $FS_VERSION_SUPPORT "
     echo "Therefore, make sure to export and source the correct FreeSurfer version before running recon-surf.sh: "
-    echo "export FREESURFER_HOME=/path/to/your/local/fs72"
+    echo "export FREESURFER_HOME=/path/to/your/local/freesurfer"
     echo "source \$FREESURFER_HOME/SetUpFreeSurfer.sh"
     exit 1;
   fi

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -489,10 +489,10 @@ RunIt "$cmd" $LF
 cmd="$python ${binpath}paint_cc_into_pred.py -in_cc $mdir/aseg.auto.mgz -in_pred $seg -out $mdir/aparc.DKTatlas+aseg.deep.withCC.mgz"
 RunIt "$cmd" $LF
 
+# Calculate volume-based segstats for deep learning prediction (with CC, requires norm.mgz as invol)
 if [ "$vol_segstats" == "1" ]
-  # Calculate volume-based segstats for deep learning prediction (with CC, requires norm.mgz as invol)
 then
-    cmd="mri_segstats --seg $mdir/aparc.DKTatlas+aseg.deep.withCC.mgz --sum $mdir/../stats/aparc.DKTatlas+aseg.deep.volume.stats --pv $mdir/norm.mgz --empty --brainmask $mdir/brainmask.mgz --brain-vol-from-seg --excludeid 0 --subcortgray --in $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --etiv --id 2, 4, 5, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 24, 26, 28, 31, 41, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 58, 60, 63, 77, 251, 252, 253, 254, 255, 1002, 1003, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1034, 1035, 2002, 2003, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2034, 2035 --ctab /$FREESURFER_HOME/FreeSurferColorLUT.txt --subject $subject"
+    cmd="mri_segstats --seed 1234 --seg $mdir/aparc.DKTatlas+aseg.deep.withCC.mgz --sum $mdir/../stats/aparc.DKTatlas+aseg.deep.volume.stats --pv $mdir/norm.mgz --empty --brainmask $mdir/brainmask.mgz --brain-vol-from-seg --excludeid 0 --subcortgray --in $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --etiv --id 2, 4, 5, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 24, 26, 28, 31, 41, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 58, 60, 63, 77, 251, 252, 253, 254, 255, 1002, 1003, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1034, 1035, 2002, 2003, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2034, 2035 --ctab /$FREESURFER_HOME/FreeSurferColorLUT.txt --subject $subject"
     RunIt "$cmd" $LF
 fi
 
@@ -827,7 +827,7 @@ echo " " |& tee -a $LF
 
   # 1m 11sec also create stats for aseg.presurf.hypos (which is basically the aseg derived from the input with CC and hypos)
   # difference between this and the surface improved one above are probably tiny, so the surface improvement above can probably be skipped to save time
-  cmd="mri_segstats --seed 1234  --seg $mdir/aseg.presurf.hypos.mgz --sum $mdir/../stats/aseg.presurf.hypos.stats --pv $mdir/norm.mgz --empty --brainmask $mdir/brainmask.mgz --brain-vol-from-seg --excludeid 0 --excl-ctxgmwm --supratent --subcortgray --in $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --etiv --surf-wm-vol --surf-ctx-vol --totalgray --euler --ctab /$FREESURFER_HOME/ASegStatsLUT.txt --subject $subject"
+  cmd="mri_segstats --seed 1234 --seg $mdir/aseg.presurf.hypos.mgz --sum $mdir/../stats/aseg.presurf.hypos.stats --pv $mdir/norm.mgz --empty --brainmask $mdir/brainmask.mgz --brain-vol-from-seg --excludeid 0 --excl-ctxgmwm --supratent --subcortgray --in $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --etiv --surf-wm-vol --surf-ctx-vol --totalgray --euler --ctab /$FREESURFER_HOME/ASegStatsLUT.txt --subject $subject"
   RunIt "$cmd" $LF
 
   # -wmparc based on mapped aparc labels (from input seg) (1min40sec) needs ribbon and we need to point it to aparc.mapped:

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -440,16 +440,8 @@ pushd $mdir
 # frontal head), we don't. Also this avoids a second call to nu correct. 
 # talairach.xfm is also not needed here at all, it can be dropped if other places in the
 # stream can be changed to avoid it. 
-cmd="mri_convert $mdir/orig.mgz $mdir/orig.nii.gz"
-RunIt "$cmd" $LF
-cmd="mri_convert $mdir/mask.mgz $mdir/mask.nii.gz"
-RunIt "$cmd" $LF
 #cmd="mri_nu_correct.mni --no-rescale --i $mdir/orig.mgz --o $mdir/orig_nu.mgz --n 1 --proto-iters 1000 --distance 50 --mask $mdir/mask.mgz"
-cmd="$python ${binpath}/N4_bias_correct.py --in $mdir/orig.nii.gz --out $mdir/orig_nu.nii.gz --mask $mdir/mask.nii.gz  --threads $threads"
-RunIt "$cmd" $LF
-cmd="mri_convert -odt uchar $mdir/orig_nu.nii.gz $mdir/orig_nu.mgz"
-RunIt "$cmd" $LF
-cmd="rm $mdir/orig_nu.nii.gz $mdir/mask.nii.gz"
+cmd="$python ${binpath}/N4_bias_correct.py --in $mdir/orig.mgz --out $mdir/orig_nu.mgz --mask $mdir/mask.mgz  --threads $threads"
 RunIt "$cmd" $LF
 
 # talairach.xfm: compute talairach full head (25sec)

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ nibabel==2.5.1
 numpy==1.17.4
 scikit-image==0.15.0
 scipy==1.3.1
+simpleitk==2.1.1
 python-dateutil==2.8.2
 pyyaml==5.4.1
 
@@ -20,7 +21,3 @@ torch===1.2.0
 -f https://download.pytorch.org/whl/torch_stable.html
 torchvision===0.4.0
 
-# The dependency scikit-sparse is optional (but recommended) for the recon-surf script only.
-# Due to its dependency on numpy, it can however not be installed sequentially with the other
-# packages (see also https://github.com/pypa/pip/issues/25 for an indepth discussion on the topic)
-# scikit-sparse==0.4.4


### PR DESCRIPTION
This pull requests is targeted at release 1.1 of FastSurfer and moves recon-surf to FreeSurfer 7.2. (see also #66 )

Tests will need to be performed for the different flag options in recon-surf. Also note that maybe the script to extract timings needs to be adopted to the new pipeline. 

Furthermore we need the full testing pipeline eventually (once the v1.1. release is ready) to check if accuracy, group differentiation and test-retest reliability remain high.

## Background: 
recon-all in FreeSurfer changed significantly between FS6.0 and FS7* (see https://surfer.nmr.mgh.harvard.edu/fswiki/ReleaseNotes ). In order to perform similar surface processing I needed to modify recon-surf in many places: with respect to our commands (to make them similar to how FreeSurfer does it now), with respect to some new commands passed to recon-all, and with respect to the new order in which recon-all blocks are called now.  This way we can inherit many minor changes directly via recon-all calls and we can finally drop the distribution of the mris_make_surfaces binary. 

## Improvements: 
- NU correct: the first correction in recon-surf would still use N3 (MNI tools) as passing a mask did not work with the new ANTS N4 in FreeSurfer. Therefore I now directly call N4 from python (via SimpleITK) and added code to read and write mgz format into sITK images. With a brain mask, N4 is fast and the following WM normalisation (to around 110) can be done without the talairach , using a ball (r=50) at the  center of the brain mask instead. 

