### PR TITLE
Feature: shrink docker - FS dependencies

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,45 +7,46 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install custom libraries + freesurfer 6.0 (and necessary dependencies)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-         build-essential \
-         cmake \
-         git \
-         vim \
-         wget \
-         ca-certificates \
-         bzip2 \
-         libx11-6 \
-         libjpeg-dev \
-         libpng-dev \
-         bc \
-         tar \
-         zip \
-         gawk \
-         tcsh \
-         time \
-         libgomp1 \
-         libglu1-mesa \
-	 libglu1-mesa-dev \
-	 perl-modules && \
-         apt-get clean && \
-         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	 wget -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-centos6_x86_64-7.2.0.tar.gz | tar zxv --no-same-owner -C /opt \
-    	--exclude='freesurfer/trctrain' \
-    	--exclude='freesurfer/subjects/fsaverage_sym' \
-    	--exclude='freesurfer/subjects/fsaverage3' \
-    	--exclude='freesurfer/subjects/fsaverage4' \
-    	--exclude='freesurfer/subjects/fsaverage5' \
-    	--exclude='freesurfer/subjects/fsaverage6' \
-    	--exclude='freesurfer/subjects/cvs_avg35' \
-    	--exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
-    	--exclude='freesurfer/subjects/bert' \
-    	--exclude='freesurfer/subjects/V1_average' \
-    	--exclude='freesurfer/average/mult-comp-cor' \
-    	--exclude='freesurfer/lib/cuda' \
-    	--exclude='freesurfer/lib/qt'
+      wget \
+      git \
+      tcsh \
+      time \
+      bc \
+      gawk \
+      libgomp1 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    wget --no-check-certificate -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz  | tar zxv --no-same-owner -C /opt \
+      --exclude='freesurfer/trctrain' \
+      --exclude='freesurfer/subjects/fsaverage_sym' \
+      --exclude='freesurfer/subjects/fsaverage3' \
+      --exclude='freesurfer/subjects/fsaverage4' \
+      --exclude='freesurfer/subjects/fsaverage5' \
+      --exclude='freesurfer/subjects/fsaverage6' \
+      --exclude='freesurfer/subjects/cvs_avg35' \
+      --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
+      --exclude='freesurfer/subjects/bert' \
+      --exclude='freesurfer/subjects/V1_average' \
+      --exclude='freesurfer/average/mult-comp-cor' \
+      --exclude='freesurfer/lib/cuda' \
+      --exclude='freesurfer/lib/qt' \
+      --exclude='freesurfer/matlab' \
+      --exclude='freesurfer/diffusion' \
+      --exclude='freesurfer/bin/freeview.bin' \
+      --exclude='freesurfer/bin/freeview' \
+      --exclude='freesurfer/bin/mris_decimate_gui.bin' \
+      --exclude='freesurfer/bin/mris_decimate_gui' \
+      --exclude='freesurfer/bin/qdec.bin' \
+      --exclude='freesurfer/bin/qdec' \
+      --exclude='freesurfer/bin/qdec_glmfit' \
+      --exclude='freesurfer/bin/SegmentSubfieldsT1Longitudinal' \
+      --exclude='freesurfer/bin/SegmentSubjectT1T2_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/SegmentSubjectT1_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/fs_spmreg.glnxa64'
 
 # Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       time \
       bc \
       gawk \
+      ca-certificates \
       libgomp1 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -7,61 +7,48 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install custom libraries + freesurfer 6.0 (and necessary dependencies)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-         build-essential \
