### PR TITLE
Added check for adjusted conformed_name flag

### DIFF
--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -295,6 +295,14 @@ then
   export PYTHONUNBUFFERED=0
 fi
 
+if [ "${seg: -3}" != "${conformed_name: -3}" ]
+  then
+    echo "ERROR: Specified segmentation output and conformed image output do not have same file type."
+    echo "You passed --seg ${seg} and --conformed_name ${conformed_name}."
+    echo "Make sure these have the same file-format and adjust the names passed to the flags accordingly!"
+    exit 1;
+fi
+
 if [ "$surf_only" == "1" ] && [ ! -f "$seg" ]
   then
     echo "ERROR: To run the surface pipeline only, whole brain segmentation must already exist."


### PR DESCRIPTION
 When changing the default segmentation input type with --seg, the --conformed_name needs to be changed to the same file-format (i.e. both need to be .nii.gz or .nii). By default, .mgz is used, which is also necessary for running the recon-surf pipeline.

Example:
```bash
./run_fastsurfer.sh --t1 ../data_input/bert_t1.nii.gz \
                                --seg ../data_output/bert/mri/aparc.DKTatlas+aseg.deep.nii.gz \
                                --conformed_name ../data_output/bert/mri/orig.nii.gz \
                                --seg_only --sid bert --sd ../data_output/bert 
```