### PR TITLE
Bug fix: seg_only assigned to string 0 - dev branch

### DIFF
--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -402,7 +402,7 @@ fi
 if [ "$seg_only" == "1" ] && [ ! -z "$vol_segstats" ]
   then
     seg_cc="--seg_with_cc_only"
-    seg_only=0
+    seg_only="0"
     echo "You requested segstats without running the surface pipeline. In this case, recon-surf will"
     echo "run until the corpus callsoum is added to the segmentation and the norm.mgz is generated "
     echo "(needed for partial volume correction). "


### PR DESCRIPTION
Same as #184 for the dev branch

As indicated in issue https://github.com/Deep-MI/FastSurfer/issues/102 by [liqingbioinfo](https://github.com/liqingbioinfo) combination of --seg_only and --vol_segstats failed to run the recon-surf part for creating volume statistics. The seg_only flag was not correctly reset to "0" and hence failed the check for running the surface pipeline at all.

This commit fixes the issue by changing assignment to seg_only="0"