### PR TITLE
Fix: Pull Freesurfer rca-config script from commit instead of dev branch

### DIFF
--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -363,7 +363,7 @@ ln -s $p3 $fsd/bin/fspython
 # (it misunderstands -hemi as -h for help and emi)
 # sed -i 's/allow_abbrev=False/allow_abbrev=False,add_help=False/' $fsd/python/scripts/rca-config 
 # this and problem with -s has been fixed in freesurfer dev, so we get it from there:
-wget https://raw.githubusercontent.com/freesurfer/freesurfer/dev/scripts/rca-config -O $fsd/python/scripts/rca-config
+wget https://raw.githubusercontent.com/freesurfer/freesurfer/c10e63484a3cfda5c272641241427fa154777cc2/scripts/rca-config -O $fsd/python/scripts/rca-config
 
 #cleanup
 rm -rf $fss


### PR DESCRIPTION
## Description

This PR modifies the inclusion of Freesurfer's `rca-config` within the `Docker/install_fs_pruned.sh` script such that we pull the version from a specific commit (https://github.com/freesurfer/freesurfer/blob/c10e63484a3cfda5c272641241427fa154777cc2/scripts/rca-config) instead of Freesurfer's `dev` branch.

This is to ensure that we always use this version of the script in case it changes on the latest `dev` commit in the future.

The change has been tested and works as expected.
