### PR TITLE
Hires-flag for hires processing in recon-surf

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -110,6 +110,7 @@ class RunModelOnData:
         self.model = Inference(self.cfg_fin, self.ckpt_fin, args.no_cuda, self.small_gpu)
         self.device = self.model.get_device()
         self.dim = self.model.get_max_size()
+        self.hires = args.hires
 
     def set_view_ops(self, args):
         cfg_cor = set_up_cfgs(args.cfg_cor, args) if args.cfg_cor is not None else None
@@ -131,7 +132,7 @@ class RunModelOnData:
         LOGGER.info("Saving original image to {}".format(self.input_img_name))
         self.save_img(self.input_img_name, self.orig_data)
 
-        if not conf.is_conform(self.orig, conform_min=True, check_dtype=True, verbose=False):
+        if not conf.is_conform(self.orig, conform_min=self.hires, check_dtype=True, verbose=False):
             LOGGER.info("Conforming image")
             self.orig = conf.conform(self.orig, conform_min=True)
             self.orig_data = np.asanyarray(self.orig.dataobj)
@@ -322,6 +323,7 @@ if __name__ == "__main__":
     parser.add_argument("--single_img", default=False, action="store_true",
                         help="Run single image for testing purposes instead of entire csv-file")
     parser.add_argument('--save_img', action='store_true', default=False, help="Save prediction as mgz on disk.")
+    parser.add_argument('--hires', action="store_true", default=False, dest='hires')
 
 
     # 3. Checkpoint to load

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -374,7 +374,7 @@ if [ "$surf_only" == "0" ]; then
   echo "" |& tee -a $seg_log
 
   pushd $fastsurfercnndir
-  cmd="$python run_prediction.py --orig_name $t1 --pred_name $seg --conf_name $conformed_name --ckpt_sag $weights_sag --ckpt_ax $weights_ax --ckpt_cor $weights_cor --batch_size $batch_size --single_img --cfg_cor $config_cor --cfg_ax $config_ax --cfg_sag $config_sag --save_img --run_viewagg_on $viewagg $cuda"
+  cmd="$python run_prediction.py --orig_name $t1 --pred_name $seg --conf_name $conformed_name $hires --ckpt_sag $weights_sag --ckpt_ax $weights_ax --ckpt_cor $weights_cor --batch_size $batch_size --single_img --cfg_cor $config_cor --cfg_ax $config_ax --cfg_sag $config_sag --save_img --run_viewagg_on $viewagg $cuda"
   echo $cmd |& tee -a $seg_log
   $cmd |& tee -a $seg_log
   if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -52,6 +52,7 @@ fstess=""
 fsqsphere=""
 fsaparc=""
 fssurfreg=""
+hires=""
 doParallel=""
 threads="1"
 python="python3.8"
@@ -94,6 +95,7 @@ function usage()
     echo -e "\t--fsqsphere                            Use FreeSurfer iterative inflation for qsphere (default: spectral spherical projection)"
     echo -e "\t--fsaparc                              Additionally create FS aparc segmentations and ribbon. Skipped by default (--> DL prediction is used which is faster, and usually these mapped ones are fine)"
     echo -e "\t--surfreg                              Run Surface registration with FreeSurfer (for cross-subject correspondence)"
+    echo -e "\t--hires                                Run FastSurfer recon-surf stream for hires image"
     echo -e "\t--parallel                             Run both hemispheres in parallel"
     echo -e "\t--threads <int>                        Set openMP and ITK threads to <int>"
     echo -e "\t--py <python_cmd>                      Command for python, default 'python3.6'"
@@ -245,6 +247,10 @@ case $key in
     fssurfreg="--surfreg"
     shift # past argument
     ;;
+    --hires)
+    hires="--hires"
+    shift # past argument
+    ;;
     --parallel)
     doParallel="--parallel"
     shift # past argument
@@ -379,7 +385,7 @@ if [ "$seg_only" == "0" ]; then
   # ============= Running recon-surf (surfaces, thickness etc.) ===============
   # use recon-surf to create surface models based on the FastSurferCNN segmentation.
   pushd $reconsurfdir
-  cmd="./recon-surf.sh --sid $subject --sd $sd --t1 $conformed_name --seg $seg $seg_cc $vol_segstats $fstess $fsqsphere $fsaparc $fssurfreg $doParallel --threads $threads --py $python $vcheck $vfst1"
+  cmd="./recon-surf.sh --sid $subject --sd $sd --t1 $conformed_name --seg $seg $seg_cc $vol_segstats $fstess $fsqsphere $fsaparc $fssurfreg $hires $doParallel --threads $threads --py $python $vcheck $vfst1"
   $cmd
   if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   popd


### PR DESCRIPTION
Added missing hires flag in run-fastsurfer.sh. Will be passed over to recon-surf.sh to allow conforming of images to minimum size (not 1.0 mm).