-         cmake \
-         git \
-         vim \
-         wget \
-         ca-certificates \
-         bzip2 \
-         libx11-6 \
-         libjpeg-dev \
-         libpng-dev \
-         bc \
-         tar \
-         zip \
-         gawk \
-         tcsh \
-         time \
-         libgomp1 \
-         libglu1-mesa \
-	 libglu1-mesa-dev \
-	 perl-modules && \
-         apt-get clean && \
-         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	 wget -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-centos6_x86_64-7.2.0.tar.gz | tar zxv --no-same-owner -C /opt \
-    	--exclude='freesurfer/trctrain' \
-    	--exclude='freesurfer/subjects/fsaverage_sym' \
-    	--exclude='freesurfer/subjects/fsaverage3' \
-    	--exclude='freesurfer/subjects/fsaverage4' \
-    	--exclude='freesurfer/subjects/fsaverage5' \
-    	--exclude='freesurfer/subjects/fsaverage6' \
-    	--exclude='freesurfer/subjects/cvs_avg35' \
-    	--exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
-    	--exclude='freesurfer/subjects/bert' \
-    	--exclude='freesurfer/subjects/V1_average' \
-    	--exclude='freesurfer/average/mult-comp-cor' \
-    	--exclude='freesurfer/lib/cuda' \
-    	--exclude='freesurfer/lib/qt' \
-        --exclude='freesurfer/matlab' \
-        --exclude='freesurfer/diffusion' \
-        --exclude='freesurfer/bin/freeview.bin' \
-        --exclude='freesurfer/bin/freeview' \
-        --exclude='freesurfer/bin/mris_decimate_gui.bin' \
-        --exclude='freesurfer/bin/mris_decimate_gui' \
-        --exclude='freesurfer/bin/qdec.bin' \
-        --exclude='freesurfer/bin/qdec' \
-        --exclude='freesurfer/bin/qdec_glmfit' \
-        --exclude='freesurfer/bin/SegmentSubfieldsT1Longitudinal' \
-        --exclude='freesurfer/bin/SegmentSubjectT1T2_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/SegmentSubjectT1_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/fs_spmreg.glnxa64'
+      wget \
+      git \
+      tcsh \
+      time \
+      bc \
+      gawk \
+      libgomp1 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    wget --no-check-certificate -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz  | tar zxv --no-same-owner -C /opt \
+      --exclude='freesurfer/trctrain' \
+      --exclude='freesurfer/subjects/fsaverage_sym' \
+      --exclude='freesurfer/subjects/fsaverage3' \
+      --exclude='freesurfer/subjects/fsaverage4' \
+      --exclude='freesurfer/subjects/fsaverage5' \
+      --exclude='freesurfer/subjects/fsaverage6' \
+      --exclude='freesurfer/subjects/cvs_avg35' \
+      --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
+      --exclude='freesurfer/subjects/bert' \
+      --exclude='freesurfer/subjects/V1_average' \
+      --exclude='freesurfer/average/mult-comp-cor' \
+      --exclude='freesurfer/lib/cuda' \
+      --exclude='freesurfer/lib/qt' \
+      --exclude='freesurfer/matlab' \
+      --exclude='freesurfer/diffusion' \
+      --exclude='freesurfer/bin/freeview.bin' \
+      --exclude='freesurfer/bin/freeview' \
+      --exclude='freesurfer/bin/mris_decimate_gui.bin' \
+      --exclude='freesurfer/bin/mris_decimate_gui' \
+      --exclude='freesurfer/bin/qdec.bin' \
+      --exclude='freesurfer/bin/qdec' \
+      --exclude='freesurfer/bin/qdec_glmfit' \
+      --exclude='freesurfer/bin/SegmentSubfieldsT1Longitudinal' \
+      --exclude='freesurfer/bin/SegmentSubjectT1T2_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/SegmentSubjectT1_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/fs_spmreg.glnxa64'
 
 
 
 # Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       time \
       bc \
       gawk \
+      ca-certificates \
       libgomp1 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -13,6 +13,7 @@ RUN apt update && apt-get install -y --no-install-recommends \
       time \
       bc \
       gawk \
