### PR TITLE
Download correct conda architecture

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,10 +1,10 @@
 ## Start with ubuntu base
 
 FROM ubuntu:20.04 AS build
-
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
-ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
+ARG TARGETARCH
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-${TARGETARCH}.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
 # get install scripts into docker
@@ -21,11 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
-# Install conda
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh 
+# Install conda for target architecture
+RUN CONDA_FILE=$(echo $CONDA_FILE | sed 's/arm64/aarch64/g' | sed 's/amd64/x86_64/g') && \
+    wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh 
 
 ENV PATH /opt/conda/bin:$PATH
 
@@ -37,8 +38,8 @@ RUN conda install -c conda-forge conda-pack
 
 # Use conda-pack to create a standalone enviornment in /venv:
 RUN conda-pack -n fastsurfer_gpu -o /tmp/env.tar && \
-  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
 
 # Now that venv in a new location, fix up paths:
 RUN /venv/bin/conda-unpack

--- a/Docker/Dockerfile_CPU
+++ b/Docker/Dockerfile_CPU
@@ -3,7 +3,8 @@
 FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
-ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
+ARG TARGETARCH
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-${TARGETARCH}.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
 # get install scripts into docker
@@ -20,11 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
-# Install conda
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh 
+# Install conda for target architecture
+RUN CONDA_FILE=$(echo $CONDA_FILE | sed 's/arm64/aarch64/g' | sed 's/amd64/x86_64/g') && \
+    wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh 
 
 ENV PATH /opt/conda/bin:$PATH
 
@@ -36,8 +38,8 @@ RUN conda install -c conda-forge conda-pack
 
 # Use conda-pack to create a standalone enviornment in /venv:
 RUN conda-pack -n fastsurfer_cpu -o /tmp/env.tar && \
-  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
 
 # Now that venv in a new location, fix up paths:
 RUN /venv/bin/conda-unpack

--- a/Docker/Dockerfile_FastSurferCNN
+++ b/Docker/Dockerfile_FastSurferCNN
@@ -3,11 +3,13 @@
 FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
-ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
+ARG TARGETARCH
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-${TARGETARCH}.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
 # get install scripts into docker
 COPY ./fastsurfer_env_gpu.yml /fastsurfer/fastsurfer_env_gpu.yml
+
 
 # Install packages needed for build
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,11 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
-# Install conda
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh 
+# Install conda for target architecture
+RUN CONDA_FILE=$(echo $CONDA_FILE | sed 's/arm64/aarch64/g' | sed 's/amd64/x86_64/g') && \
+    wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh 
 
 ENV PATH /opt/conda/bin:$PATH
 
@@ -35,8 +38,8 @@ RUN conda install -c conda-forge conda-pack
 
 # Use conda-pack to create a standalone enviornment in /venv:
 RUN conda-pack -n fastsurfer_gpu -o /tmp/env.tar && \
-  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
 
 # Now that venv in a new location, fix up paths:
 RUN /venv/bin/conda-unpack

--- a/Docker/Dockerfile_FastSurferCNN_CPU
+++ b/Docker/Dockerfile_FastSurferCNN_CPU
@@ -3,11 +3,13 @@
 FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
-ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
+ARG TARGETARCH
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-${TARGETARCH}.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
 # get install scripts into docker
 COPY ./fastsurfer_env_cpu.yml /fastsurfer/fastsurfer_env_cpu.yml
+
 
 # Install packages needed for build
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,11 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
-# Install conda
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh 
+# Install conda for target architecture
+RUN CONDA_FILE=$(echo $CONDA_FILE | sed 's/arm64/aarch64/g' | sed 's/amd64/x86_64/g') && \
+    wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh 
 
 ENV PATH /opt/conda/bin:$PATH
 
@@ -35,8 +38,8 @@ RUN conda install -c conda-forge conda-pack
 
 # Use conda-pack to create a standalone enviornment in /venv:
 RUN conda-pack -n fastsurfer_cpu -o /tmp/env.tar && \
-  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
 
 # Now that venv in a new location, fix up paths:
 RUN /venv/bin/conda-unpack

--- a/Docker/Dockerfile_reconsurf
+++ b/Docker/Dockerfile_reconsurf
@@ -1,9 +1,10 @@
-## Start with ubuntu as build container
+## Start with ubuntu base
+
 FROM ubuntu:20.04 AS build
 ENV LANG=C.UTF-8
 ARG PYTHON_VERSION=3.8
-ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-x86_64.sh
-#ARG CONDA_FILE=Miniconda3-py37_4.10.3-Linux-x86_64.sh
+ARG TARGETARCH
+ARG CONDA_FILE=Miniconda3-py38_4.11.0-Linux-${TARGETARCH}.sh
 ENV DEBIAN_FRONTEND=noninteractive
 
 # get install scripts into docker
@@ -20,11 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
-# Insstall conda
-RUN wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh 
+# Install conda for target architecture
+RUN CONDA_FILE=$(echo $CONDA_FILE | sed 's/arm64/aarch64/g' | sed 's/amd64/x86_64/g') && \
+    wget --no-check-certificate -qO ~/miniconda.sh https://repo.continuum.io/miniconda/$CONDA_FILE && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh 
 
 ENV PATH /opt/conda/bin:$PATH
 
@@ -36,8 +38,8 @@ RUN conda install -c conda-forge conda-pack
 
 # Use conda-pack to create a standalone enviornment in /venv:
 RUN conda-pack -n fastsurfer_reconsurf -o /tmp/env.tar && \
-  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
 
 # Now that venv in a new location, fix up paths:
 RUN /venv/bin/conda-unpack

--- a/fastsurfer_env_cpu.yml
+++ b/fastsurfer_env_cpu.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - cpuonly=1.0
   - cudatoolkit=11.3
-  - h5py==3.6.0
+  - h5py=3.6.0
   - matplotlib=3.5.1
   - pytorch=1.10.0 
   - torchvision=0.11.1 

--- a/fastsurfer_env_gpu.yml
+++ b/fastsurfer_env_gpu.yml
@@ -7,7 +7,7 @@ channels:
   
 dependencies:
   - cudatoolkit=11.3
-  - h5py==3.6.0
+  - h5py=3.6.0
   - matplotlib=3.5.1
   - pytorch=1.10.0 
   - torchvision=0.11.1 


### PR DESCRIPTION
This uses the docker variable targetarch to determine which miniconda file to download. It translates amd64 to x86_64 and arm64 to aarch64. 