### PR TITLE
Upgrade: Python packages (conda and pip)

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -49,15 +49,18 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
      /opt/conda/bin/conda install -y pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
+     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH
 
 # install pip related dependencies
 RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install simpleitk==2.1.1
+    python$PYTHON_VERSION -m pip install simpleitk==2.1.1 && \
+    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
+    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
+    python$PYTHON_VERSION -m pip install nibabel==3.2.2
 
 # Add FreeSurfer Environment variables (.license file needed, alternatively export FS_LICENSE=path/to/license)
 ENV OS=Linux \

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -58,22 +58,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
         --exclude='freesurfer/bin/fs_spmreg.glnxa64'
 
-
-
 # Install miniconda and needed python packages (for FastSurferCNN)
 RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
      /opt/conda/bin/conda install -y cpuonly pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
+     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH
 
 # install pip related dependencies
 RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install simpleitk==2.1.1
+    python$PYTHON_VERSION -m pip install simpleitk==2.1.1 && \
+    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
+    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
+    python$PYTHON_VERSION -m pip install nibabel==3.2.2
 
 # Add FreeSurfer Environment variables (.license file needed, alternatively export FS_LICENSE=path/to/license)
 ENV OS=Linux \

--- a/Docker/Dockerfile_FastSurferCNN
+++ b/Docker/Dockerfile_FastSurferCNN
@@ -16,15 +16,18 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
      /opt/conda/bin/conda install -y pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
+     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
      /opt/conda/bin/conda clean -ya
 ENV PYTHONUNBUFFERED=0 \
     PATH=/opt/conda/bin:$PATH
 
 # install pip related dependencies
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy
+RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
+    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
+    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
+    python$PYTHON_VERSION -m pip install nibabel==3.2.2
 
 # Add FastSurfer (copy application code) to docker image
 COPY ./FastSurferCNN /FastSurferCNN/

--- a/Docker/Dockerfile_FastSurferCNN_CPU
+++ b/Docker/Dockerfile_FastSurferCNN_CPU
@@ -17,15 +17,18 @@ RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy scipy matplotlib h5py scikit-image && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
      /opt/conda/bin/conda install -y cpuonly pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
+     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
      /opt/conda/bin/conda clean -ya
 ENV PYTHONUNBUFFERED=0 \
     PATH=/opt/conda/bin:$PATH
 
 # install pip related dependencies
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy
+RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
+    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
+    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
+    python$PYTHON_VERSION -m pip install nibabel==3.2.2
 
 # Add FastSurfer (copy application code) to docker image
 COPY ./FastSurferCNN /FastSurferCNN/

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -58,21 +58,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
         --exclude='freesurfer/bin/fs_spmreg.glnxa64'
 
-
-
-# Install miniconda and needed python packages (for recon-surf)
+# Install miniconda and needed python packages (for FastSurferCNN)
 RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy scikit-image && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 scikit-image=0.19.2 && \
+     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH
 
 # install pip related dependencies
 RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install simpleitk==2.1.1
+    python$PYTHON_VERSION -m pip install simpleitk==2.1.1 && \
+    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
+    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
+    python$PYTHON_VERSION -m pip install nibabel==3.2.2
 
 # Add FreeSurfer Environment variables (.license file needed, alternatively export FS_LICENSE=path/to/license)
 ENV OS=Linux \

--- a/FastSurferCNN/eval.py
+++ b/FastSurferCNN/eval.py
@@ -29,7 +29,7 @@ from torch.autograd import Variable
 from torch.utils.data.dataloader import DataLoader
 from torchvision import transforms, utils
 
-from scipy.ndimage.filters import median_filter, gaussian_filter
+from scipy.ndimage import median_filter, gaussian_filter
 from skimage.measure import label, regionprops
 from skimage.measure import label
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
-h5py==2.9.0
+h5py==3.6.0
 matplotlib==3.5.1
-nibabel==2.5.1
+nibabel==3.2.2
 numpy==1.22.3
-scikit-image==0.18.3
+scikit-image==0.19.2
 scipy==1.8.0
 python-dateutil==2.8.2
 simpleitk==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cycler==0.11.0
     # via matplotlib
 fonttools==4.31.2
     # via matplotlib
-h5py==2.9.0
+h5py==3.6.0
     # via -r requirements.in
 imageio==2.16.1
     # via scikit-image
@@ -19,12 +19,10 @@ kiwisolver==1.4.2
 lapy @ git+https://github.com/Deep-MI/LaPy.git
     # via -r requirements.in
 matplotlib==3.5.1
-    # via
-    #   -r requirements.in
-    #   scikit-image
+    # via -r requirements.in
 networkx==2.7.1
     # via scikit-image
-nibabel==2.5.1
+nibabel==3.2.2
     # via -r requirements.in
 numpy==1.22.3
     # via
@@ -40,7 +38,10 @@ numpy==1.22.3
     #   tifffile
     #   torchvision
 packaging==21.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   nibabel
+    #   scikit-image
 pillow==9.0.1
     # via
     #   imageio
@@ -61,7 +62,7 @@ pywavelets==1.3.0
     # via scikit-image
 pyyaml==6.0
     # via -r requirements.in
-scikit-image==0.18.3
+scikit-image==0.19.2
     # via -r requirements.in
 scipy==1.8.0
     # via
@@ -72,8 +73,6 @@ simpleitk==2.1.1
     # via -r requirements.in
 six==1.15.0
     # via
-    #   h5py
-    #   nibabel
     #   plotly
     #   python-dateutil
 tenacity==8.0.1


### PR DESCRIPTION
## Description

This PR upgrades all python packages to the latest versions (for Ubuntu 20.04).
The versions have been updated in the pip requirements.txt (and requirements.in) and the conda installations in the Dockerfiles.

The upgrades in the pip environment include:
* `h5py`: 2.9.0 --> 3.6.0
* `nibabel`: 2.5.1 --> 3.2.2
* `scikit-image`: 0.18.3 --> 0.19.2

The version for each package installed using conda in the Dockerfiles is now explicitly specified. These versions are set to match the current requirements.txt.

The latest versions of some packages (as specified in the requirements.txt) are not available in conda. Instead, these packages are now installed using pip at a later stage in the Dockerfiles. This ensures the pip install and Dockerfile environments have the same version. These packages are:
* `numpy` `1.22.3`. Latest available through conda: `1.21.1`
* `scipy` `1.8.0`. Latest available through conda: `1.7.3`
* `nibabel` `3.2.2`. Latest available through conda: `2.5.1`

Note: These upgrades increase the size of the main Docker image by ~200MB.