### PR TITLE
Updated help information in case of missing conformed image

### DIFF
--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -303,12 +303,23 @@ if [ "${seg: -3}" != "${conformed_name: -3}" ]
     exit 1;
 fi
 
-if [ "$surf_only" == "1" ] && [ ! -f "$seg" ]
+if [ "$surf_only" == "1" ]
   then
-    echo "ERROR: To run the surface pipeline only, whole brain segmentation must already exist."
-    echo "You passed --surf_only but the whole-brain segmentation ($seg) could not be found."
-    echo "If the segmentation is not saved in the default location (\$SUBJECTS_DIR/\$SID/mri/aparc.DKTatlas+aseg.deep.mgz), specify the absolute path and name via --seg"
-    exit 1;
+    if [ ! -f "$seg" ]
+    then
+        echo "ERROR: To run the surface pipeline only, whole brain segmentation must already exist."
+        echo "You passed --surf_only but the whole-brain segmentation ($seg) could not be found."
+        echo "If the segmentation is not saved in the default location (\$SUBJECTS_DIR/\$SID/mri/aparc.DKTatlas+aseg.deep.mgz), specify the absolute path and name via --seg"
+        exit 1;
+    fi
+    if [ ! -f "$conformed_name" ]
+    then
+        echo "ERROR: To run the surface pipeline only, a conformed T1 image must already exist."
+        echo "You passed --surf_only but the conformed image ($conformed_name) could not be found."
+        echo "If the conformed image is not saved in the default location (\$SUBJECTS_DIR/\$SID/mri/orig.mgz),"
+        echo "specify the absolute path and name via --conformed_name."
+        exit 1;
+    fi
 fi
 
 if [ "$surf_only" == "1" ] && [ "$seg_only" == "1" ]


### PR DESCRIPTION
This is a fix for issue #162. The error message displayed when the conformed T1-image is not specified and can not be found in the default location has been updated. Instead of throwing an error in recon-surf.sh for the --t1 flag, the existence of the conformed file is already checked in run_fastsurfer.sh. The following error message is displayed in case --surf_only is specified and --conformed_name could not be found:

```
ERROR: To run the surface pipeline only, a conformed T1 image must already exist.
You passed --surf_only but the conformed image (/data/berty/mri/orig.mgz) could not be found.
If the conformed image is not saved in the default location ($SUBJECTS_DIR/$SID/mri/orig.mgz),
specify the absolute path and name via --conformed_name.
```