### PR TITLE
Modify other Dockerfiles with 2stage and conda-pack improvements

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,45 +1,72 @@
 ## Start with Docker pytorch base
 
-FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
-# get fastsurfer into docker (needed for some install scripts)
-COPY . /fastsurfer/
+# get install scripts into docker
+COPY ./fastsurfer_env_gpu.yml /fastsurfer/fastsurfer_env_gpu.yml
+COPY ./Docker/install_fs_pruned.sh /fastsurfer/install_fs_pruned.sh
 
-# Install custom libraries, freesurfer dependencies
-# Install miniconda python packages, pip packages and freesurfer
+# Install packages needed for build
 RUN apt-get update && apt-get install -y --no-install-recommends \
       wget \
       git \
-      tcsh \
-      time \
-      bc \
-      gawk \
       ca-certificates \
-      libgomp1 \
       upx \
       file && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
-    
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+
+# Install conda
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
-     /opt/conda/bin/conda install -y pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
-     /opt/conda/bin/conda clean -ya
+     rm ~/miniconda.sh 
+
 ENV PATH /opt/conda/bin:$PATH
 
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install simpleitk==2.1.1 && \
-    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
-    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
-    python$PYTHON_VERSION -m pip install nibabel==3.2.2 && \
-    /fastsurfer/Docker/install_fs_pruned.sh /opt --upx
+# Install our dependencies
+RUN conda env create -f /fastsurfer/fastsurfer_env_gpu.yml 
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack
+
+# Use conda-pack to create a standalone enviornment in /venv:
+RUN conda-pack -n fastsurfer_gpu -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# Now that venv in a new location, fix up paths:
+RUN /venv/bin/conda-unpack
+ENV PATH /venv/bin:$PATH
+
+# setup shell for install command below
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# install freesurfer and point to new python location
+RUN /fastsurfer/install_fs_pruned.sh /opt --upx && \
+    rm /opt/freesurfer/bin/fspython && \
+    ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
+
+# ========================================
+# Here we create the smaller runtime image
+# ========================================
+
+FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04 AS runtime
+
+# Install required packages for freesurfer to run
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tcsh \
+      time \
+      bc \
+      gawk \
+      libgomp1 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
 # Add FreeSurfer Environment variables
 ENV OS=Linux \
@@ -49,11 +76,21 @@ ENV OS=Linux \
     FSF_OUTPUT_FORMAT=nii.gz \
     FREESURFER_HOME=/opt/freesurfer \
     PYTHONUNBUFFERED=0 \
-    PATH=/opt/freesurfer/bin:$PATH
+    PATH=/venv/bin:/opt/freesurfer/bin:$PATH
 
+# make sure we use bash and activate conda env
+#  (in case someone starts this interactively)
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
 
-# Set FastSurfer env and workdir:
+# Copy venv fastsurfer and pruned freesurfer from builder
+COPY --from=build /venv /venv
+COPY --from=build /opt/freesurfer /opt/freesurfer
+COPY . /fastsurfer/
+
+# Set FastSurfer workdir and entrypoint
+#  the script entrypoint ensures that our conda env is active
 WORKDIR "/fastsurfer"
 ENV FASTSURFER_HOME=/fastsurfer
-ENTRYPOINT ["./run_fastsurfer.sh"]
+ENTRYPOINT ["./Docker/entrypoint.sh","./run_fastsurfer.sh"]
 CMD ["--help"]

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -1,45 +1,72 @@
-## Start with Docker pytorch base
+## Start with ubuntu base
 
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
-# get fastsurfer into docker (needed for some install scripts)
-COPY . /fastsurfer/
+# get install scripts into docker
+COPY ./fastsurfer_env_cpu.yml /fastsurfer/fastsurfer_env_cpu.yml
+COPY ./Docker/install_fs_pruned.sh /fastsurfer/install_fs_pruned.sh
 
-# Install custom libraries, freesurfer dependencies
-# Install miniconda python packages, pip packages and freesurfer
+# Install packages needed for build
 RUN apt-get update && apt-get install -y --no-install-recommends \
       wget \
       git \
-      tcsh \
-      time \
-      bc \
-      gawk \
       ca-certificates \
-      libgomp1 \
       upx \
       file && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
