### PR TITLE
Fix: pctsurfcon Argument

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -828,7 +828,7 @@ if [ "$fsaparc" == "0" ] ; then
   RunIt "$cmd" $LF
   popd
   for hemi in lh rh; do
-    cmd="pctsurfcon --subject $subject --$hemi-only"
+    cmd="pctsurfcon --s $subject --$hemi-only"
     RunIt "$cmd" $LF
   done
   pushd $ldir


### PR DESCRIPTION
## Description

An argument to `pctsurfcon` in `recon-surf.sh` was recently changed from `--s` to `--subject` in 434739bec70b5c1cab72e1ff452031aee62aeeee.
This leads to the following error:
```
pctsurfcon --subject OAS1_0061_MR1 --lh-only                                    
ERROR: Flag --subject unrecognized.                                             
--subject OAS1_0061_MR1 --lh-only
```

This PR reverts that change.