### PR TITLE
Speed-up BA exvivo labels projection with python

### DIFF
--- a/fastsurfer_env_cpu.yml
+++ b/fastsurfer_env_cpu.yml
@@ -19,6 +19,7 @@ dependencies:
   - python-dateutil=2.8.2
   - pyyaml=6.0
   - scikit-image=0.19.2
+  - scikit-learn=1.1.2
   - scipy=1.8.0
   - pip=21.2.4
   - pip:

--- a/fastsurfer_env_gpu.yml
+++ b/fastsurfer_env_gpu.yml
@@ -18,6 +18,7 @@ dependencies:
   - python-dateutil=2.8.2
   - pyyaml=6.0
   - scikit-image=0.19.2
+  - scikit-learn=1.1.2
   - scipy=1.8.0
   - pip=21.2.4
   - pip:

--- a/fastsurfer_env_reconsurf.yml
+++ b/fastsurfer_env_reconsurf.yml
@@ -12,6 +12,7 @@ dependencies:
   - python-dateutil=2.8.2
   - pyyaml=6.0
   - scikit-image=0.19.2
+  - scikit-learn=1.1.2
   - scipy=1.8.0
   - pip=21.2.4
   - pip:

--- a/recon_surf/align_seg.py
+++ b/recon_surf/align_seg.py
@@ -37,7 +37,8 @@ align_seg.py --srcseg <img> --flipped      [--affine] --outlta <out.lta>
 
 
 Dependencies:
-    Python 3.6
+    Python 3.8
+    numpy
     SimpleITK https://simpleitk.org/ (v2.1.1)
     
 

--- a/recon_surf/align_seg.py
+++ b/recon_surf/align_seg.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2022 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# IMPORTS
+import optparse
+import numpy as np
+import sys
+import SimpleITK as sitk
+import image_io as iio
+import align_points as align
+import lta as lta
+
+
+HELPTEXT = """
+
+Script to align two images based on the centroids of their segmentations
+
+USAGE:
+
+align_seg.py --srcseg <img> --trgseg <img> [--affine] --outlta <out.lta> 
+
+align_seg.py --srcseg <img> --flipped      [--affine] --outlta <out.lta>
+
+
+Dependencies:
+    Python 3.6
+    SimpleITK https://simpleitk.org/ (v2.1.1)
+    
+
+Description:
+For each common segmentation ID in the two inputs, the centroid coordinate is 
+computed. The point pairs are then aligned by finding the optimal translation and rotation
+(rigid) or affine. The output is a FreeSurfer LTA registration file. 
+
+Original Author: Martin Reuter
+Date: Aug-24-2022
+"""
+
+
+h_srcseg   = 'path to src source segmentation (e.g. aparc+aseg.mgz)'
+h_trgseg   = 'path to trg source segmentation '
+h_affine   = 'register affine, instead of rigid (default), cannot be combined with --flipped'
+h_outlta   = 'path to output transform lta file'
+h_flipped  = 'register to left-right flipped as target aparc+aseg (cortical needed)'
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id:align_seg.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--srcseg',  dest='srcseg',  help=h_srcseg)
+    parser.add_option('--trgseg',  dest='trgseg',  help=h_trgseg)
+    parser.add_option('--affine',  dest='affine',  help=h_affine,  default=False, action="store_true")
+    parser.add_option('--flipped', dest='flipped', help=h_flipped, default=False, action="store_true")
+    parser.add_option('--outlta',  dest='outlta',  help=h_outlta)
+    (options, args) = parser.parse_args()
+    if options.srcseg is None or ( options.trgseg is None and not options.flipped ) or options.outlta is None:
+        sys.exit('\nERROR: Please specify srcseg and trgseg (or flipped) as well as output lta file\n   Use --help to see all options.\n')
+    return options
+
+
+def get_seg_centroids(seg_mov, seg_dst, label_ids=[]):
+# extracts the centroids of the segmentation labels for mov and dst in RAS coords
+    if not label_ids:
+        # use all joint labels except -1 and 0:
+        nda1 = sitk.GetArrayFromImage(seg_mov)
+        nda2 = sitk.GetArrayFromImage(seg_dst)
+        lids=np.intersect1d(nda1,nda2)
+        lids=lids[(lids>0)]
+    else:
+        lids=label_ids
+    # extract centroids from segmentation labels
+    label_stats_mov = sitk.LabelShapeStatisticsImageFilter()
+    label_stats_mov.Execute(seg_mov)
+    label_stats_dst = sitk.LabelShapeStatisticsImageFilter()
+    label_stats_dst.Execute(seg_dst)
+    counter = 0
+    centroids_mov=np.empty([lids.size,3])
+    centroids_dst=np.empty([lids.size,3])
+    #print(lids)
+    for label in lids:
+        label=int(label)
+        centroids_mov[counter] = label_stats_mov.GetCentroid(label)
+        centroids_dst[counter] = label_stats_dst.GetCentroid(label)
+        #print("centroid pyhsical: {}".format(centroid_world))
+        #centroidf = itkmask.TransformPhysicalPointToContinuousIndex(centroid_world)
+        #print("centroid voxel: {}".format(centroidf))
+        #centroid  = itkmask.TransformPhysicalPointToIndex(centroid_world)
+        counter=counter+1
+    # FreeSurfer seems to have different RAS than sITK physical space
+    # so we flip the axis accordingly (will ensure the return matrix
+    # of a registration is RAS2RAS)
+    centroids_mov = centroids_mov * np.array([-1,-1,1])
+    centroids_dst = centroids_dst * np.array([-1,-1,1])
+    return centroids_mov, centroids_dst
+
+
+def align_seg_centroids(seg_mov, seg_dst, label_ids=[], affine=False):
+# Aligns the segmentations based on label centroids (rigid is default)#
+# returns RAS2RAS transform
+    # get centroids of each label in image
+    centroids_mov, centroids_dst = get_seg_centroids(seg_mov, seg_dst, label_ids)
+    # register
+    if affine:
+        T = align.find_affine(centroids_mov,centroids_dst)
+    else:
+        T = align.find_rigid(centroids_mov,centroids_dst)
+    #print(T)
+    return T
+
+
+def align_flipped(seg):
+    # left - right registration (make upright)
+    # segmentation should be aparc+aseg (DKT or not)
+    # we are registering cortial lables
+
+    lhids = np.array([
+        1002, 1003, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014,
+        1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026,
+        1027, 1028, 1029, 1030, 1031, 1034, 1035])
+    rhids = np.array([
+        2002, 2003, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,
+        2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026,
+        2027, 2028, 2029, 2030, 2031, 2034, 2035])
+    l = lhids.size
+    label_stats = sitk.LabelShapeStatisticsImageFilter()
+    label_stats.Execute(seg)
+    centroids=np.empty([2*lhids.size,3])
+    counter = 0
+    for label in np.concatenate((lhids,rhids)):
+        label=int(label)
+        centroids[counter] = label_stats.GetCentroid(label)
+        counter=counter+1
+
+    centroids = centroids * np.array([-1,-1,1])
+    # negate right-left
+    centroids_flipped = centroids * np.array([[-1,1,1]])
+    # now right is left and left is right (re-order)
+    centroids_flipped = np.concatenate((centroids_flipped[l::,:], centroids_flipped[0:l,:]))
+    # register centroids to LR-flipped versions
+    T = align.find_rigid(centroids,centroids_flipped)
+    # get half-way transform
+    from scipy.linalg import sqrtm
+    Tsqrt = np.real(sqrtm(T))
+    print(np.linalg.norm(T- (Tsqrt @ Tsqrt)))
+    return Tsqrt
+
+
+
+
+if __name__ == "__main__":
+
+    # Command Line options are error checking done here
+    options = options_parse()
+
+    print()
+    print("Align Segmentations Parameters:")
+    print()
+    print("- src seg {}".format(options.srcseg))
+    if options.trgseg is not None:
+        print("- trg seg {}".format(options.trgseg))
+    if options.flipped:
+        print("- registering with left-right flipped image")
+    if options.affine:
+        print("- affine registration")
+    else:
+        print("- rigid registration")
+    print("- out lta {}".format(options.outlta))
+    
+    print("\nreading src {}".format(options.srcseg))
+    srcseg, srcheader = iio.readITKimage(options.srcseg, sitk.sitkInt16, with_header=True)
+    if options.trgseg is not None:
+        print("reading trg {} ...".format(options.trgseg))
+        trgseg, trgheader = iio.readITKimage(options.trgseg, sitk.sitkInt16, with_header=True)
+        # register segmentations:
+        T = align_seg_centroids(srcseg,trgseg,affine=options.affine)
+    else:
+        # flipped:
+        T = align_flipped(srcseg)
+        trgheader = srcheader
+        
+    # write transform lta
+    print("writing: {}".format(options.outlta))
+    lta.writeLTA(options.outlta, T, options.srcseg, srcheader, options.trgseg, trgheader)
+
+    print("...done\n")
+    
+    sys.exit(0)