-    
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+
+# Install conda
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
-     /opt/conda/bin/conda install -y cpuonly pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
-     /opt/conda/bin/conda clean -ya
+     rm ~/miniconda.sh 
+
 ENV PATH /opt/conda/bin:$PATH
 
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install simpleitk==2.1.1 && \
-    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
-    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
-    python$PYTHON_VERSION -m pip install nibabel==3.2.2 && \
-    /fastsurfer/Docker/install_fs_pruned.sh /opt --upx
+# Install our dependencies
+RUN conda env create -f /fastsurfer/fastsurfer_env_cpu.yml 
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack
+
+# Use conda-pack to create a standalone enviornment in /venv:
+RUN conda-pack -n fastsurfer_cpu -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# Now that venv in a new location, fix up paths:
+RUN /venv/bin/conda-unpack
+ENV PATH /venv/bin:$PATH
+
+# setup shell for install command below
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# install freesurfer and point to new python location
+RUN /fastsurfer/install_fs_pruned.sh /opt --upx && \
+    rm /opt/freesurfer/bin/fspython && \
+    ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
+
+# ========================================
+# Here we create the smaller runtime image
+# ========================================
+
+FROM ubuntu:20.04 AS runtime
+
+# Install required packages for freesurfer to run
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tcsh \
+      time \
+      bc \
+      gawk \
+      libgomp1 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
 # Add FreeSurfer Environment variables
 ENV OS=Linux \
@@ -49,11 +76,21 @@ ENV OS=Linux \
     FSF_OUTPUT_FORMAT=nii.gz \
     FREESURFER_HOME=/opt/freesurfer \
     PYTHONUNBUFFERED=0 \
-    PATH=/opt/freesurfer/bin:$PATH
+    PATH=/venv/bin:/opt/freesurfer/bin:$PATH
 
+# make sure we use bash and activate conda env
+#  (in case someone starts this interactively)
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
 
-# Set FastSurfer env and workdir:
+# Copy venv fastsurfer and pruned freesurfer from builder
+COPY --from=build /venv /venv
+COPY --from=build /opt/freesurfer /opt/freesurfer
+COPY . /fastsurfer/
+
+# Set FastSurfer workdir and entrypoint
+#  the script entrypoint ensures that our conda env is active
 WORKDIR "/fastsurfer"
 ENV FASTSURFER_HOME=/fastsurfer
-ENTRYPOINT ["./run_fastsurfer.sh"]
+ENTRYPOINT ["./Docker/entrypoint.sh","./run_fastsurfer.sh"]
 CMD ["--help"]

--- a/Docker/Dockerfile_FastSurferCNN
+++ b/Docker/Dockerfile_FastSurferCNN
@@ -1,38 +1,73 @@
 ## Start with Docker pytorch base
 
-FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install custom libraries
+# get install scripts into docker
+COPY ./fastsurfer_env_gpu.yml /fastsurfer/fastsurfer_env_gpu.yml
+
+# Install packages needed for build
 RUN apt-get update && apt-get install -y --no-install-recommends \
