### PR TITLE
[logging] cleanup and unify the logging in vinn

### DIFF
--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -23,7 +23,8 @@ from scipy.ndimage import binary_erosion, binary_closing, filters, uniform_filte
 import scipy.ndimage.morphology as morphology
 import nibabel as nib
 import pandas as pd
-import logging
+
+from utils import logging
 from .conform import is_conform, conform, check_affine_in_nifti
 
 
@@ -31,9 +32,7 @@ from .conform import is_conform, conform, check_affine_in_nifti
 # Global Vars
 ##
 SUPPORTED_OUTPUT_FILE_FORMATS = ['mgz', 'nii', 'nii.gz']
-LOGGER = logging.getLogger("eval")
-LOGGER.setLevel(logging.DEBUG)
-LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
+LOGGER = logging.getLogger(__name__)
 
 ##
 # Helper Functions

--- a/FastSurferCNN/data_loader/dataset.py
+++ b/FastSurferCNN/data_loader/dataset.py
@@ -24,9 +24,9 @@ import time
 
 import data_loader.data_utils as du
 
-import utils.logging_script as logging
+from utils import logging
 
-logger = logging.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # Operator to load imaged for inference

--- a/FastSurferCNN/data_loader/loader.py
+++ b/FastSurferCNN/data_loader/loader.py
@@ -21,9 +21,9 @@ import data_loader.dataset as dset
 from data_loader.augmentation import ToTensor, ZeroPad2D, AddGaussianNoise
 import torchio as tio
 
-import utils.logging_script as logging
+from utils import logging
 
-logger = logging.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_dataloader(cfg, mode):

--- a/FastSurferCNN/generate_hdf5.py
+++ b/FastSurferCNN/generate_hdf5.py
@@ -27,9 +27,9 @@ from data_loader.data_utils import transform_axial, transform_sagittal, \
     get_thick_slices, filter_blank_slices_thick, \
     read_classes_from_lut, get_labels_from_lut, unify_lateralized_labels
 
-from utils import logging_script as ls
+from utils import logging as ls
 
-LOGGER = ls.get_logger(__name__)
+LOGGER = ls.getLogger(__name__)
 
 
 class H5pyDataset:

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -19,17 +19,18 @@ from typing import Tuple, Optional, Union, Dict
 import numpy as np
 import torch
 import os
-import logging
 import nibabel as nib
 import time
 import glob
 import sys
+import argparse
+
 print("Run pred", sys.path)
 
 from eval import Inference
 from utils.load_config import load_config
 from utils.checkpoint import get_checkpoints_vinn, VINN_AXI, VINN_COR, VINN_SAG
-import sys
+from utils import logging as logging
 
 import data_loader.data_utils as du
 import data_loader.conform as conf
@@ -37,9 +38,7 @@ import data_loader.conform as conf
 ##
 # Global Variables
 ##
-LOGGER = logging.getLogger("eval")
-LOGGER.setLevel(logging.DEBUG)
-LOGGER.addHandler(logging.StreamHandler(stream=sys.stdout))
+LOGGER = logging.getLogger(__name__)
 
 ##
 # Processing
@@ -53,6 +52,16 @@ def set_up_cfgs(cfg, args):
     cfg.MODEL.OUT_TENSOR_WIDTH = cfg.DATA.PADDED_SIZE
     cfg.MODEL.OUT_TENSOR_HEIGHT = cfg.DATA.PADDED_SIZE
     return cfg
+
+
+def args2cfg(args: argparse.Namespace):
+    """Extract the configuration objects from the arguments."""
+    cfg_cor = set_up_cfgs(args.cfg_cor, args) if args.cfg_cor is not None else None
+    cfg_sag = set_up_cfgs(args.cfg_sag, args) if args.cfg_sag is not None else None
+    cfg_ax = set_up_cfgs(args.cfg_ax, args) if args.cfg_ax is not None else None
+    cfg_fin = cfg_cor if cfg_cor is not None else cfg_sag if cfg_sag is not None else cfg_ax
+    return cfg_fin, cfg_cor, cfg_sag, cfg_ax
+
 
 
 ##