--- a/recon_surf/create_annotation.py
+++ b/recon_surf/create_annotation.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2022 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import optparse
+import os.path
+import numpy as np
+import sys
+import nibabel.freesurfer.io as fs
+from map_surf_label import mapSurfLabel, getSurfCorrespondence
+
+
+HELPTEXT = """
+
+Script to map and combine a set of labels into an annotation file
+
+create_annotation.py --hemi <lh,rh> --colortab <table.txt> --labeldir <ldir>
+                     --white <hemi.white> --outannot <hemi.annot>
+                     --cortex <hemi.cortex.label> --thresh
+
+when mapping labels use these additional flags:
+
+                     --srcsphere <hemi.shpere.reg> --trgsphere <hemi.sphere.reg>
+                     --trgdir <label-dir> --trgsid <sid>
+
+
+Dependencies:
+    Python 3.8
+    numpy, nibabel, sklearn
+    
+
+Description:
+This script reads a set of labels as listed in the color table file (and hemi) from the
+label directory and creates a FreeSurfer annotation file usually on the white surface of
+that subject, optionally cropping to the cortex region if a cortex label is passed. 
+It therefore is similar to FreeSurfer's mris_label2annot.
+
+Additionally it is possible to take the labels from another subject (usually fsaverage) 
+and map those to the current subject. For this you need to pass src and trg sphere.reg 
+files as well as the src label directory. If the mapped labels should be output, also
+pass the trgdir where to write the labels and trgsid, else it only creates the
+annotation after mapping and discards the individual labels. In this case --labeldir is 
+understood to be the label directory in the source subject. 
+
+Note, the ordering of the labels in the colortable is relevant as later labels can 
+overwrite earlier ones (if their label value is equal, else the one with the higher value
+will prevail).
+
+Also note, all filenames require full (or relative) path including hemi and filename, e.g.
+--outannot $SUBJECTS_DIR/subjectid/surf/lh.BA_exvivo.annot
+
+
+Original Author: Martin Reuter
+Date: Aug-24-2022
+"""
+
+h_hemi       = '"lh" or "rh" for reading labels'
+h_colortab   = 'colortab with label ids, names and colors'
+h_labeldir   = 'dir where to find the label files (when reading)'
+h_white      = 'path/filename of white surface for the annotation'
+h_cortex     = 'optional path to hemi.cortex for optional masking of annotation to only cortex'
+h_outannot   = 'path to output annotation file'
+h_thresh     = 'optional, ".thresh" will be appended to label names for exvivo FS labels'
+# when mapping labels additionally
+h_srcsphere  = 'optional, when mapping: path to src sphere.reg'
+h_trgsphere  = 'optional, when mapping: path to trg sphere.reg'
+h_trgdir     = 'optional: directory where to write mapped label files'
+h_trgsid     = 'optional, when storing mapped labels: target subject id, also written into label file'
+
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id:create_annotation.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--hemi',      dest='hemi',      help=h_hemi)
+    parser.add_option('--colortab',  dest='colortab',  help=h_colortab)
+    parser.add_option('--labeldir',  dest='labeldir',  help=h_labeldir)
+    parser.add_option('--white',     dest='white',     help=h_white)
+    parser.add_option('--cortex',    dest='cortex',    help=h_cortex)
+    parser.add_option('--thresh',    dest='thresh',    help=h_thresh, default=False, action="store_true")
+    parser.add_option('--outannot',  dest='outannot',  help=h_outannot)
+    parser.add_option('--srcsphere', dest='srcsphere', help=h_srcsphere)
+    parser.add_option('--trgsphere', dest='trgsphere', help=h_trgsphere)
+    parser.add_option('--trgdir',    dest='trgdir',    help=h_trgdir)
+    parser.add_option('--trgsid',    dest='trgsid',    help=h_trgsid)
+    (options, args) = parser.parse_args()
+    if options.hemi is None or options.colortab is None or options.labeldir is None \
+       or options.white is None or options.outannot is None:
+        sys.exit('\nERROR: Please specify all parameters!\n   Use --help to see all options.\n')
+    if options.trgsphere is not None or options.srcsphere is not None or options.trgdir is not None \
+       or options.trgsid is not None:
+        if options.trgsphere is None or options.srcsphere is None:
+            sys.exit('\nERROR: Please specify at least src and trg sphere when mapping!\n   Use --help to see all options.\n')
+    if (options.trgdir is not None and options.trgsid is None) or (options.trgdir is None and options.trgsid is not None):
+        sys.exit('\nERROR: Please specify both trgdir and trgsid when outputting mapped labels!\n   Use --help to see all options.\n')
+
+    return options
+
+
+
+def map_multiple_labels(hemi, src_dir, src_labels, src_sphere_name, 
+                        trg_sphere_name, trg_white_name, trg_sid, 
+                        out_dir = None):
+# function to map a list of labels (just names without hemisphere or path, which are 
+#  passed via hemi, src_dir, out_dir) from one surface (e.g. fsavaerage sphere.reg)
+#  to another. 
+#  all mapped labels and their values (in case it is not binary) are returned
+#  Also mapped label files are written to the out_dir if specified
+    # get reverse mapping (trg->src) for sampling
+    rev_mapping,_,_ = getSurfCorrespondence(trg_sphere_name, src_sphere_name)
+    all_labels = []
+    all_values = []
+    # read target surf info (for label writing)
+    print("Reading in trg white surface: {} ...".format(trg_white_name))
+    trg_white = fs.read_geometry(trg_white_name, read_metadata=False)[0]
+    out_label_name = None
+    for l_name in src_labels:
+        if l_name == "unknown":
+            print("unknown label: skipping ...")
+            continue
+        src_label_name = os.path.join(src_dir,hemi+"."+l_name+".label")
+        if out_dir is not None:
+            out_label_name = os.path.join(out_dir,hemi+"."+l_name+".label")
+        # map label from src to target
+        if os.path.exists(src_label_name):
+            #print("Mapping label {}.{} ...".format(hemi,l_name))
+            l,v = mapSurfLabel(src_label_name, out_label_name, trg_white, trg_sid, rev_mapping)
+        else:
+            print("\nWARNING: Label file missing {}\n".format(src_label_name))
+            l=[]
+            v=[]
+        all_labels.append(l)
+        all_values.append(v)
+    return all_labels, all_values
+
+
+def read_multiple_labels(hemi, input_dir, label_names):
+# read multiple label files from input_dir
+    all_labels = []
+    all_values = []
+    for l_name in label_names:
+        label_file = os.path.join(input_dir,hemi+"."+l_name+".label")
+        if os.path.exists(label_file):
+            l, v = fs.read_label(label_file, read_scalars=True)
+        else:
+            print("\nWARNING: Label file missing {}\n".format(label_file))
+            l=[]
+            v=[]
+        all_labels.append(l)
+        all_values.append(v)
+    return all_labels, all_values
+  
+
+
+def create_annot(all_labels, all_values, col_ids, trg_white, cortex_label_name=None):
+# function to create an annotation from multiple labels. Here we also consider the
+# label values and overwrite existing labels if values of current are larger (or equal,
+# so the order of the labels matters). 
+# annot_ids and values are returned, no output is written.
+#
+    # create annot from a bunch of labels (and values)
+    if isinstance(trg_white, str):
+        trg_white= fs.read_geometry(trg_white, read_metadata=False)[0]
+    annot_ids  = np.zeros(trg_white.shape[0],dtype="i8")
+    annot_vals = np.zeros(trg_white.shape[0])
+    counter=0
+    print(col_ids)
+    #offset =1 # start with id=1 (as zero is unknown)
+    for label in all_labels:
+        #print("counter={}".format(counter))
+        if len(label) == 0:
+            print("\nWARNING: Label with id {} missing, skipping ...\n".format(col_ids[counter]))
+            counter=counter+1
+            continue
+        vals = np.squeeze(all_values[counter])
+        label = np.squeeze(label)
+        mask = (vals >= annot_vals[label])
+        label_masked = label[mask]
+        vals_masked = vals[mask]
+        #annot_ids[label_masked] = counter + offset
+        annot_ids[label_masked] = col_ids[counter]
+        annot_vals[label_masked] = vals_masked
+        counter=counter+1
+    # mask non-cortex if cortex label is passed (mask value is -1)
+    if cortex_label_name is not None:
+        cortex_label = fs.read_label(cortex_label_name, read_scalars=False)
+        mask = np.ones(trg_white.shape[0], dtype=bool)
+        mask[cortex_label] = False
+        annot_ids[mask] = -1 
+    return annot_ids, annot_vals
+
+
+def read_colortable(colortab_name):
+    colortab = np.genfromtxt(colortab_name, dtype="i8",usecols=(0,2,3,4,5))
+    ids = colortab[:,0]
+    colors = colortab[:,1:]
+    names = np.genfromtxt(colortab_name, dtype="S30",usecols=(1))
+    names = [x.decode() for x in names]
+    return ids, names, colors
+
+
+def write_annot(annot_ids, label_names, colortab_name, out_annot):
+# This function combines the colortable with the annotations ids to 
+# write an annotation file (which contains colortable information)
+# Care needs to be taken that the colortable file has the same number
+# and order of labels as specified in the label_names list
+#
+    #colortab_name="colortable_BA.txt"
+    col_ids, col_names, col_colors = read_colortable(colortab_name)
+    for name_tab, name_list in zip(col_names[1:], label_names):
+        if name_tab != name_list:
+            print("Name in colortable and in label lists disagree: {} != {}".format(name_tab,name_list))
+            #raise ValueError("Error: name in colortable and in label lists disagree: {} != {}".format(name_tab,name_list))
+    # fill_ctab computes the last column (R+G*2^8+B*2^16)
+    fs.write_annot(out_annot, annot_ids, col_colors, col_names, fill_ctab=True)
+
+
+
+if __name__ == "__main__":
+
+    # Command Line options are error checking done here
+    options = options_parse()
+
+    print()
+    print("Map BA Labels Parameters:")
+    print()
+    print("- hemi: {}".format(options.hemi))
+    print("- color table: {}".format(options.colortab))
+    print("- label dir: {}".format(options.labeldir))
+    print("- white: {}".format(options.white))
+    print("- out annot: {}".format(options.outannot))
+    if options.cortex is not None:
+        print("- cortex mask: {}".format(options.cortex))  
+    if options.thresh:
+        print("- appending .thresh to label names")  
+    if options.trgsphere is not None:
+        print("Mapping labels from another subject:")
+        print("- src sphere: {}".format(options.srcsphere))    
+        print("- trg sphere: {}".format(options.trgsphere))    
+        if options.trgdir is not None:
+            print("And will write mapped labels:")
+            print("- trg dir: {}".format(options.trgdir))    
+            print("- trg sid: {}".format(options.trgsid))
+    print()
+
+    # for example:
+        
+    #./create_annotation.py --hemi lh \
+    #   --colortab colortable_BA.txt \
+    #   --labeldir fsaverage/label \
+    #   --white OAS1_0111_MR1/surf/lh.white \
+    #   --outannot lh.test.annot \
+    #   --cortex OAS1_0111_MR1/label/lh.cortex.label \
+    #   --srcsphere fsaverage/surf/lh.sphere.reg \
+    #   --trgsphere OAS1_0111_MR1/surf/lh.sphere.reg \
+    #   --trgdir test --trgsid OAS1_0111_MR1
+    
+    #./create_annotation.py --hemi lh \
+    #   --colortab colortable_BA.txt \
+    #   --labeldir OAS1_0111_MR1/label \
+    #   --white OAS1_0111_MR1/surf/lh.white \
+    #   --outannot lh.test2.annot \
+    #   --cortex OAS1_0111_MR1/label/lh.cortex.label \
+    
+    
+    # read label names from color table
+    print("Reading in colortable: {} ...".format(options.colortab))
+    ids, names, cols = read_colortable(options.colortab)
+    if (names[0]=="unknown"):
+        ids = ids[1:]
+        names = names[1:]
+        cols = cols[1:] # although we do not care about color at this stage at all
+    if options.thresh:
+            names = [x+".thresh" for x in names]
+    print("Merging these labels into annot:\n{}\n".format(names))
+
+    # if reading multiple label files
+    if options.trgsphere is None:
+        print("Reading multiple labels from {} ...".format(options.labeldir))
+        all_labels, all_values = read_multiple_labels(options.hemi, options.labeldir, names)
+    else:
+    # if mapping multiple label files
+        print("Mapping multiple labels from {} to {} ...".format(options.labeldir, options.trgdir))
+        all_labels, all_values = map_multiple_labels(options.hemi, options.labeldir, 
+                        names, options.srcsphere, options.trgsphere,
+                        options.white, options.trgsid, options.trgdir)
+        
+    # merge labels into annot
+    print("Creating annotation on {}".format(options.white))
+    annot_ids, annot_vals = create_annot(all_labels, all_values, ids, options.white, options.cortex)
+    
+    # write annot
+    print("Writing annotation to {}".format(options.outannot))
+    write_annot(annot_ids, names, options.colortab, options.outannot)
+    
+    
+    print("...done\n")
+    
+    sys.exit(0)
+
+

