### PR TITLE
Fix conform.py import error with new recon-surf docker

### DIFF
--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -93,8 +93,8 @@ ENV OS=Linux \
 
 
 # Add FastSurfer recon-surf (copy application code) to docker image
-COPY ./recon_surf /recon_surf/
-WORKDIR "/recon_surf"
+COPY . /fastsurfer/
+WORKDIR "/fastsurfer"
 
-ENTRYPOINT ["./recon-surf.sh"]
+ENTRYPOINT ["./recon_surf/recon-surf.sh"]
 CMD ["--help"]

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -95,6 +95,7 @@ ENV OS=Linux \
 # Add FastSurfer recon-surf (copy application code) to docker image
 COPY . /fastsurfer/
 WORKDIR "/fastsurfer"
+ENV FASTSURFER_HOME=/fastsurfer
 
 ENTRYPOINT ["./recon_surf/recon-surf.sh"]
 CMD ["--help"]


### PR DESCRIPTION
Dockerfile_recon-surf only copied recon_surf part of FastSurfer. Latest changes to conform procedure require conform.py from FastSuferCNN directory. This pull request fixes import issues by including all of fastsurfer in the docker images. 