@@ -96,7 +105,7 @@ class RunModelOnData:
             # check, if GPU is big enough to run view agg on it
             # (this currently takes only the total memory into account, not the occupied on)
             total_gpu_memory = sum([torch.cuda.get_device_properties(i).__getattribute__("total_memory") for i in
-                                    range(torch.cuda.device_count())])
+                                    range(torch.cuda.device_count())]) if torch.cuda.is_available() else 0
             self.small_gpu = total_gpu_memory < 8000000000
 
         elif args.run_viewagg_on == "cpu":
@@ -114,25 +123,15 @@ class RunModelOnData:
         self.torch_labels = torch.from_numpy(self.lut["ID"].values)
         self.names = ["SubjectName", "Average", "Subcortical", "Cortical"]
         self.gn_noise = args.gn
-        self.view_ops, self.cfg_fin, self.ckpt_fin = self.set_view_ops(args)
+        self.cfg_fin, cfg_cor, cfg_sag, cfg_ax = args2cfg(args)
+        self.view_ops = {"coronal": {"cfg": cfg_cor, "ckpt": args.ckpt_cor},
+                         "sagittal": {"cfg": cfg_sag, "ckpt": args.ckpt_sag},
+                         "axial": {"cfg": cfg_ax, "ckpt": args.ckpt_ax}}
         self.ckpt_fin = args.ckpt_cor if args.ckpt_cor is not None else args.ckpt_sag if args.ckpt_sag is not None else args.ckpt_ax
         self.model = Inference(self.cfg_fin, self.ckpt_fin, args.device)
         self.device = self.model.get_device()
         self.dim = self.model.get_max_size()
         self.hires = args.hires
-
-    def set_view_ops(self, args):
-        cfg_cor = set_up_cfgs(args.cfg_cor, args) if args.cfg_cor is not None else None
-        cfg_sag = set_up_cfgs(args.cfg_sag, args) if args.cfg_sag is not None else None
-        cfg_ax = set_up_cfgs(args.cfg_ax, args) if args.cfg_ax is not None else None
-        cfg_fin = cfg_cor if cfg_cor is not None else cfg_sag if cfg_sag is not None else cfg_ax
-        ckpt_fin = args.ckpt_cor if args.ckpt_cor is not None else args.ckpt_sag if args.ckpt_sag is not None else args.ckpt_ax
-        return {"coronal": {"cfg": cfg_cor,
-                            "ckpt": args.ckpt_cor},
-                "sagittal": {"cfg": cfg_sag,
-                             "ckpt": args.ckpt_sag},
-                "axial": {"cfg": cfg_ax,
-                          "ckpt": args.ckpt_ax}}, cfg_fin, ckpt_fin
 
     def set_orig(self, orig_str):
         self.orig, self.orig_data = self.get_img(orig_str)
@@ -237,9 +236,9 @@ class RunModelOnData:
         if seg:
             header = self.orig.header.copy()
             header.set_data_dtype(np.int16)
-            du.save_image(header, self.orig.header.get_affine(), data, save_as)
+            du.save_image(header, self.orig.affine, data, save_as)
         else:
-            du.save_image(self.orig.header, self.orig.header.get_affine(), data, save_as)
+            du.save_image(self.orig.header, self.orig.affine, data, save_as)
         LOGGER.info("Successfully saved image as {}".format(save_as))
 
     def run(self, csv, save_img, metrics, logger=LOGGER):
