### PR TITLE
Activate denormal flushing in FastSurferCNN

### DIFF
--- a/FastSurferCNN/eval.py
+++ b/FastSurferCNN/eval.py
@@ -443,6 +443,8 @@ if __name__ == "__main__":
     # check what device to use and how much memory is available (memory can be overwritten)
     use_cuda = not options.no_cuda and torch.cuda.is_available()
 
+    torch.set_flush_denormal(True)
+
     if options.run_viewagg_on == "gpu":
         # run view agg on the gpu (force)
         small_gpu = False


### PR DESCRIPTION
This PR adds flushing denormal numbers when running FastSurferCNN inference, as suggested in https://github.com/Deep-MI/FastSurfer/issues/165.

According to tests with images from six subjects, inference time is reduced by approximately 40% and segmentation results are identical (from DICE scores).

This can later be added to the ongoing FastSurferVINN updates.