### PR TITLE
optimize interpolation_layer.py

### DIFF
--- a/FastSurferCNN/models/interpolation_layer.py
+++ b/FastSurferCNN/models/interpolation_layer.py
@@ -104,6 +104,16 @@ class _ZoomNd(nn.Module):
         if len(scales_chunks) == 0:
             raise ValueError(f"Invalid scale_factors {scale_factors}, no chunks returned.")
         scales, chunks = map(list, scales_chunks)
+
+        if len(scales) == 1:
+            if isinstance(scales[0], Tensor):
+                skip_interp = torch.all(torch.stack(scales, -1) == 1)
+            else:
+                skip_interp = np.all(np.asarray(scales) == 1)
+            if skip_interp:
+                # skip rescaling, this is the same resolution
+                return input_tensor, scales[:1] * chunks[0]
+
         interp, scales_out = [], []
 
         # Pytorch Tensor shape BxCxHxW --> loop over batches, interpolate single images, concatenate output at end


### PR DESCRIPTION
if scale_factor is 1 (1mm resolution), interpolation is the identity operation and my be skipped

Adressing https://github.com/Deep-MI/FastSurfer/issues/187

Speed improvement is about 1% (205 to 203 seconds on cpu)

Tested on bert -- identical for both cpu and gpu