@@ -303,8 +302,6 @@ def handle_cuda_memory_exception(exception: RuntimeError, exit_on_out_of_memory:
 
 
 if __name__ == "__main__":
-    import argparse
-
     parser = argparse.ArgumentParser(description='Evaluation metrics')
 
     # 1. Options for input directories and filenames
@@ -387,6 +384,12 @@ if __name__ == "__main__":
         parser.print_help(sys.stderr)
         sys.exit('----------------------------\nERROR: Please specify data output directory '
                  '(can be same as input directory)\n')
+
+
+    # Set up logging
+    from utils.logging import setup_logging
+    cfg = args2cfg(args)[0]
+    setup_logging(cfg.OUT_LOG_DIR, cfg.OUT_LOG_NAME)
 
     LOGGER.info("Origs: {}".format(args.orig_name))
 

--- a/FastSurferCNN/train.py
+++ b/FastSurferCNN/train.py
@@ -31,12 +31,12 @@ from utils.meters import Meter
 from utils.metrics import iou_score, precision_recall
 from utils.misc import update_num_steps, plot_predictions
 from config.global_var import get_class_names
-import utils.logging_script as logging
+import utils.logging as logging
 import time
 import os
 from collections import defaultdict
 
-logger = logging.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Trainer:

--- a/FastSurferCNN/utils/__init_.py
+++ b/FastSurferCNN/utils/__init_.py
@@ -1,0 +1,2 @@
+
+__all__ = ["checkpoint", "load_config", "logging", "lr_scheduler", "meters", "metrics", "misc"]

--- a/FastSurferCNN/utils/logging.py
+++ b/FastSurferCNN/utils/logging.py
@@ -14,33 +14,28 @@
 # limitations under the License.
 
 # IMPORTS
-import sys
-import logging
-from os import makedirs
-from os.path import join
+from logging import *
+from typing import Union as _Union
+from sys import stdout as _stdout
+from pathlib import Path as _Path
+from os import makedirs as _makedirs
+from os.path import join as _join
 
 
-def setup_logging(output_dir, expr_num):
+def setup_logging(output_dir: _Union[str, _Path], expr_num: str):
     """
     Sets up the logging
     """
     # Set up logging format.
     _FORMAT = "[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s"
-    log_folder = join(output_dir, "logs")
-    makedirs(log_folder, exist_ok=True)
-    log_file = join(log_folder, f"expr_{expr_num}.log")
+    log_folder = _join(output_dir, "logs")
+    _makedirs(log_folder, exist_ok=True)
+    log_file = _join(log_folder, f"expr_{expr_num}.log")
 
-    fh = logging.FileHandler(filename=log_file, mode='a')
-    ch = logging.StreamHandler(sys.stdout)
+    fh = FileHandler(filename=log_file, mode='a')
+    ch = StreamHandler(_stdout)
 
-    logging.basicConfig(level=logging.INFO, format=_FORMAT, handlers=[fh, ch])
+    basicConfig(level=INFO, format=_FORMAT, handlers=[fh, ch])
 
-
-def get_logger(name):
-    """
-    Retrieve the logger with the given name or, if name is None, return a
-    logger which is the root logger of the hierarchy.
-    Args:
-        name (string): name of the logger.
-    """
-    return logging.getLogger(name)
+# At this point, this is just an alias for compatibility’s sake
+get_logger = getLogger

--- a/FastSurferCNN/utils/meters.py
+++ b/FastSurferCNN/utils/meters.py
@@ -19,10 +19,10 @@ import matplotlib.pyplot as plt
 
 from utils.metrics import DiceScore
 from utils.misc import plot_confusion_matrix
-import utils.logging_script as logging
+from utils import logging
 
 
-logger = logging.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Meter:

--- a/FastSurferCNN/utils/metrics.py
+++ b/FastSurferCNN/utils/metrics.py
@@ -16,9 +16,9 @@
 # IMPORTS
 import torch
 import numpy as np
-import utils.logging_script as logging
+from utils import logging
 
-logger = logging.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def iou_score(pred_cls, true_cls, nclass=79):


### PR DESCRIPTION
cleanup the logging in run_prediction.py
- replace stub get_logger to getLogger
- add `__init__.py` in utils
- rename logging_script.py to logging.py (which is now an extension to the builtin logging, so it is less confusing)
- remove duplicate logging
- move the initialization of the logger to the beginning (instead of in __init__ of RunModelOnData
- added a tqdm progress bar and cleaned log messages for batches in Inference.eval
- change `image.header.get_affine()` to `image.affine` in a couple of places