-         git \
-         wget && \
-         rm -rf /var/lib/apt/lists/*
-	 
-# Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+      wget \
+      git \
+      ca-certificates \
+      upx \
+      file && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Install conda
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
-     /opt/conda/bin/conda install -y pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
-     /opt/conda/bin/conda clean -ya
-ENV PYTHONUNBUFFERED=0 \
-    PATH=/opt/conda/bin:$PATH
+     rm ~/miniconda.sh 
 
-# install pip related dependencies
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
-    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
-    python$PYTHON_VERSION -m pip install nibabel==3.2.2
+ENV PATH /opt/conda/bin:$PATH
 
-# Add FastSurfer (copy application code) to docker image
+# Install our dependencies
+RUN conda env create -f /fastsurfer/fastsurfer_env_gpu.yml 
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack
+
+# Use conda-pack to create a standalone enviornment in /venv:
+RUN conda-pack -n fastsurfer_gpu -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# Now that venv in a new location, fix up paths:
+RUN /venv/bin/conda-unpack
+ENV PATH /venv/bin:$PATH
+
+# setup shell for install command below
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# ========================================
+# Here we create the smaller runtime image
+# ========================================
+
+FROM nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04 AS runtime
+
+# Add venv to path:
+ENV PATH=/venv/bin:$PATH
+
+# make sure we use bash and activate conda env
+#  (in case someone starts this interactively)
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Copy venv and FastSurferCNN 
+COPY --from=build /venv /venv
 COPY ./FastSurferCNN /FastSurferCNN/
 COPY ./checkpoints /FastSurferCNN/checkpoints/
-WORKDIR "/FastSurferCNN"
+COPY ./Docker/entrypoint.sh /FastSurferCNN/entrypoint.sh
 
-ENTRYPOINT ["python3.8", "eval.py"]
+# Set FastSurferCNN workdir and entrypoint
+#  the script entrypoint ensures that our conda env is active
+WORKDIR "/FastSurferCNN"
+ENTRYPOINT ["./entrypoint.sh", "python3.8", "eval.py"]
 CMD ["--help"]

--- a/Docker/Dockerfile_FastSurferCNN_CPU
+++ b/Docker/Dockerfile_FastSurferCNN_CPU
@@ -1,39 +1,73 @@
 ## Start with ubuntu base
 
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install custom libraries
-RUN apt-get update && apt-get install -y --no-install-recommends \
-         wget \
-         git \
-         ca-certificates && \
-         rm -rf /var/lib/apt/lists/*
+# get install scripts into docker
+COPY ./fastsurfer_env_cpu.yml /fastsurfer/fastsurfer_env_cpu.yml
 
-# Install miniconda and needed python packages (for FastSurferCNN)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+# Install packages needed for build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      wget \
+      git \
+      ca-certificates \
+      upx \
+      file && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Install conda
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil=2.8.2 pyyaml=6.0 matplotlib=3.5.1 h5py=3.6.0 scikit-image=0.19.2 && \
-     /opt/conda/bin/conda install -y cpuonly pytorch=1.10.0 torchvision=0.11.1 cudatoolkit=11.3 -c pytorch && \
-     /opt/conda/bin/conda install -y -c conda-forge pillow=9.0.1 && \
-     /opt/conda/bin/conda clean -ya
-ENV PYTHONUNBUFFERED=0 \
-    PATH=/opt/conda/bin:$PATH
+     rm ~/miniconda.sh 
 
-# install pip related dependencies
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy && \
-    python$PYTHON_VERSION -m pip install numpy==1.22.3 && \
-    python$PYTHON_VERSION -m pip install scipy==1.8.0 && \
-    python$PYTHON_VERSION -m pip install nibabel==3.2.2
+ENV PATH /opt/conda/bin:$PATH
 
-# Add FastSurfer (copy application code) to docker image
+# Install our dependencies
+RUN conda env create -f /fastsurfer/fastsurfer_env_cpu.yml 
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack
+
+# Use conda-pack to create a standalone enviornment in /venv:
+RUN conda-pack -n fastsurfer_cpu -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# Now that venv in a new location, fix up paths:
+RUN /venv/bin/conda-unpack
+ENV PATH /venv/bin:$PATH
+
+# setup shell for install command below
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# ========================================
+# Here we create the smaller runtime image
+# ========================================
+
+FROM ubuntu:20.04 AS runtime
+
+# Add venv to path:
+ENV PATH=/venv/bin:$PATH
+
+# make sure we use bash and activate conda env
+#  (in case someone starts this interactively)
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Copy venv and FastSurferCNN 
+COPY --from=build /venv /venv
 COPY ./FastSurferCNN /FastSurferCNN/
 COPY ./checkpoints /FastSurferCNN/checkpoints/
-WORKDIR "/FastSurferCNN"
+COPY ./Docker/entrypoint.sh /FastSurferCNN/entrypoint.sh
 
-ENTRYPOINT ["python3.6", "eval.py"]
+# Set FastSurferCNN workdir and entrypoint
+#  the script entrypoint ensures that our conda env is active
+WORKDIR "/FastSurferCNN"
+ENTRYPOINT ["./entrypoint.sh", "python3.8", "eval.py"]
 CMD ["--help"]


### PR DESCRIPTION
## Description

This is an extension of #145, where the `Dockerfile_reconsurf` was improved with multi-stage builds, integrating conda-pack, and installing packages using yaml files.

Here, the other Dockerfiles are modified to include the same changes.
The sizes of images produced by each Dockerfile are now as follows:
* Dockerfile: 12.1GB
* Dockerfile_CPU: 4.96GB
* Dockerfile_FastSurferCNN: 11.5GB
* Dockerfile_FastSurferCNN_CPU: 4.42GB
* Dockefile_reconsurf: 1.56GB

## Follow-up Items

(1) The base image for the GPU-supporting images may be switched from `nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04` to `ubuntu20.04` soon, since a global CUDA+CuDNN installation may be unnecessary for pytorch installed with cudatoolkit. With this change, these images will shrink considerably, and all images will share the same base image.
(2) Once (1) is included, the Dockerfiles are quite similar except for the input yaml files and whether FreeSurfer is installed or not. They could be reduced to a single file with docker build arguments, such as `WITH_CUDA` and `WITH_FS`.