### PR TITLE
[ENH] add Singularity build and usage

### DIFF
--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -93,8 +93,9 @@ ENV OS=Linux \
 
 
 # Add FastSurfer recon-surf (copy application code) to docker image
-COPY ./recon_surf /recon_surf/
-WORKDIR "/recon_surf"
+COPY . /fastsurfer/
+WORKDIR "/fastsurfer"
+ENV FASTSURFER_HOME=/fastsurfer
 
-ENTRYPOINT ["./recon-surf.sh"]
+ENTRYPOINT ["./recon_surf/recon-surf.sh"]
 CMD ["--help"]

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -1,101 +1,97 @@
-## Start with Docker pytorch base
-
-FROM ubuntu:16.04
+## Start with ubuntu as build container
+FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
-ARG PYTHON_VERSION=3.6
+ARG PYTHON_VERSION=3.8
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
+#ARG CONDA_FILE=Miniconda3-py37_4.10.3-Linux-x86_64.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Install custom libraries + freesurfer 6.0 (and necessary dependencies)
+# get install scripts into docker
+COPY ./fastsurfer_env_reconsurf.yml /fastsurfer/fastsurfer_env_reconsurf.yml
+COPY ./Docker/install_fs_pruned.sh /fastsurfer/install_fs_pruned.sh
+
+# Install packages needed for build
 RUN apt-get update && apt-get install -y --no-install-recommends \
-         build-essential \
-         cmake \
-         git \
-         vim \
-         wget \
-         ca-certificates \
-         bzip2 \
-         libx11-6 \
-         libjpeg-dev \
-         libpng-dev \
-         bc \
-         tar \
-         zip \
-         gawk \
-         tcsh \
-         time \
-         libgomp1 \
-         libglu1-mesa \
-	     libglu1-mesa-dev \
-	     perl-modules && \
-         apt-get clean && \
-         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	    wget -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz | tar zxv --no-same-owner -C /opt \
-    	--exclude='freesurfer/trctrain' \
-    	--exclude='freesurfer/subjects/fsaverage_sym' \
-    	--exclude='freesurfer/subjects/fsaverage3' \
-    	--exclude='freesurfer/subjects/fsaverage4' \
-    	--exclude='freesurfer/subjects/fsaverage5' \
-    	--exclude='freesurfer/subjects/fsaverage6' \
-    	--exclude='freesurfer/subjects/cvs_avg35' \
-    	--exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
-    	--exclude='freesurfer/subjects/bert' \
-    	--exclude='freesurfer/subjects/V1_average' \
-    	--exclude='freesurfer/average/mult-comp-cor' \
-    	--exclude='freesurfer/lib/cuda' \
-    	--exclude='freesurfer/lib/qt' \
-        --exclude='freesurfer/matlab' \
-        --exclude='freesurfer/diffusion' \
-        --exclude='freesurfer/bin/freeview.bin' \
-        --exclude='freesurfer/bin/freeview' \
-        --exclude='freesurfer/bin/mris_decimate_gui.bin' \
-        --exclude='freesurfer/bin/mris_decimate_gui' \
-        --exclude='freesurfer/bin/qdec.bin' \
-        --exclude='freesurfer/bin/qdec' \
-        --exclude='freesurfer/bin/qdec_glmfit' \
-        --exclude='freesurfer/bin/SegmentSubfieldsT1Longitudinal' \
-        --exclude='freesurfer/bin/SegmentSubjectT1T2_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/SegmentSubjectT1_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/SegmentSubjectT2_autoEstimateAlveusML' \
-        --exclude='freesurfer/bin/fs_spmreg.glnxa64'
+      wget \
+      git \
+      ca-certificates \
+      upx \
+      file && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
-
-
-# Install miniconda and needed python packages (for recon-surf)
-RUN wget -qO ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-py37_4.10.3-Linux-x86_64.sh  && \
+# Insstall conda
+RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION python-dateutil pyyaml numpy scipy scikit-image && \
-     /opt/conda/bin/conda install -y -c conda-forge scikit-sparse nibabel=2.5.1 pillow=8.3.2 && \
-     /opt/conda/bin/conda clean -ya
+     rm ~/miniconda.sh 
+
 ENV PATH /opt/conda/bin:$PATH
 
-# install pip related dependencies
-RUN python$PYTHON_VERSION -m pip install -U git+https://github.com/Deep-MI/LaPy.git#egg=lapy
+# Install our dependencies
+RUN conda env create -f /fastsurfer/fastsurfer_env_reconsurf.yml 
 
