### PR TITLE
Fix: Replace Sphere Rotation in FS7.2 mris_register

### DIFF
--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -273,8 +273,12 @@ copy_files="
   subjects/fsaverage/label/rh.hOc2.mpm.vpnl.label
   subjects/fsaverage/label/rh.hOc3v.mpm.vpnl.label
   subjects/fsaverage/label/rh.hOc4v.mpm.vpnl.label
+  subjects/fsaverage/label/lh.aparc.annot
+  subjects/fsaverage/label/rh.aparc.annot
   subjects/fsaverage/surf/lh.sphere.reg
   subjects/fsaverage/surf/rh.sphere.reg
+  subjects/fsaverage/surf/lh.sphere
+  subjects/fsaverage/surf/rh.sphere
   subjects/fsaverage/surf/lh.white
   subjects/fsaverage/surf/rh.white
   python/scripts/rca-config

--- a/recon_surf/align_points.py
+++ b/recon_surf/align_points.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2021 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# functions to align paired point sets 
+# - find_rotation
+# - find_rigid
+# - find_affine
+
+# IMPORTS
+import numpy as np
+
+
+
+def rmat2angles(R):
+    # Extracts rotation angles (alpha,beta,gamma) in FreeSurfer format (mris_register)
+    # from a rotation matrix
+    alpha = np.degrees(-np.arctan2(R[1,0],R[0,0]))
+    beta  = np.degrees(np.arcsin(R[2,0]))
+    gamma = np.degrees(np.arctan2(R[2,1],R[2,2]))
+    return (alpha,beta,gamma)
+
+
+def angles2rmat(alpha, beta, gamma):
+    # Converts FreeSurfer angles (alpha,beta,gamma) in degrees to a rotation matrix
+    sa = np.sin(np.radians(alpha))
+    sb = np.sin(np.radians(beta))
+    sg = np.sin(np.radians(gamma))
+    ca = np.cos(np.radians(alpha))
+    cb = np.cos(np.radians(beta))
+    cg = np.cos(np.radians(gamma))
+    R = np.array([[ ca*cb, cg*sa-ca*sb*sg, -ca*cg*sb-sa*sg],
+                  [-cb*sa, ca*cg+sa*sb*sg,  cg*sa*sb-ca*sg],
+                  [    sb,          cb*sg,           cb*cg]])
+    return R
+
+
+def find_rotation(p_mov, p_dst):
+    if p_mov.shape != p_dst.shape:
+        raise ValueError("Shape of points should be identical, but mov = {}, dst = {} expecting Nx3".format(p_mov.shape,p_dst.shape))    
+    # average SSD
+    #dd = p_mov-p_dst
+    #print("Initial avg SSD: {}".format(np.sum(dd*dd)/p_mov.shape[0]))
+    # find rotation
+    H = np.dot(p_mov.T, p_dst)
+    U, S, Vt = np.linalg.svd(H)
+    R = np.dot(Vt.T, U.T)
+    # special reflection case
+    m = p_mov.shape[1]
+    if np.linalg.det(R) < 0:
+        print("det(R) < R, reflection detected!, correcting for it ...")
+        Vt[m-1,:] *= -1
+        R = np.dot(Vt.T, U.T)
+    #print("Rotation Matrix: \n{}".format(R))
+    # average SSD after rotation
+    #dd = np.transpose(R @ np.transpose(p_mov)) - p_dst
+    #print("Final avg SSD: {}".format(np.sum(dd*dd)/p_mov.shape[0]))
+    #print("Angles FS format alpha, beta, gamma: {}".format(mat2angle(R)))
+    return R
+
+
+
+def find_rigid(p_mov, p_dst):
+    if p_mov.shape != p_dst.shape:
+        raise ValueError("Shape of points should be identical, but mov = {}, dst = {} expecting Nx3".format(p_mov.shape,p_dst.shape))        # average SSD
+    # translate points to be centered around origin
+    centroid_mov = np.mean(p_mov, axis=0)
+    centroid_dst = np.mean(p_dst, axis=0)
+    pn_mov = p_mov - centroid_mov
+    pn_dst = p_dst - centroid_dst
+    # find rotation of point pairs
+    R = find_rotation(pn_mov,pn_dst)
+    # get translation
+    t = centroid_dst.T - np.dot(R,centroid_mov.T)
+    # homogeneous transformation
+    m = p_mov.shape[1]
+    T = np.identity(m+1)
+    T[:m, :m] = R
+    T[:m, m] = t
+    # compute disteances
+    dd = p_mov-p_dst
+    print("Initial avg SSD: {}".format(np.sum(dd*dd)/p_mov.shape[0]))    
+    dd = (np.transpose(R @ np.transpose(p_mov)) + t)  - p_dst
+    print("Final avg SSD: {}".format(np.sum(dd*dd)/p_mov.shape[0]))
+    #return T, R, t
+    return T
+
+def find_affine(p_mov, p_dst):
+    # find affine by least squares solution of overdetermined system
+    # (assuming we have more than 4 point pairs)
+    from scipy.linalg import pinv
+    if p_mov.shape != p_dst.shape:
+        raise ValueError("Shape of points should be identical, but mov = {}, dst = {} expecting Nx3".format(p_mov.shape,p_dst.shape))        # average SSD
+    n = len(p_mov)
+    # Solve overdetermined system for the three rows of 
+    # affine matrix in one step (same matrix A for different b=cols_of_p_dst)
+    A = np.hstack([p_mov, np.ones((n,1))])
+    L, _, _, _ = np.linalg.lstsq(A, p_dst,rcond=None)
+    T = np.vstack([np.transpose(L),np.array((0.0,0.0,0.0,1.0))])
+    return T
+
+

