### PR TITLE
get rca-config from freesurfer dev

### DIFF
--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -361,7 +361,9 @@ ln -s $p3 $fsd/bin/fspython
 
 # modify rca_config to work with python3.8
 # (it misunderstands -hemi as -h for help and emi)
-sed -i 's/allow_abbrev=False/allow_abbrev=False,add_help=False/' $fsd/python/scripts/rca-config 
+# sed -i 's/allow_abbrev=False/allow_abbrev=False,add_help=False/' $fsd/python/scripts/rca-config 
+# this and problem with -s has been fixed in freesurfer dev, so we get it from there:
+wget https://raw.githubusercontent.com/freesurfer/freesurfer/dev/scripts/rca-config -O $fsd/python/scripts/rca-config
 
 #cleanup
 rm -rf $fss


### PR DESCRIPTION
In the meantime freesurfer dev has a fixed rca-config that additionally fixes problems with -s flag

see:

- https://github.com/freesurfer/freesurfer/commit/c10e63484a3cfda5c272641241427fa154777cc2 
- https://github.com/freesurfer/freesurfer/issues/972

so instead of our "sed" fix, we now download this file from dev. 