-# Add FreeSurfer Environment variables (.license file needed, alternatively export FS_LICENSE=path/to/license)
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack
+
+# Use conda-pack to create a standalone enviornment in /venv:
+RUN conda-pack -n fastsurfer_reconsurf -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# Now that venv in a new location, fix up paths:
+RUN /venv/bin/conda-unpack
+ENV PATH /venv/bin:$PATH
+
+# setup shell for install command below
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# install freesurfer and point to new python location
+RUN /fastsurfer/install_fs_pruned.sh /opt --upx && \
+    rm /opt/freesurfer/bin/fspython && \
+    ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
+
+
+# ========================================
+# Here we create the smaller runtime image
+# ========================================
+
+FROM ubuntu:20.04 AS runtime
+
+# Install required packages for freesurfer to run
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tcsh \
+      time \
+      bc \
+      gawk \
+      libgomp1 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Add FreeSurfer Environment variables
 ENV OS=Linux \
     FS_OVERRIDE=0 \
     FIX_VERTEX_AREA= \
     SUBJECTS_DIR=/opt/freesurfer/subjects \
     FSF_OUTPUT_FORMAT=nii.gz \
-    MNI_DIR=/opt/freesurfer/mni \
-    LOCAL_DIR=/opt/freesurfer/local \
     FREESURFER_HOME=/opt/freesurfer \
-    FSFAST_HOME=/opt/freesurfer/fsfast \
-    MINC_BIN_DIR=/opt/freesurfer/mni/bin \
-    MINC_LIB_DIR=/opt/freesurfer/mni/lib \
-    MNI_DATAPATH=/opt/freesurfer/mni/data \
-    FMRI_ANALYSIS_DIR=/opt/freesurfer/fsfast \
-    PERL5LIB=/opt/freesurfer/mni/lib/perl5/5.8.5 \
-    MNI_PERL5LIB=/opt/freesurfer/mni/lib/perl5/5.8.5 \
     PYTHONUNBUFFERED=0 \
-    PATH=/opt/freesurfer/bin:/opt/freesurfer/fsfast/bin:/opt/freesurfer/tktools:/opt/freesurfer/mni/bin:$PATH
+    PATH=/venv/bin:/opt/freesurfer/bin:$PATH
 
+# make sure we use bash and activate conda env
+#  (in case someone starts this interactively)
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
 
-# Add FastSurfer recon-surf (copy application code) to docker image
+# Copy venv fastsurfer and pruned freesurfer from builder
+COPY --from=build /venv /venv
+COPY --from=build /opt/freesurfer /opt/freesurfer
 COPY . /fastsurfer/
+
+# Set FastSurfer workdir and entrypoint
+#  the script entrypoint ensures that our conda env is active
 WORKDIR "/fastsurfer"
 ENV FASTSURFER_HOME=/fastsurfer