--- a/recon_surf/rotate_sphere.py
+++ b/recon_surf/rotate_sphere.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2021 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import optparse
+import numpy as np
+import sys
+import nibabel.freesurfer.io as fs
+import align_points as align
+
+
+HELPTEXT = """
+
+Script to rigidly align two spheres (=rotation) using APARCs
+
+USAGE:
+rotate_sphere.py --srcsphere <?h.sphere> --srcaparc <?h.aparc>
+                 --trgsphere <?h.sphere> --trgaparc <?h.aparc> 
+                 --out <angles.txt>
+
+Dependencies:
+    Python 3.6
+
+    SimpleITK https://simpleitk.org/ (v2.1.1)
+
+
+Description:
+
+For each common segmentation ID in the two aparcs, the centroid coordinate is 
+computed (and mapped back to the sphere of radius 100, FS format). The point pairs
+are then aligned by finding the rotation that minimizes their SSD. The output file
+will contain the angles (alpha,beta,gama) as expected by mris_register for rotation
+initialization.
+
+
+Original Author: Martin Reuter
+Date: Jun-8-2022
+"""
+
+
+# In the future, maybe add a way to specify what labels to align as a list or 
+# txt file to pass to the routine. 
+
+h_srcsphere = 'path to src ?h.sphere'
+h_srcaparc  = 'path to src corresponding cortical parcellation'
+h_trgsphere = 'path to trg ?h.sphere'
+h_trgaparc  = 'path to trg corresponding cortical parcellation'
+h_out       = 'path to output txt files for angles'
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id: N4_bias_correct.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--srcsphere', dest='srcsphere', help=h_srcsphere)
+    parser.add_option('--srcaparc',  dest='srcaparc',  help=h_srcaparc)
+    parser.add_option('--trgsphere', dest='trgsphere', help=h_trgsphere)
+    parser.add_option('--trgaparc',  dest='trgaparc',  help=h_trgaparc)
+    parser.add_option('--out',       dest='out',       help=h_out)
+    (options, args) = parser.parse_args()
+
+    if options.srcsphere is None or options.srcaparc is None or options.trgsphere is None or options.trgaparc is None or options.out is None:
+        sys.exit('\nERROR: Please specify src and target sphere and parcellation files as well as output txt file\n   Use --help to see all options.\n')
+
+    return options
+
+
+def align_aparc_centroids(v_mov, labels_mov, v_dst, labels_dst, label_ids=[]):
+# Aligns centroid of aparc parcels on the sphere (Attention mapping back to sphere!)
+    # inferiorparietal,inferiortemporal,lateraloccipital,postcentral, posteriorsingulate
+    #  precentral, precuneus, superiorfrontal, supramarginal
+    #lids=np.array([8,9,11,22,23,24,25,28,31])
+    #lids=np.array([8,9,22,24,31])
+    # lids=np.array([8,22,24])
+    if not label_ids:
+        # use all joint labels except -1 and 0:
+        lids=np.intersect1d(labels_mov,labels_dst)
+        lids=lids[(lids>0)]
+    else:
+        lids=label_ids
+    # compute mean for each label id
+    counter=0
+    centroids_mov=np.empty([lids.size,3])
+    centroids_dst=np.empty([lids.size,3])
+    for id in lids:
+        centroids_mov[counter] = np.mean(v_mov[(labels_mov==id),:],axis=0)
+        centroids_dst[counter] = np.mean(v_dst[(labels_dst==id),:],axis=0)
+        counter=counter+1
+    # map back to sphere of radius 100
+    centroids_mov = (100/np.sqrt(np.sum(centroids_mov*centroids_mov,axis=1)))[:, np.newaxis] * centroids_mov
+    centroids_dst = (100/np.sqrt(np.sum(centroids_dst*centroids_dst,axis=1)))[:, np.newaxis] * centroids_dst
+    # find rotation
+    R = align.find_rotation(centroids_mov, centroids_dst)    
+    return R
+
+
+
+if __name__ == "__main__":
+
+    # Command Line options are error checking done here
+    options = options_parse()
+
+    print()
+    print("Rotate Sphere Parameters:")
+    print()
+    print("- src sphere {}".format(options.srcsphere))
+    print("- src aparc: {}".format(options.srcaparc))
+    print("- trg sphere {}".format(options.trgsphere))
+    print("- trg aparc: {}".format(options.trgaparc))
+    print("- out txt {}".format(options.out))
+    
+    # read image (only nii supported) and convert to float32
+    print("\nreading {}".format(options.srcsphere))
+    srcsphere = fs.read_geometry(options.srcsphere, read_metadata=True)
+    print("reading annotation: {} ...".format(options.srcaparc))
+    srcaparc = fs.read_annot(options.srcaparc)
+    print("reading {}".format(options.trgsphere))
+    trgsphere = fs.read_geometry(options.trgsphere, read_metadata=True)
+    print("reading annotation: {} ...".format(options.trgaparc))
+    trgaparc = fs.read_annot(options.trgaparc)
+
+    R = align_aparc_centroids(srcsphere[0],srcaparc[0],trgsphere[0],trgaparc[0])
+    alpha,beta,gamma = align.rmat2angles(R)
+    print("\nalpha {:.1f}   beta {:.1f}   gamma {:.1f}\n".format(alpha,beta,gamma))
+
+    # write angles
+    print("writing: {}".format(options.out))
+    f = open(options.out, "w")
+    f.write("{:.1f} {:.1f} {:.1f}\n".format(alpha,beta,gamma))
+    f.close()
+    print("...done\n")
+    
+    sys.exit(0)
+
+
+
+
+


