### PR TITLE
Fix: Setting of original image save path

### DIFF
--- a/FastSurferCNN/eval.py
+++ b/FastSurferCNN/eval.py
@@ -471,14 +471,14 @@ if __name__ == "__main__":
         if not op.exists(op.join(sub_dir, 'orig')):
             makedirs(op.join(sub_dir, 'orig'))
 
+        # Save input image to standard location
+        input_image = nib.load(options.iname)
+        save_image(np.asanyarray(input_image.dataobj), input_image.affine, input_image.header, op.join(sub_dir, 'orig', '001.mgz'))
+
         # Check if conformed image directory exists and create it otherwise
         sub_dir, out = op.split(options.conformed_name)
         if not op.exists(sub_dir):
             makedirs(sub_dir)
-
-        # Save input image to standard location
-        input_image = nib.load(options.iname)
-        save_image(np.asanyarray(input_image.dataobj), input_image.affine, input_image.header, op.join(sub_dir, 'orig', '001.mgz'))
 
         fastsurfercnn(options.iname, options.oname, options.conformed_name, use_cuda, small_gpu, logger, options)
 


### PR DESCRIPTION
## Summary

This PR applies a minor fix in `eval.py`, where the original input image is saved in sub-directory `$ID/mri/orig/001.mgz`.

The call to `save_image` for the original image was moved before `sub_dir, out = op.split(options.conformed_name)` to avoid using the same `sub_dir` variable, which may lead to saving the input image in the wrong path.