-
-ENTRYPOINT ["./recon_surf/recon-surf.sh"]
+ENTRYPOINT ["./Docker/entrypoint.sh","./recon_surf/recon-surf.sh"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ singularity exec --nv -B /home/user/my_mri_data:/data \
 * The fs_license points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
 * Note, that the paths following --fs_license, --t1, and --sd are inside the container, not global paths on your system, so they should point to the places where you mapped these paths above with the -B arguments. 
 * A directory with the name as specified in --sid (here subject2) will be created in the output directory. So in this example output will be written to /home/user/my_fastsurfer_analysis/subject2/ . Make sure the output directory is empty, to avoid overwriting existing files. 
-* You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image and excluding the `--nv` argument in your Singularity exec comand.
+* You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image and excluding the `--nv` argument in your Singularity exec command.
                                
 ## System Requirements
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Within this repository, we provide the code and Docker files for running FastSur
 ![](/images/teaser.png)
 
 ## Usage
-There are two ways to run FastSurfer - (a) as a native install or (b) using Docker. 
+There are three ways to run FastSurfer - (a) as a native install, (b) using Docker, (c) using Singularity
 
 (a) For a __native install__ on a modern linux (e.g. Ubuntu 18.04 or Centos 7, or higher), download this github repository (use git clone or download as zip and unpack) for the necessary source code and python scripts. You also need to have the necessary Python 3 libraries installed (see __requirements.txt__) as well as bash-4.0 or higher (when using pip, upgrade pip first as older versions will fail). This is already enough to generate the whole-brain segmentation using FastSurferCNN (see the README.md in the FastSurferCNN directory for the exact commands). In order to run the whole FastSurfer pipeline locally on your machine, a working version of __FreeSurfer__ (v6.0, https://surfer.nmr.mgh.harvard.edu/fswiki/rel6downloads) is needed (specifically to run recon-surf). See [Example 1](#example-1:-fastSurfer-on-subject1) and [Example 2](#example-2:-fastSurfer-on-multiple-subjects-(parallel-processing)) for an illustration of the commands to run the entire FastSurfer pipeline (FastSurferCNN + recon-surf) natively.
 
 (b) For a __docker version__, simply use the provided Dockerfiles in our Docker directory to build your image (see the README.md in the Docker directory). No other local installations are needed (FreeSurfer and everything else will be included, you only need to provide a [FreeSurfer license file](https://surfer.nmr.mgh.harvard.edu/fswiki/License)). We will also make a Docker image available on Dockerhub in the near future (probably with the official release of version 1.0, the current release is beta). See [Example 3](#example-3:-fastSurfer-inside-docker) for an example how to run FastSurfer inside a Docker container. Mac users need to increase docker memory to 10 GB by overwriting the settings under Docker Desktop --> Preferences --> Resources --> Advanced (slide the bar under Memory to 10 GB; see: [docker for mac](https://docs.docker.com/docker-for-mac/) for details).
+
+(c) For a __singularity version__, use the desired Docker image to build the corresponding Singularity image (see the README.md in the Singularity directory for directions on building from Docker). Note that the `--gpus all` argument from Docker is replaced with `--nv` when running in Singularity, along with other arguments shown in the example command below (see [Example 4](#example-4:-fastSurfer-inside-singularity)).
 
 The main script called __run_fastsurfer.sh__ can be used to run both FastSurferCNN and recon-surf sequentially on a given subject. There are several options which can be selected and set via the command line. 
 List them by running the following command:
@@ -141,6 +143,30 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 * A directory with the name as specified in --sid (here subject2) will be created in the output directory. So in this example output will be written to /home/user/my_fastsurfer_analysis/subject2/ . Make sure the output directory is empty, to avoid overwriting existing files. 
 * You can also run a CPU-Docker with very similar commands. See [Docker/README.md](Docker/README.md) for more details.
 
+### Example 4: FastSurfer inside Singularity
+After building the Singularity image (see instructions in ./Singularity/README.md), you need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license (for free) - just as when using Docker. This license needs to be passed to the script via the --fs_license flag.
+
+To run FastSurfer on a given subject using the Singularity image with GPU access, execute the following command:
+
+```bash
+singularity exec --nv -B /home/user/my_mri_data:/data \
+                      -B /home/user/my_fastsurfer_analysis:/output \
+                      -B /home/user/my_fs_license_dir:/fs60 \
+                       /home/user/fastsurfer-gpu.sif \
+                       /fastsurfer/run_fastsurfer.sh \
+                      --fs_license /fs60/.license \
+                      --t1 /data/subject2/orig.mgz \
+                      --sid subject2 --sd /output \
+                      --parallel
+```
+
+* The `--nv` flag is used to access GPU resources. 
+* The -B commands mount your data, output, and directory with the FreeSurfer license file into the Singularity container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs60). 
+* The fs_license points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
+* Note, that the paths following --fs_license, --t1, and --sd are inside the container, not global paths on your system, so they should point to the places where you mapped these paths above with the -B arguments. 
+* A directory with the name as specified in --sid (here subject2) will be created in the output directory. So in this example output will be written to /home/user/my_fastsurfer_analysis/subject2/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+* You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image and excluding the `--nv` argument in your Singularity exec comand.
+                               
 ## System Requirements
 
 Recommendation: At least 8GB CPU RAM and 8GB NVIDIA GPU RAM ```--batch 1 --run_viewagg_on gpu```  

--- a/Singularity/README.md
+++ b/Singularity/README.md
@@ -1,0 +1,47 @@
+# FastSurfer Singularity image creation
+
+After building a Docker image from the desired Dockerfile in ../Docker, you can build a Singularity image for use on HPCs or in other cases where Docker is not preferred.
+
+In the absence of a Dockerhub image, you can push to a local Docker registry server:
+
+```bash
+
+#Start Docker registry for localhost
+docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
+#tag your Docker image of FastSurfer and push to local registry
+docker tag fastsurfer:gpu localhost:5000/fastsurfer:gpu
+docker push localhost:5000/fastsurfer:gpu
+```
+
+Working from a directory in which you store Singularity images, you can then build your Singularity image:
+
+```bash
+
+singularity build fastsurfer-gpu.sif localhost:5000/fastsurfer:gpu
+```
+
+# FastSurfer Singularity image usage
+
+After building the Singularity image, you need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license (for free) - just as when using Docker. This license needs to be passed to the script via the --fs_license flag.
+
+To run FastSurfer on a given subject using the Singularity image with GPU access, execute the following command:
+
+```bash
+singularity exec --nv -B /home/user/my_mri_data:/data \
+                      -B /home/user/my_fastsurfer_analysis:/output \
+                      -B /home/user/my_fs_license_dir:/fs60 \
+                       /home/user/fastsurfer-gpu.sif \
+                       /fastsurfer/run_fastsurfer.sh \
+                      --fs_license /fs60/.license \
+                      --t1 /data/subject2/orig.mgz \
+                      --sid subject2 --sd /output \
+                      --parallel
+```
+
+* The `--nv` flag is used to access GPU resources. This should be excluded if you intend to use the CPU version of FastSurfer
+* The -B commands mount your data, output, and directory with the FreeSurfer license file into the Singularity container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs60). 
+* The fs_license points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
+* Note, that the paths following --fs_license, --t1, and --sd are inside the container, not global paths on your system, so they should point to the places where you mapped these paths above with the -B arguments. 
+* A directory with the name as specified in --sid (here subject2) will be created in the output directory. So in this example output will be written to /home/user/my_fastsurfer_analysis/subject2/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+* You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image and excluding the `--nv` argument in your Singularity exec command.


### PR DESCRIPTION
Updated README.md files to include instructions for building Singularity images of FastSurfer from a Docker base on a container development machine and running FastSurfer in Singularity containers. This supports containerized deployment on systems in which a direct installation is not feasible and Docker is not preferable or not allowed, such as high performance computing clusters.