--- a/recon_surf/create_annotation.py
+++ b/recon_surf/create_annotation.py
@@ -31,7 +31,7 @@ Script to map and combine a set of labels into an annotation file
 
 create_annotation.py --hemi <lh,rh> --colortab <table.txt> --labeldir <ldir>
                      --white <hemi.white> --outannot <hemi.annot>
-                     --cortex <hemi.cortex.label> --thresh
+                     --cortex <hemi.cortex.label> --append <extension>
 
 when mapping labels use these additional flags:
 
@@ -75,7 +75,7 @@ h_labeldir   = 'dir where to find the label files (when reading)'
 h_white      = 'path/filename of white surface for the annotation'
 h_cortex     = 'optional path to hemi.cortex for optional masking of annotation to only cortex'
 h_outannot   = 'path to output annotation file'
-h_thresh     = 'optional, ".thresh" will be appended to label names for exvivo FS labels'
+h_append     = 'optional, e.g. ".thresh" can be appended to label names (I/O) for exvivo FS labels'
 # when mapping labels additionally
 h_srcsphere  = 'optional, when mapping: path to src sphere.reg'
 h_trgsphere  = 'optional, when mapping: path to trg sphere.reg'
@@ -93,7 +93,7 @@ def options_parse():
     parser.add_option('--labeldir',  dest='labeldir',  help=h_labeldir)
     parser.add_option('--white',     dest='white',     help=h_white)
     parser.add_option('--cortex',    dest='cortex',    help=h_cortex)
