### PR TITLE
Fix surface parameter for sphere-reg fix

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -684,7 +684,7 @@ if [ "$fsaparc" == "1" ] || [ "$fssurfreg" == "1" ] ; then
   # seem to do this, so we initialize the spherical registration with the better 
   # label from FastSurferCNN, this replaces recon-al -surfreg
   # 1. extract label 24 = precentral from FastSurferCNN mapped annotation
-  cmd="mri_annotation2label --subject $subject --hemi $hemi --label 24 --labelbase ${hemi}.mapped --annotation aparc.mapped"
+  cmd="mri_annotation2label --subject $subject --hemi $hemi --label 24 --labelbase ${hemi}.mapped --annotation aparc.mapped --surface white.preaparc"
   RunIt "$cmd" $LF "$CMDF"
   # 2. guide spherical registration to align label 24 to precentral in the atlas
   cmd="mris_register -curv \


### PR DESCRIPTION
Small fix for updates spherical registration (initialize the spherical registration with the better label from FastSurferCNN). Surface default in mri_annotation2label is ?h.white which does not exist at this point in the pipeline. The correct surface (?h.white.preaparc) is now specified via the --surface flag:

```bash
mri_annotation2label --subject $subject --hemi $hemi --label 24 --labelbase ${hemi}.mapped --annotation aparc.mapped --surface white.preaparc
```

