### PR TITLE
Fix: Include freesurfer mris_topo_fixer command

### DIFF
--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -139,6 +139,7 @@ copy_files="
   bin/mris_sphere
   bin/mris_register
   bin/mris_fix_topology
+  bin/mris_topo_fixer
   bin/mris_euler_number
   bin/defect2seg
   bin/mri_label2vol
@@ -319,7 +320,6 @@ link_files="
   bin/mri_stats2seg
   bin/mris_thickness
   bin/mris_thickness_diff
-  bin/mris_topo_fixer
   bin/mri_surf2surf
   bin/mri_surf2vol
   bin/mri_surfcluster


### PR DESCRIPTION
## Description

With freesurfer 7.2 (the default for FastSurfer v1.1), `mris_fix_topology` falls back on the `mris_topo_fixer` command if it fails. This fallback command was removed from the install, so any runs in which `mris_fix_topology` fails would faild completely.

This PR includes the command in the freesurfer install.