### PR DESCRIPTION
In #112 we fixed an issue that we noticed in FreeSurfer's spherical registration where the global alignment (rotation on the sphere) seems to converge to a sub-optimal position so that the non-linear spherical warp cannot recover and the registrations jumps by one gyrus. The fix was to initialize the alignment by passing the pre-central label to mris_register via the -L flag. 

This fix does no longer work in FreeSurfer 7.1 and 7.2 where a new global alignment was implemented which ignores the label initialisation. The old code in FreeSurfer (which can be switched on via an undocumented environment variable) was also modified and  ignores the label initialisation. See our upstream fix for that here: https://github.com/freesurfer/freesurfer/pull/995 

In this PR we had to come up with a different solution of fixing this, as we cannot wait for a new FreeSurfer release: 
- We now perform a global registration on the sphere from our mapped aparc (the images-CNN-based segmentation labels) to fsaverage's aparc. This provides an initial rotation on the sphere, that looks good in the inspected cases.
- We then switch off the global alignment in mris_register and instead pass the rotation angles directly, therefore completely replacing FreeSurfers global spherical rotation. 

This has been tested thoroughly and:
1. improves test-retest results on OASIS especially on the left hemisphere. 
2. does not change group analysis results (OASIS) nor test-retest on Rhineland Study data, which already looked pretty awesome anyway.  

This is probably the last PR that goes into our next release V1.1 , as it was the last thing that was holding us back to commit to upgrading to FreeSurfer 7.2.