+      ca-certificates \
       libgomp1 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -6,67 +6,54 @@ ARG PYTHON_VERSION=3.8
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install custom libraries + freesurfer 6.0 (and necessary dependencies)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-         build-essential \
-         cmake \
-         git \
-         vim \
-         wget \
-         ca-certificates \
-         bzip2 \
-         libx11-6 \
-         libjpeg-dev \
-         libpng-dev \
-         bc \
-         tar \
-         zip \
-         gawk \
-         tcsh \
-         time \
-         libgomp1 \
-         libglu1-mesa \
-	     libglu1-mesa-dev \
-	     perl-modules && \
-         apt-get clean && \
-         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	    wget -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-centos6_x86_64-7.2.0.tar.gz | tar zxv --no-same-owner -C /opt \
-    	--exclude='freesurfer/trctrain' \
-    	--exclude='freesurfer/subjects/fsaverage_sym' \
-    	--exclude='freesurfer/subjects/fsaverage3' \
-    	--exclude='freesurfer/subjects/fsaverage4' \
-    	--exclude='freesurfer/subjects/fsaverage5' \
-    	--exclude='freesurfer/subjects/fsaverage6' \
-    	--exclude='freesurfer/subjects/cvs_avg35' \
-    	--exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
-    	--exclude='freesurfer/subjects/bert' \
-    	--exclude='freesurfer/subjects/V1_average' \
-    	--exclude='freesurfer/average/mult-comp-cor' \
-    	--exclude='freesurfer/lib/cuda' \
-    	--exclude='freesurfer/lib/qt' \
-        --exclude='freesurfer/matlab' \
-        --exclude='freesurfer/diffusion' \
-        --exclude='freesurfer/bin/freeview.bin' \
-        --exclude='freesurfer/bin/freeview' \
-        --exclude='freesurfer/bin/mris_decimate_gui.bin' \
-        --exclude='freesurfer/bin/mris_decimate_gui' \
-        --exclude='freesurfer/bin/qdec.bin' \
-        --exclude='freesurfer/bin/qdec' \
-        --exclude='freesurfer/bin/qdec_glmfit' \
-        --exclude='freesurfer/bin/SegmentSubfieldsT1Longitudinal' \
-        --exclude='freesurfer/bin/SegmentSubjectT1T2_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/SegmentSubjectT1_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/fs_spmreg.glnxa64'
+RUN apt update && apt-get install -y --no-install-recommends \
+      wget \
+      git \
+      tcsh \
+      time \
+      bc \
+      gawk \
+    libgomp1 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    wget --no-check-certificate -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz  | tar zxv --no-same-owner -C /opt \
+      --exclude='freesurfer/trctrain' \
+      --exclude='freesurfer/subjects/fsaverage_sym' \
+      --exclude='freesurfer/subjects/fsaverage3' \
+      --exclude='freesurfer/subjects/fsaverage4' \
+      --exclude='freesurfer/subjects/fsaverage5' \
+      --exclude='freesurfer/subjects/fsaverage6' \
+      --exclude='freesurfer/subjects/cvs_avg35' \
+      --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
+      --exclude='freesurfer/subjects/bert' \
+      --exclude='freesurfer/subjects/V1_average' \
+      --exclude='freesurfer/average/mult-comp-cor' \
+      --exclude='freesurfer/lib/cuda' \
+      --exclude='freesurfer/lib/qt' \
+      --exclude='freesurfer/matlab' \
+      --exclude='freesurfer/diffusion' \
+      --exclude='freesurfer/bin/freeview.bin' \
+      --exclude='freesurfer/bin/freeview' \
+      --exclude='freesurfer/bin/mris_decimate_gui.bin' \
+      --exclude='freesurfer/bin/mris_decimate_gui' \
+      --exclude='freesurfer/bin/qdec.bin' \
+      --exclude='freesurfer/bin/qdec' \
+      --exclude='freesurfer/bin/qdec_glmfit' \
+      --exclude='freesurfer/bin/SegmentSubfieldsT1Longitudinal' \
+      --exclude='freesurfer/bin/SegmentSubjectT1T2_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/SegmentSubjectT1_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
+      --exclude='freesurfer/bin/fs_spmreg.glnxa64'
 
 
 
 # Install miniconda and needed python packages (for recon-surf)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
      /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy scikit-image && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
+     /opt/conda/bin/conda install -y -c conda-forge nibabel=2.5.1 pillow=8.3.2 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH
 

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -13,7 +13,7 @@ RUN apt update && apt-get install -y --no-install-recommends \
       time \
       bc \
       gawk \
-    libgomp1 && \
+      libgomp1 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     wget --no-check-certificate -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.2.0/freesurfer-linux-ubuntu18_amd64-7.2.0.tar.gz  | tar zxv --no-same-owner -C /opt \

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -278,6 +278,8 @@ then
   echo "source \$FREESURFER_HOME/SetUpFreeSurfer.sh"
   exit 1;
 fi
+# needed in FS72 due to a bug in recon-all --fill using FREESURFER instead of FREESURFER_HOME
+export FREESURFER=$FREESURFER_HOME   
 
 if [ "$check_version" == "1" ]
 then


### PR DESCRIPTION
This PR removes several dependencies from the Docker images with FreeSurfer, shaving away around 2GB of data. 

It has not yet been fully tested for all parameter settings, but worked for default. 

This is addressing #138 
