### PR TITLE
Removed pipefail env setting

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enable strict mode pipefail
-set -euo pipefail
-
 VERSION='$Id$'
 FS_VERSION_SUPPORT="7.2.0"
 


### PR DESCRIPTION
Removed command setting pipefail. Normally, these settings can help to prevent covering bugs as certain common errors will cause the script to immediately fail. However, here it causes issue with running run_fastsurfer.sh (POSITIONAL[@]: unbound variable), because POSITIONAL=() is empty. 

If there are other suggestions (removing some of the pipefail options e.g.), feel free to comment here @m-reuter @AhmedFaisal95 