### PR TITLE
Add experimental docker for AMD GPUs

### DIFF
--- a/Docker/Dockerfile_FastSurferCNN_AMD
+++ b/Docker/Dockerfile_FastSurferCNN_AMD
@@ -1,0 +1,32 @@
+## Experimental Dockerimage for testing AMD GPUs
+
+## Start with rocm/pytorch latest
+FROM rocm/pytorch
+ENV LANG=C.UTF-8
+ENV HSA_OVERRIDE_GFX_VERSION=10.3.0
+ARG PYTHON_VERSION=3.7
+
+# install our python dependencies (manually here, as version for 3.7 are behind
+# our requirements files that are based on 3.8, and rocm/pytorch is working
+# with 3.7 still
+
+RUN pip3 install \
+     numpy==1.21.6 \
+     nibabel==4.0.2 \
+     torchio==0.18.84 \
+     pandas==1.3.5 \
+     h5py==3.7.0 \
+     yacs==0.1.8
+     
+
+# Copy FastSurferCNN 
+COPY ./FastSurferCNN /FastSurferCNN/
+
+# Download all remote network checkpoints already
+RUN cd /FastSurferCNN/ ; python3 download_checkpoints.py --all --vinn
+
+# Set FastSurferCNN workdir and entrypoint
+#  the script entrypoint ensures that our conda env is active
+WORKDIR "/FastSurferCNN"
+ENTRYPOINT ["python3.7", "run_prediction.py"]
+CMD ["--help"]

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -147,3 +147,31 @@ docker run -v /home/user/my_mri_data:/data \
 * Note, that the paths following --fs_license, --t1, and --sd are inside the container, not global paths on your system, so they should point to the places where you mapped these paths above with the -v arguments. 
 
 All other flags are identical to the ones explained on the main page [README](../README.md).
+
+
+### Example 6: Experimental build for AMD GPUs
+
+Here we build an experimental image to test performance when running on AMD GPUs. Note that you need a supported OS and Kernel version and supported GPU for the RocM to work correctly. You need to install the Kernel drivers into 
+your host machine kernel (amdgpu-install --usecase=dkms) for the amd docker to work. For this follow:
+https://docs.amd.com/bundle/ROCm-Installation-Guide-v5.2.3/page/Introduction_to_AMD_ROCm_Installation_Guide_for_Linux.html
+
+
+```bash
+cd ..
+docker build --rm=true -t fastsurfercnn:amd -f ./Docker/Dockerfile_FastSurferCNN_AMD .
+```
+
+and run segmentation only:
+
+```bash
+docker run --rm --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+           --device=/dev/kfd --device=/dev/dri --group-add video --ipc=host \
+	   --shm-size 8G \
+	   -v /home/user/my_mri_data:/data \
+	   -v /home/user/my_fastsurfer_analysis:/output \
+	   fastsurfercnn:amd \
+	   --orig_name /data/subject2/orig.mgz \
+	   --pred_name /output/subject2/aparc.DKTatlas+aseg.deep.mgz
+```
+
+Note, we tested on an AMD Radeon Pro W6600, which is not officially supported, but setting HSA_OVERRIDE_GFX_VERSION=10.3.0 inside docker did the trick.


### PR DESCRIPTION
This PR adds a Dockerfile to experiment with running FastSurfer on an AMD GPU. This will not be supported or thoroughly tested but it looks like it is working on my Radeon Pro W6600.  