### PR TITLE
Fix WM labels for disconnected islands

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -420,7 +420,7 @@ echo " " |& tee -a $LF
 
 # reduce labels to aseg, then create mask (dilate 5, erode 4, largest component), also mask aseg to remove outliers
 # output will be uchar (else mri_cc will fail below)
-cmd="$python ${binpath}reduce_to_aseg.py -i $mdir/aparc.DKTatlas+aseg.orig.mgz -o $mdir/aseg.auto_noCCseg.mgz --outmask $mask"
+cmd="$python ${binpath}reduce_to_aseg.py -i $mdir/aparc.DKTatlas+aseg.orig.mgz -o $mdir/aseg.auto_noCCseg.mgz --outmask $mask --fixwm"
 RunIt "$cmd" $LF
 
 


### PR DESCRIPTION
Sometimes disconnected WM islands (sometimes only single voxel) are labeled with the label from the wrong hemisphere. This seems to happen more if the head is tilted. Usually this is not problematic and gets fixed later in recon-surf by help of the surfaces. However, it leads to longer run times in mri_cc as it needs to search a much larger box to find the midplane and corpus callosum. 

This fix is intended to correct those labels and flip them back to the correct hemisphere. For that we
- first find connected components
- generate a left/right probability map based on WM and GM labels (of the main component)
- use this map to decide whether disconnected components need to flip to the other hemi

