### PR TITLE
Fix: Adapt recon-surf command run-time extraction to v1.1 modifications

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -941,4 +941,4 @@ echo "CMDARGS ${inputargs[*]}"    >> $DoneFile
 echo "recon-surf.sh $subject finished without error at `date`"  |& tee -a $LF
 
 cmd="$python ${binpath}utils/extract_recon_surf_time_info.py -i $LF -o $SUBJECTS_DIR/$subject/scripts/recon-surf_times.yaml"
-RunIt "$cmd"
+RunIt "$cmd" "/dev/null"

--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
                 print('[WARN] Could not find the line containing the full command for {} in line {}! Skipping...\n'.format(cmd_name[:-1], i))
                 continue
 
-            entry_dict['cmd'] = cmd_line
+            entry_dict['cmd'] = cmd_line.lstrip()
             entry_dict['start'] = start_time
             entry_dict['stop'] = end_time
             if time_units == 's':

--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -43,8 +43,10 @@ if __name__ == "__main__":
 
     timestamp_feature = '@#@FSTIME'
     recon_all_stage_feature = '#@# '
-    cmd_line_filter_phrases = ['done', 'Done', 'successful', 'finished without error', 'cmdline' ,'Running command', 'failed']
-    filtered_cmds = ['ln ', 'rm ']
+    cmd_line_filter_phrases = ['done', 'Done', 'successful', 'finished without error', 'cmdline' ,'Running command', 'failed', 'FSRUNTIME@',
+                               'ru_nivcsw', 'ru_nvcsw', 'ru_nsignals', 'ru_msgrcv', 'ru_msgsnd', 'ru_oublock', 'ru_inblock', 'ru_nswap',
+                               'ru_majflt', 'ru_minflt', 'ru_isrss', 'ru_idrss', 'ru_ixrss', 'ru_maxrss', 'stimesec', 'utimesec', '#' ]
+    filtered_cmds = ['ln ', 'rm ', 'cp ']
 
     if args.output_file_path == '':
         output_file_path = args.input_file_path.rsplit('/', 1)[0] + '/' + 'recon-surf_times.yaml'

--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     for i, line in enumerate(lines):
         ## Use recon_surf "stage" names as top level of recon-surf_commands entries:
-        if '======' in line:
+        if '======' in line and 'teration' not in line:
             stage_line = line
             current_recon_surf_stage_name = stage_line.strip('=')[1:-1].replace(' ', '-')
             if current_recon_surf_stage_name == 'DONE':

--- a/recon_surf/utils/extract_recon_surf_time_info.py
+++ b/recon_surf/utils/extract_recon_surf_time_info.py
@@ -45,7 +45,8 @@ if __name__ == "__main__":
     recon_all_stage_feature = '#@# '
     cmd_line_filter_phrases = ['done', 'Done', 'successful', 'finished without error', 'cmdline' ,'Running command', 'failed', 'FSRUNTIME@',
                                'ru_nivcsw', 'ru_nvcsw', 'ru_nsignals', 'ru_msgrcv', 'ru_msgsnd', 'ru_oublock', 'ru_inblock', 'ru_nswap',
-                               'ru_majflt', 'ru_minflt', 'ru_isrss', 'ru_idrss', 'ru_ixrss', 'ru_maxrss', 'stimesec', 'utimesec', '#' ]
+                               'ru_majflt', 'ru_minflt', 'ru_isrss', 'ru_idrss', 'ru_ixrss', 'ru_maxrss', 'stimesec', 'utimesec', '#' ,
+                               'This may cause']
     filtered_cmds = ['ln ', 'rm ', 'cp ']
 
     if args.output_file_path == '':


### PR DESCRIPTION
## Description

The [extract_recon_surf_time_info.py](https://github.com/Deep-MI/FastSurfer/blob/dev/recon_surf/utils/extract_recon_surf_time_info.py) script works well with `recon-surf` output for `v1.0` and before, but the latest changes to `recon-surf` and integration of Freesurfer 7.2 require adapting the command run-time extraction.

This PR adapts `extract_recon_surf_time_info.py` for the `v1.1` release modifications and includes changes such as:
- Filtering out some phrases that cause incorrect extraction of executed command strings
- Filtering out some uninteresting commands, such as cp
- Removing additional leading whitespaces from some command strings