### PR TITLE
Fixed output volume name of mapped segmentation

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -836,9 +836,9 @@ if [ "$fsaparc" == "0" ] ; then
 fi
 
 
-# creating aparc.DKTatlas.mapped+aseg.mgz by mapping aparc.DKTatlas.mapped from surface to aseg.mgz
+# creating aparc.DKTatlas+aseg.mapped.mgz by mapping aparc.DKTatlas.mapped from surface to aseg.mgz
 # (should be a nicer aparc+aseg compared to orig CNN segmentation, due to surface updates)???
-cmd="mri_surf2volseg --o $mdir/aparc.DKTatlas.mapped+aseg.mgz --label-cortex --i $mdir/aseg.mgz --threads $threads --lh-annot $ldir/lh.aparc.DKTatlas.mapped.annot 1000 --lh-cortex-mask $ldir/lh.cortex.label --lh-white $sdir/lh.white --lh-pial $sdir/lh.pial --rh-annot $ldir/rh.aparc.DKTatlas.mapped.annot 2000 --rh-cortex-mask $ldir/rh.cortex.label --rh-white $sdir/rh.white --rh-pial $sdir/rh.pial"
+cmd="mri_surf2volseg --o $mdir/aparc.DKTatlas+aseg.mapped.mgz --label-cortex --i $mdir/aseg.mgz --threads $threads --lh-annot $ldir/lh.aparc.DKTatlas.mapped.annot 1000 --lh-cortex-mask $ldir/lh.cortex.label --lh-white $sdir/lh.white --lh-pial $sdir/lh.pial --rh-annot $ldir/rh.aparc.DKTatlas.mapped.annot 2000 --rh-cortex-mask $ldir/rh.cortex.label --rh-white $sdir/rh.white --rh-pial $sdir/rh.pial"
 RunIt "$cmd" $LF
 
 


### PR DESCRIPTION
Fixed volume name for mapped parcellations (aparc.DKTatlas.mapped from surface to aseg). This was set to aparc.DKTatlas.mapped+aseg.mgz, but should be aparc.DKTatlas+aseg.mapped.mgz for forward compatibility (wmparc expects this name as well as the symlinks created at the end of the pipeline).