-    parser.add_option('--thresh',    dest='thresh',    help=h_thresh, default=False, action="store_true")
+    parser.add_option('--append',    dest='append',    help=h_append)
     parser.add_option('--outannot',  dest='outannot',  help=h_outannot)
     parser.add_option('--srcsphere', dest='srcsphere', help=h_srcsphere)
     parser.add_option('--trgsphere', dest='trgsphere', help=h_trgsphere)
@@ -116,11 +116,13 @@ def options_parse():
 
 def map_multiple_labels(hemi, src_dir, src_labels, src_sphere_name, 
                         trg_sphere_name, trg_white_name, trg_sid, 
-                        out_dir = None):
+                        out_dir = None, stop_missing = True):
 # function to map a list of labels (just names without hemisphere or path, which are 
 #  passed via hemi, src_dir, out_dir) from one surface (e.g. fsavaerage sphere.reg)
 #  to another. 
-#  all mapped labels and their values (in case it is not binary) are returned
+#  stop_missing determines whether to stop on a missing src label file, or continue
+#  with a warning. 
+#  All mapped labels and their values are returned
 #  Also mapped label files are written to the out_dir if specified
     # get reverse mapping (trg->src) for sampling
     rev_mapping,_,_ = getSurfCorrespondence(trg_sphere_name, src_sphere_name)
