### PR TITLE
[data_utils] fix and optimize split_cortex_labels

### DIFF
--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -446,8 +446,9 @@ def split_cortex_labels(aparc):
     # Problematic classes: 1026, 1011, 1029, 1019
     for prob_class_lh in [1011, 1019, 1026, 1029]:
         prob_class_rh = prob_class_lh + 1000
-        mask_lh = ((aparc == prob_class_lh) | (aparc == prob_class_rh)) & (lh_rh_split == 0)
-        mask_rh = ((aparc == prob_class_lh) | (aparc == prob_class_rh)) & (lh_rh_split == 1)
+        mask_prob_class = (aparc == prob_class_lh) | (aparc == prob_class_rh)
+        mask_lh = np.logical_and(mask_prob_class, lh_rh_split == 0)
+        mask_rh = np.logical_and(mask_prob_class, lh_rh_split == 1)
 
         aparc[mask_lh] = prob_class_lh
         aparc[mask_rh] = prob_class_rh
@@ -455,7 +456,7 @@ def split_cortex_labels(aparc):
     return aparc
 
 
-def unify_lateralized_labels(lut, combi=["Left-", "Right-"]):
+def unify_lateralized_labels(lut, combi=("Left-", "Right-")):
     """
     Function to generate lookup dictionary of left-right labels
     :param str or pd.DataFrame lut: either lut-file string to load or pandas dataframe


### PR DESCRIPTION
Previously had a torch warning, because `mask_lh` and `mask_rh` were not bool (but uint8). Probably the whole function should be ported to torch... even if it currently runs on the CPU.