@@ -142,9 +144,12 @@ def map_multiple_labels(hemi, src_dir, src_labels, src_sphere_name,
             #print("Mapping label {}.{} ...".format(hemi,l_name))
             l,v = mapSurfLabel(src_label_name, out_label_name, trg_white, trg_sid, rev_mapping)
         else:
-            print("\nWARNING: Label file missing {}\n".format(src_label_name))
-            l=[]
-            v=[]
+            if stop_missing:
+                raise ValueError("ERROR: Label file missing {}\n".format(src_label_name))
+            else:
+                print("\nWARNING: Label file missing {}\n".format(src_label_name))
+                l=[]
+                v=[]
         all_labels.append(l)
         all_values.append(v)
     return all_labels, all_values
@@ -168,7 +173,7 @@ def read_multiple_labels(hemi, input_dir, label_names):
   
 
 
-def create_annot(all_labels, all_values, col_ids, trg_white, cortex_label_name=None):
+def build_annot(all_labels, all_values, col_ids, trg_white, cortex_label_name=None):
 # function to create an annotation from multiple labels. Here we also consider the
 # label values and overwrite existing labels if values of current are larger (or equal,
 # so the order of the labels matters). 
@@ -180,7 +185,7 @@ def create_annot(all_labels, all_values, col_ids, trg_white, cortex_label_name=N
     annot_ids  = np.zeros(trg_white.shape[0],dtype="i8")
     annot_vals = np.zeros(trg_white.shape[0])
     counter=0
-    print(col_ids)
+    #print(col_ids)
     #offset =1 # start with id=1 (as zero is unknown)
     for label in all_labels:
         #print("counter={}".format(counter))
@@ -215,7 +220,7 @@ def read_colortable(colortab_name):
     return ids, names, colors
 
 
-def write_annot(annot_ids, label_names, colortab_name, out_annot):
+def write_annot(annot_ids, label_names, colortab_name, out_annot, append=""):
 # This function combines the colortable with the annotations ids to 
 # write an annotation file (which contains colortable information)
 # Care needs to be taken that the colortable file has the same number
@@ -223,44 +228,82 @@ def write_annot(annot_ids, label_names, colortab_name, out_annot):
 #
     #colortab_name="colortable_BA.txt"
     col_ids, col_names, col_colors = read_colortable(colortab_name)
-    for name_tab, name_list in zip(col_names[1:], label_names):
-        if name_tab != name_list:
-            print("Name in colortable and in label lists disagree: {} != {}".format(name_tab,name_list))
-            #raise ValueError("Error: name in colortable and in label lists disagree: {} != {}".format(name_tab,name_list))
+    offset = 0
+    if col_names[0] == "unknown":
+        offset = 1
+    for name_tab, name_list in zip(col_names[offset:], label_names):
+        if name_tab+append != name_list:
+            #print("Name in colortable and in label lists disagree: {} != {}".format(name_tab+append,name_list))
+            raise ValueError("Error: name in colortable and in label lists disagree: {} != {}".format(name_tab+append,name_list))
     # fill_ctab computes the last column (R+G*2^8+B*2^16)
+    if offset==0:
+       # no unknown as 0 label in color table, we need to add it
+       col_names = np.concatenate((['unknown'],col_names))
+       col_colors = np.vstack([[25,5,25,0],col_colors])
     fs.write_annot(out_annot, annot_ids, col_colors, col_names, fill_ctab=True)
 
+def create_annotation(options, verbose=True):
+# main function to map (if required), build  and write annotation
+    print()
+    print("Map BA Labels Parameters:")
+    print()
+    if verbose:
+        print("- hemi: {}".format(options.hemi))
+        print("- color table: {}".format(options.colortab))
+        print("- label dir: {}".format(options.labeldir))
+        print("- white: {}".format(options.white))
+        print("- out annot: {}".format(options.outannot))
+        if options.cortex is not None:
+            print("- cortex mask: {}".format(options.cortex))
+        if options.append is not None:
+            if options.append[0] != '.':
+                options.append = '.'+options.append
+            print("- append {} to label names".format(options.append))
+        if options.trgsphere is not None:
+            print("Mapping labels from another subject:")
+            print("- src sphere: {}".format(options.srcsphere))
+            print("- trg sphere: {}".format(options.trgsphere))
+            if options.trgdir is not None:
+                print("And will write mapped labels:")
+                print("- trg dir: {}".format(options.trgdir))
+                print("- trg sid: {}".format(options.trgsid))
+        print()
+    # read label names from color table
+    print("Reading in colortable: {} ...".format(options.colortab))
+    ids, names, cols = read_colortable(options.colortab)
+    if (names[0]=="unknown"):
+        ids = ids[1:]
+        names = names[1:]
+        cols = cols[1:] # although we do not care about color at this stage at all
+    if options.append is not None:
+            names = [x+options.append for x in names]
+    print("Merging these labels into annot:\n{}\n".format(names))
+    # if reading multiple label files
+    if options.trgsphere is None:
+        print("Reading multiple labels from {} ...".format(options.labeldir))
+        all_labels, all_values = read_multiple_labels(options.hemi, options.labeldir, names)
+    else:
+    # if mapping multiple label files
+        print("Mapping multiple labels from {} to {} ...".format(options.labeldir, options.trgdir))
+        all_labels, all_values = map_multiple_labels(options.hemi, options.labeldir, 
+                        names, options.srcsphere, options.trgsphere,
+                        options.white, options.trgsid, options.trgdir)
+    # merge labels into annot
+    print("Creating annotation on {}".format(options.white))
+    annot_ids, annot_vals = build_annot(all_labels, all_values, ids, options.white, options.cortex)
+    # write annot
+    print("Writing annotation to {}".format(options.outannot))
+    write_annot(annot_ids, names, options.colortab, options.outannot, options.append)
+    print("...done\n")
 
 
 if __name__ == "__main__":
 
-    # Command Line options are error checking done here
+    # Command line options and error checking done here
     options = options_parse()
 
-    print()
-    print("Map BA Labels Parameters:")
-    print()
-    print("- hemi: {}".format(options.hemi))
-    print("- color table: {}".format(options.colortab))
-    print("- label dir: {}".format(options.labeldir))
-    print("- white: {}".format(options.white))
-    print("- out annot: {}".format(options.outannot))
-    if options.cortex is not None:
-        print("- cortex mask: {}".format(options.cortex))  
-    if options.thresh:
-        print("- appending .thresh to label names")  
-    if options.trgsphere is not None:
-        print("Mapping labels from another subject:")
-        print("- src sphere: {}".format(options.srcsphere))    
-        print("- trg sphere: {}".format(options.trgsphere))    
-        if options.trgdir is not None:
-            print("And will write mapped labels:")
-            print("- trg dir: {}".format(options.trgdir))    
-            print("- trg sid: {}".format(options.trgsid))
-    print()
-
     # for example:
-        
+
     #./create_annotation.py --hemi lh \
     #   --colortab colortable_BA.txt \
     #   --labeldir fsaverage/label \
@@ -277,40 +320,19 @@ if __name__ == "__main__":
     #   --white OAS1_0111_MR1/surf/lh.white \
     #   --outannot lh.test2.annot \
     #   --cortex OAS1_0111_MR1/label/lh.cortex.label \
-    
-    
-    # read label names from color table
-    print("Reading in colortable: {} ...".format(options.colortab))
-    ids, names, cols = read_colortable(options.colortab)
-    if (names[0]=="unknown"):
-        ids = ids[1:]
-        names = names[1:]
-        cols = cols[1:] # although we do not care about color at this stage at all
-    if options.thresh:
-            names = [x+".thresh" for x in names]
-    print("Merging these labels into annot:\n{}\n".format(names))
 
-    # if reading multiple label files
-    if options.trgsphere is None:
-        print("Reading multiple labels from {} ...".format(options.labeldir))
-        all_labels, all_values = read_multiple_labels(options.hemi, options.labeldir, names)
-    else:
-    # if mapping multiple label files
-        print("Mapping multiple labels from {} to {} ...".format(options.labeldir, options.trgdir))
-        all_labels, all_values = map_multiple_labels(options.hemi, options.labeldir, 
-                        names, options.srcsphere, options.trgsphere,
-                        options.white, options.trgsid, options.trgdir)
-        
-    # merge labels into annot
-    print("Creating annotation on {}".format(options.white))
-    annot_ids, annot_vals = create_annot(all_labels, all_values, ids, options.white, options.cortex)
-    
-    # write annot
-    print("Writing annotation to {}".format(options.outannot))
-    write_annot(annot_ids, names, options.colortab, options.outannot)
-    
-    
-    print("...done\n")
+    #./create_annotation.py --hemi lh \
+    #   --colortab $FREESURFER_HOME/average/colortable_vpnl.txt \
+    #   --labeldir fsaverage/label  \
+    #   --white OAS1_0111_MR1/surf/lh.white \
+    #   --outannot lh.vpnl.annot \
+    #   --cortex OAS1_0111_MR1/label/lh.cortex.label \
+    #   --srcsphere $FREESURFER_HOME/subjects/fsaverage/surf/lh.sphere.reg \
+    #   --trgsphere OAS1_0111_MR1/surf/lh.sphere.reg \
+    #   --trgdir test --trgsid OAS1_0111_MR1
+
+
+    create_annotation(options)
     
     sys.exit(0)
 

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -141,11 +141,7 @@ if __name__ == "__main__":
     vpnl = os.path.join(fshome,"average","colortable_vpnl.txt")
     colnames = [ ba, ba, vpnl ]
     colappend = ["",".thresh",".mpm.vpnl"]
-    annotnames = [ "BA_exvivio", "BA_exvivo.thresh", "mpm.vpnl"]
-    #colnames = [ ba, ba]
-    #colappend = ["",".thresh"]
-    #annotnames = [ "BA_exvivio", "BA_exvivo.thresh"]
-    
+    annotnames = [ "BA_exvivo", "BA_exvivo.thresh", "mpm.vpnl"]    
     label_ids, label_names, label_cols = read_colortables(colnames, colappend)
 
     labeldir = os.path.join(options.fsaverage,"label")

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -51,7 +51,7 @@ hemisphere it will:
 3. map Grill-Spector labels 
 4. create annotations for each of those 
 5. compute surface stats files for the BA_exvivo labels (currently still using
-   FreeSurfer's' mris_anatomical_stats via command line execution)
+   FreeSurfer's mris_anatomical_stats via command line execution)
 Note, this script needs to be updated if FreeSurfer introduces changes into the -balabel 
 block of recon-all. Currently this is based on FreeSurfer 7.2.
 

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2022 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import optparse
+import os.path
+import os
+import numpy as np
+import sys
+import nibabel.freesurfer.io as fs
+from create_annotation import map_multiple_labels, read_colortable, build_annot, write_annot
+
+HELPTEXT = """
+
+Script to replicate recon-all --balabels step, to map and merge BA exvivo labels and
+Grill-Spector labels into annotations and produce statistics on some.
+
+fs_balabels.py --sid <subject id> --sd <subjects_dir> 
+
+Optional flags:
+               --fsaverage <fsaverage dir> --hemi <lh or rh>
+
+Dependencies:
+    Python 3.8
+    numpy, nibabel, sklearn
+    
+    Also FreeSurfer v7.2 is needed
+    
+Description:
+This script replaces recon-all --balabels with mostly our own python based mapping 
+scripts. These are much faster as the surface correspondence is computed one time and
+used when mapping all labels from fsaverage to the current case. Precisely, for each
+hemisphere it will:
+1. map BA_exvivo labels
+2. map BA_exvivo.thresh labels
+3. map Grill-Spector labels 
+4. create annotations for each of those 
+5. compute surface stats files for the BA_exvivo labels (currently still using
+   FreeSurfer's' mris_anatomical_stats via command line execution)
+Note, this script needs to be updated if FreeSurfer introduces changes into the -balabel 
+block of recon-all. Currently this is based on FreeSurfer 7.2.
+
+Original Author: Martin Reuter
+Date: Aug-31-2022
+"""
+
+h_sid        = 'subject id (name of directory within the subject directory)'
+h_sd         = 'subject directory path'
+h_hemi       = 'optioal: "lh" or "rh" (default run both hemispheres)'
+h_fsaverage  = 'optional: path to fsaverage (default is subject_dir/fsaverage)'
+
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id:fs_balabels.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--sid',       dest='sid',       help=h_sid)
+    parser.add_option('--sd',        dest='sd',        help=h_sd)
+    parser.add_option('--hemi',      dest='hemi',      help=h_hemi)
+    parser.add_option('--fsaverage', dest='fsaverage', help=h_fsaverage)
+    
+    (options, args) = parser.parse_args()
+
+    if options.sid is None or options.sd is None:
+        sys.exit('\nERROR: Please specify --sid and --sd !\n   Use --help to see all options.\n')
+    if options.fsaverage is None:
+        options.fsaverage=options.sd+"/fsaverage"
+    if options.hemi is None:
+        options.hemi = ["lh","rh"]
+    else:
+        options.hemi = [options.hemi]
+    
+    return options
+
+
+def read_colortables(colnames,colappend,drop_unknown=True):
+# reads multiple colortables and appends extensions, 
+# drops unknown by default
+    pos=0
+    all_names = []
+    all_ids = []
+    all_cols = []
+    for coltab in colnames:
+        print("Reading in colortable: {} ...".format(coltab))
+        ids, names, cols = read_colortable(coltab)
+        if drop_unknown and names[0]=="unknown":
+            ids = ids[1:]
+            names = names[1:]
+            cols = cols[1:]
+        if colappend[pos]:
+            names = [x+colappend[pos] for x in names]
+        all_names.append(names)
+        all_ids.append(ids)
+        all_cols.append(cols)
+        pos=pos+1
+    return all_ids, all_names, all_cols
+
+if __name__ == "__main__":
+
+    stream = os.popen('date')
+    output = stream.read()
+
+    print
+    print("#--------------------------------------------")
+    print("#@# BA_exvivo Labels "+output)
+    print
+
+    # Command line options and error checking done here
+    options = options_parse()
+
+    fshome = os.environ.get('FREESURFER_HOME')
+    if not fshome:
+        sys.exit('\nERROR: FREESURFER_HOME environment variable needs to be specified.\n')
+    sdir = os.environ.get('SUBJECTS_DIR')
+    if not sdir:
+        os.environ['SUBJECTS_DIR'] = options.sd
+    else:
+        if sdir != options.sd:
+            print("WARNING environment $SUBJECTS_DIR is set differently to --sd !")
+            os.environ['SUBJECTS_DIR'] = options.sd
+    
+    # read and stack colortable labels
+    ba   = os.path.join(fshome,"average","colortable_BA.txt")
+    vpnl = os.path.join(fshome,"average","colortable_vpnl.txt")
+    colnames = [ ba, ba, vpnl ]
+    colappend = ["",".thresh",".mpm.vpnl"]
+    annotnames = [ "BA_exvivio", "BA_exvivo.thresh", "mpm.vpnl"]
+    #colnames = [ ba, ba]
+    #colappend = ["",".thresh"]
+    #annotnames = [ "BA_exvivio", "BA_exvivo.thresh"]
+    
+    label_ids, label_names, label_cols = read_colortables(colnames, colappend)
+
+    labeldir = os.path.join(options.fsaverage,"label")
+    trgdir = os.path.join(options.sd,options.sid,"label")
+    for hemi in options.hemi:
+        # map all labels for this hemisphere in one step (one registration)
+        srcsphere=os.path.join(options.fsaverage,"surf",hemi+".sphere.reg")
+        trgsphere=os.path.join(options.sd,options.sid,"surf",hemi+".sphere.reg")
+        white=os.path.join(options.sd,options.sid,"surf",hemi+".white")
+        cortex=os.path.join(options.sd,options.sid,"label",hemi+".cortex.label")
+        print("Mapping multiple labels from {} to {} for {} ...\n".format(labeldir, trgdir, hemi))
+        all_labels, all_values = map_multiple_labels(hemi, labeldir, 
+                                 np.concatenate(label_names), srcsphere, trgsphere,
+                                 white, options.sid, trgdir)
+        # merge labels into annot
+        pos = 0  # 0,1,2
+        start = 0 # to corresponding blocks from all_labels and all_values
+        #print("Debug length all labels: {}".format(len(all_labels)))
+        for annot in annotnames:
+            #print("Debug length labelids pos {}".format(len(label_ids[pos])))
+            stop = start + len(label_ids[pos])
+            print("\nCreating {} annotation on {}".format(annot,white))
+            #print("Debug info start: {}, stop: {}".format(start,stop))
+            annot_ids, annot_vals = build_annot(all_labels[start:stop], all_values[start:stop], label_ids[pos], white, cortex)
+            # write annot
+            print("Writing BA_exvivo annotation to {}\n".format(annot))
+            annotout = os.path.join(options.sd,options.sid,"label",hemi+"."+annot+".annot")
+            write_annot(annot_ids, label_names[pos], colnames[pos], annotout, colappend[pos])
+            # now call annatomical stats from comand line (onyl for BA_exvivo)
+            if pos < 2:
+                print("Computing "+hemi+"."+annot+".stats ...")
+                stats = os.path.join(options.sd,options.sid,"stats",hemi+"."+annot+".stats")
+                ctab  = os.path.join(options.sd,options.sid,"label",annot+".ctab")
+                cmd = "mris_anatomical_stats -mgz -f {} -b -a {} -c {} \
+                       {} {} white".format(stats,annotout,ctab,options.sid,hemi)
+                print("Debug cmd: "+cmd)
+                stream = os.popen(cmd)
+                print(stream.read())
+            start = stop
+            pos=pos+1
+    
+    print("...done\n")
+
+
+
+
+
+

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -62,7 +62,7 @@ Date: Aug-31-2022
 h_sid        = 'subject id (name of directory within the subject directory)'
 h_sd         = 'subject directory path'
 h_hemi       = 'optioal: "lh" or "rh" (default run both hemispheres)'
-h_fsaverage  = 'optional: path to fsaverage (default is subject_dir/fsaverage)'
+h_fsaverage  = 'optional: path to fsaverage (default is $FREESURFER_HOME/subjects/fsaverage)'
 
 
 def options_parse():
@@ -79,8 +79,6 @@ def options_parse():
 
     if options.sid is None or options.sd is None:
         sys.exit('\nERROR: Please specify --sid and --sd !\n   Use --help to see all options.\n')
-    if options.fsaverage is None:
-        options.fsaverage=options.sd+"/fsaverage"
     if options.hemi is None:
         options.hemi = ["lh","rh"]
     else:
@@ -134,7 +132,10 @@ if __name__ == "__main__":
         if sdir != options.sd:
             print("WARNING environment $SUBJECTS_DIR is set differently to --sd !")
             os.environ['SUBJECTS_DIR'] = options.sd
-    
+    if options.fsaverage is None:
+        options.fsaverage=os.path.join(fshome,"subjects","fsaverage")
+
+
     # read and stack colortable labels
     ba   = os.path.join(fshome,"average","colortable_BA.txt")
     vpnl = os.path.join(fshome,"average","colortable_vpnl.txt")
@@ -187,9 +188,4 @@ if __name__ == "__main__":
             pos=pos+1
     
     print("...done\n")
-
-
-
-
-
 

--- a/recon_surf/lta.py
+++ b/recon_surf/lta.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2021 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# Collection of functions related to FreeSurfer's LTA (linear transform array) files:
+
+
+def writeLTA(filename, T, src_fname, src_header, dst_fname, dst_header):
+    from datetime import datetime
+    import getpass
+    
+    fields = ("dims","delta","Mdc","Pxyz_c")
+    for field in fields:
+        if not field in src_header:
+            raise ValueError("writeLTA Error: src_header format missing field: {}".format(field))
+        if not field in dst_header:
+            raise ValueError("writeLTA Error: dst_header format missing field: {}".format(field))
+
+    src_dims = str(src_header["dims"][0:3]).replace('[', '').replace(']', '')
+    src_vsize = str(src_header["delta"][0:3]).replace('[', '').replace(']', '')
+    src_v2r = src_header["Mdc"]
+    src_c   = src_header["Pxyz_c"]
+
+    dst_dims = str(dst_header["dims"][0:3]).replace('[', '').replace(']', '')
+    dst_vsize = str(dst_header["delta"][0:3]).replace('[', '').replace(']', '')
+    dst_v2r = dst_header["Mdc"]
+    dst_c   = dst_header["Pxyz_c"]
+
+    f = open(filename, "w")
+    f.write("# transform file {}\n".format(filename))
+    f.write("# created by {} on {}\n\n".format(getpass.getuser(),datetime.now().ctime()))
+    f.write("type      = 1 # LINEAR_RAS_TO_RAS\n")
+    f.write("nxforms   = 1\n")
+    f.write("mean      = 0.0 0.0 0.0\n")
+    f.write("sigma     = 1.0\n")
+    f.write("1 4 4\n")
+    f.write(str(T).replace(' [', '').replace('[', '').replace(']', ''))
+    f.write("\n")
+    f.write("src volume info\n")
+    f.write("valid = 1  # volume info valid\n")
+    f.write("filename = {}\n".format(src_fname))
+    f.write("volume = {}\n".format(src_dims))
+    f.write("voxelsize = {}\n".format(src_vsize))
+    f.write("xras   = {}\n".format(src_v2r[0,:]).replace('[', '').replace(']', ''))
+    f.write("yras   = {}\n".format(src_v2r[1,:]).replace('[', '').replace(']', ''))
+    f.write("zras   = {}\n".format(src_v2r[2,:]).replace('[', '').replace(']', ''))
+    f.write("cras   = {}\n".format(src_c).replace('[', '').replace(']', ''))
+    f.write("dst volume info\n")
+    f.write("valid = 1  # volume info valid\n")
+    f.write("filename = {}\n".format(dst_fname))
+    f.write("volume = {}\n".format(dst_dims))
+    f.write("voxelsize = {}\n".format(dst_vsize))
+    f.write("xras   = {}\n".format(dst_v2r[0,:]).replace('[', '').replace(']', ''))
+    f.write("yras   = {}\n".format(dst_v2r[1,:]).replace('[', '').replace(']', ''))
+    f.write("zras   = {}\n".format(dst_v2r[2,:]).replace('[', '').replace(']', ''))
+    f.write("cras   = {}\n".format(dst_c).replace('[', '').replace(']', ''))
+    f.close()
+
+

--- a/recon_surf/map_surf_label.py
+++ b/recon_surf/map_surf_label.py
@@ -123,7 +123,7 @@ def mapSurfLabel(src_label_name, out_label_name, trg_surf, trg_sid, rev_mapping)
     # correct coordinates (usually the white surface), can be vetrices or filename
     # trg_sid is the subject id (str) of the target subject (as 
     # stored in the output label file header)
-    print("Reading in label: {} ...".format(src_label_name))
+    print("Mapping label: {} ...".format(src_label_name))
     src_label, src_values = fs.read_label(src_label_name, read_scalars=True)
     smax = max(np.max(src_label),np.max(rev_mapping)) + 1
     tmax = rev_mapping.size
@@ -148,7 +148,7 @@ def mapSurfLabel(src_label_name, out_label_name, trg_surf, trg_sid, rev_mapping)
 
 if __name__ == "__main__":
 
-    # Command Line options are error checking done here
+    # Command line options and error checking done here
     options = options_parse()
 
     print()

--- a/recon_surf/map_surf_label.py
+++ b/recon_surf/map_surf_label.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+
+# Copyright 2022 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import optparse
+import numpy as np
+import sys
+import nibabel.freesurfer.io as fs
+from sklearn.neighbors import KDTree
+
+
+
+HELPTEXT = """
+
+Script to map surface labels across surfaces based on given sphere registrations
+
+map_surf_label.py --srclabel <in.label> --srcsphere <sphere.reg>
+                  --trgsphere <sphere.reg> --trgsurf <white> --trgsid <sid>
+                  --outlabel <out.label>
+
+
+Dependencies:
+    Python 3.8
+    numpy, nibabel, sklearn
+    
+
+Description:
+Computes correspondence between source and target spheres and maps src-label to target.
+Target surf (usually the white) coordinates at label vertices and SID is only written
+to output label and not used for any computations. 
+
+Original Author: Martin Reuter
+Date: Aug-24-2022
+"""
+
+
+h_srclabel   = 'path to src surface label file'
+h_srcsphere  = 'path to src sphere.reg'
+h_trgsphere  = 'path to trg sphere.reg'
+h_trgsurf    = 'path to trg surf (usually white) to write coordinates into label file'
+h_trgsid     = 'target subject id, also written into label file'
+h_outlabel   = 'output label file'
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id:map_surf_label.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--srclabel',  dest='srclabel',  help=h_srclabel)
+    parser.add_option('--srcsphere', dest='srcsphere', help=h_srcsphere)
+    parser.add_option('--trgsphere', dest='trgsphere', help=h_trgsphere)
+    parser.add_option('--trgsurf',   dest='trgsurf',   help=h_trgsurf)
+    parser.add_option('--trgsid',    dest='trgsid',    help=h_trgsid)
+    parser.add_option('--outlabel',  dest='outlabel',  help=h_outlabel)
+    (options, args) = parser.parse_args()
+    if options.srclabel is None or options.srcsphere is None or options.trgsphere is None \
+       or options.trgsurf is None or options.trgsid is None or options.outlabel is None:
+        sys.exit('\nERROR: Please specify all parameters!\n   Use --help to see all options.\n')
+    return options
+
+
+
+def writeSurfLabel(filename, sid, label, values, surf):
+    # writes a FS surface label file to filename (e.g. lh.labelname.label)
+    # stores sid string in the header, then number of vertices
+    # and table of vertex index, RAS wm-surface coords (taken from surf)
+    # and values (which can be zero)
+    if values is None:
+        values = np.zeros(label.shape)
+    if values.size != label.size :
+        raise ValueError("writeLabel Error: label and values should have same sizes {}!={}".format(label.size,values.size))
+    coords = surf[label,:]
+    header="#!ascii label  , from subject {} vox2ras=TkReg \n{}".format(sid,label.size)
+    data = np.column_stack([label, coords, values])
+    np.savetxt(filename, data, fmt=['%d','%.3f','%.3f','%.3f','%.6f'], header=header, comments='')
+
+
+def getSurfCorrespondence(src_sphere, trg_sphere, tree=None):
+    # For each vertex in src_sphere finds the closest vertex in trg_sphere
+    # spheres are Nx3 arrays of coordinates on the sphere (usually R=100 FS format)
+    # *_sphere can also be a file name of the sphere.reg files, then we load it.
+    # Will return indices, distances and the KDtree of the trg surface.
+    # The KDtree can be passed in cases where src moves around and trg stays fixed
+    #
+    # We can also work with file names instead of surface vertices
+    if isinstance(src_sphere, str):
+        src_sphere = fs.read_geometry(src_sphere, read_metadata=False)[0]
+    if isinstance(trg_sphere, str):
+        trg_sphere = fs.read_geometry(trg_sphere, read_metadata=False)[0]
+    # if someone passed the full output of fs.read_geometry
+    if isinstance(src_sphere,tuple):
+        src_sphere = src_sphere[0]
+    if isinstance(trg_sphere,tuple):
+        trg_sphere = trg_sphere[0]
+    # create tree if necessary and compute mapping
+    if tree is None:
+        from sklearn.neighbors import KDTree
+        tree = KDTree(trg_sphere)
+    distances, mapping = tree.query(src_sphere, 1)
+    return mapping, distances, tree
+
+
+def mapSurfLabel(src_label_name, out_label_name, trg_surf, trg_sid, rev_mapping):
+    # maps a label from src surface according to the correspondence
+    # in rev_mapping (! a mapping from target to source, listing the 
+    # corresponding src vertex for each vertex on the trg surface)
+    # trg_surf is passed so that the label file will list the 
+    # correct coordinates (usually the white surface), can be vetrices or filename
+    # trg_sid is the subject id (str) of the target subject (as 
+    # stored in the output label file header)
+    print("Reading in label: {} ...".format(src_label_name))
+    src_label, src_values = fs.read_label(src_label_name, read_scalars=True)
+    smax = max(np.max(src_label),np.max(rev_mapping)) + 1
+    tmax = rev_mapping.size
+    if isinstance(trg_surf, str):
+        print("Reading in surface: {} ...".format(trg_surf))
+        trg_surf = fs.read_geometry(trg_surf, read_metadata=False)[0]
+    if trg_surf.shape[0] != tmax:
+        raise ValueError("mapSurfLabel Error: label and trg vertices should have same sizes {}!={}".format(tmax,trg_surf.shape[0]))
+    inside = np.zeros(smax, dtype=bool)
+    inside[src_label] = True
+    values = np.zeros(smax)
+    values[src_label] = src_values
+    inside_trg = inside[rev_mapping]
+    trg_label = np.nonzero(inside[rev_mapping])[0]
+    trg_values = values[rev_mapping[trg_label]]
+    #print(trg_values)
+    #print(trg_label.size)
+    if out_label_name is not None:
+        writeSurfLabel(out_label_name,trg_sid,trg_label,trg_values,trg_surf)
+    return trg_label, trg_values
+
+
+if __name__ == "__main__":
+
+    # Command Line options are error checking done here
+    options = options_parse()
+
+    print()
+    print("Map Surface Labels Parameters:")
+    print()
+    print("- src label {}".format(options.srclabel))
+    print("- src sphere {}".format(options.srcsphere))
+    print("- trg sphere {}".format(options.trgsphere))
+    print("- trg surf {}".format(options.trgsurf))
+    print("- trg sid {}".format(options.trgsid))
+    print("- out label {}".format(options.outlabel))    
+
+    # for example:
+    #src_label_name = "fsaverage/label/lh.BA1_exvivo.label"
+    #out_label_name = "lh.BA1_exvivo_my.label"
+    #src_sphere_name = "fsaverage/surf/lh.sphere.reg" # identical to fsaverage sphere
+    #trg_sphere_name = "OAS1_0111_MR1/surf/lh.sphere72_my4.reg"
+    #trg_white_name = "OAS1_0111_MR1/surf/lh.white"
+    #trg_sid = "OAS1_0111_MR1"
+    
+    # ./map_surf_label.py --srclabel fsaverage/label/lh.BA1_exvivo.label --srcsphere fsaverage/surf/lh.sphere.reg --trgsphere OAS1_0111_MR1/surf/lh.sphere72_my4.reg --trgsurf OAS1_0111_MR1/surf/lh.white --trgsid OAS1_0111_MR1 --outlabel lh.BA1_exvivo_my.label
+    
+    print("Reading in src sphere: {} ...".format(options.srcsphere))
+    src_sphere = fs.read_geometry(options.srcsphere, read_metadata=False)[0]
+    print("Reading in trg sphere: {} ...".format(options.trgsphere))
+    trg_sphere = fs.read_geometry(options.trgsphere, read_metadata=False)[0]
+    # get reverse mapping (trg->src) for sampling
+    print("Computing reverse mapping ...")
+    rev_mapping,_,_ = getSurfCorrespondence(trg_sphere, src_sphere)
+    
+    # map label from src to target
+    print("Mapping src label to trg ...")
+    mapSurfLabel(options.srclabel, options.outlabel, options.trgsurf, options.trgsid, rev_mapping)
+    print("Output label {} written".format(options.outlabel))
+
+    print("...done\n")
+    
+    sys.exit(0)
+

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1005,7 +1005,7 @@ if [ "$fssurfreg" == "1" ] ; then
   #RunIt "$cmd" $LF 
   # here we run our version of balabels: mapping and annot creation is very fast
   # time is used in mris_anatomical_stats (called 4 times, BA and BA-thresh for each hemi)
-  cmd="$python ${binpath}/fs_balabels.py --sd $SUBJECTS_DIR -sid $subject"
+  cmd="$python ${binpath}/fs_balabels.py --sd $SUBJECTS_DIR --sid $subject"
   RunIt "$cmd" $LF
 fi
 

--- a/recon_surf/rotate_sphere.py
+++ b/recon_surf/rotate_sphere.py
@@ -55,6 +55,7 @@ Date: Jun-8-2022
 
 # In the future, maybe add a way to specify what labels to align as a list or 
 # txt file to pass to the routine. 
+# Also add output as LTA instead of registration angles.
 
 h_srcsphere = 'path to src ?h.sphere'
 h_srcaparc  = 'path to src corresponding cortical parcellation'
@@ -66,7 +67,7 @@ def options_parse():
     """
     Command line option parser
     """
-    parser = optparse.OptionParser(version='$Id: N4_bias_correct.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $', usage=HELPTEXT)
+    parser = optparse.OptionParser(version='$Id: rotate_sphere.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $', usage=HELPTEXT)
     parser.add_option('--srcsphere', dest='srcsphere', help=h_srcsphere)
     parser.add_option('--srcaparc',  dest='srcaparc',  help=h_srcaparc)
     parser.add_option('--trgsphere', dest='trgsphere', help=h_trgsphere)

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ matplotlib==3.5.1
 nibabel==3.2.2
 numpy==1.22.3
 scikit-image==0.19.2
+scikit-learn==1.1.2
 scipy==1.8.0
 python-dateutil==2.8.2
 simpleitk==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,8 @@ pyyaml==6.0
     # via -r requirements.in
 scikit-image==0.19.2
     # via -r requirements.in
+scikit-learn==1.1.2
+    # via -r requirements.in
 scipy==1.8.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
Replace `recon-all -balabels` with our own python code (except for the `mris_anatomical_stats`)

In FreeSurfer BA exvivo (and other labels) are mapped from fsaverage to the current subject within the `recon-all -balabels` call. This is very slow as each label is mapped independently, requiring a nearest neighbour search. This PR adds python code (needing scikit-learn nearest neighbor search, KDTree) to compute correspondence one time per hemisphere and then map all labels as a batch and directly combine sets of labels into the corresponding annotation, which is far more efficient. 

`mris_anatomical_stats` is not yet ported. It is still called from FreeSurfer to generate stats files for BA_exvivo labels and is the slowest part in the new pipeline (maybe it makes sense to port this in the future). 

The whole thing for both hemispheres takes now 33 seconds only! Compared to `recon-all -balabels` taking 7-8 mins on my machine. 

Note, while the label mapping is almost identical to FreeSurfer (at least visually), the merging for the annotation shows some small difference when resolving overlapping labels. Here - when label values agree - we select the label listed later to be the winner. When label values disagree, the one with the larger value wins. This is what FreeSurfer should be doing, but looks like it is not. Stats file, therefore, differ slightly. It is probably caused by noise in small decimal digits in the label values in FreeSurfer.