### PR TITLE
Fix: Inference script logging

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -293,6 +293,8 @@ if __name__ == "__main__":
                         help="Name under which the conformed input image will be saved, in the same directory as the segmentation "
                              "(the input image is always conformed first, if it is not already conformed). "
                              "The original input image is saved in the output directory as $id/mri/orig/001.mgz. Default: mri/orig.mgz.")
+    parser.add_argument('--log_name', type=str, dest='log_name', default="",
+                        help="Absolute path to file in which run logs will be saved. If not set, logs will not be saved.")
     parser.add_argument("--out_dir", type=str, default=None,
                         help="Directory in which evaluation results should be written. "
                              "Will be created if it does not exist. Optional if full path is defined for --pred_name.")
@@ -349,8 +351,7 @@ if __name__ == "__main__":
 
     # Set up logging
     from utils.logging import setup_logging
-    cfg = args2cfg(args)[0]
-    setup_logging(cfg.OUT_LOG_DIR, cfg.OUT_LOG_NAME)
+    setup_logging(args.log_name)
 
     # Download checkpoints if they do not exist
     # see utils/checkpoint.py for default paths

--- a/FastSurferCNN/utils/logging.py
+++ b/FastSurferCNN/utils/logging.py
@@ -14,28 +14,29 @@
 # limitations under the License.
 
 # IMPORTS
+import os
+
 from logging import *
-from typing import Union as _Union
 from sys import stdout as _stdout
-from pathlib import Path as _Path
-from os import makedirs as _makedirs
-from os.path import join as _join
 
 
-def setup_logging(output_dir: _Union[str, _Path], expr_num: str):
+def setup_logging(log_file_path: str):
     """
     Sets up the logging
     """
     # Set up logging format.
     _FORMAT = "[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s"
-    log_folder = _join(output_dir, "logs")
-    _makedirs(log_folder, exist_ok=True)
-    log_file = _join(log_folder, f"expr_{expr_num}.log")
+    handlers = [StreamHandler(_stdout)]
 
-    fh = FileHandler(filename=log_file, mode='a')
-    ch = StreamHandler(_stdout)
+    if log_file_path:
+        log_dir_path = os.path.dirname(log_file_path)
+        log_file_name = os.path.basename(log_file_path)
+        if not os.path.exists(log_dir_path):
+            os.makedirs(log_dir_path)
 
-    basicConfig(level=INFO, format=_FORMAT, handlers=[fh, ch])
+        handlers.append(FileHandler(filename=log_file_path, mode='a'))
+
+    basicConfig(level=INFO, format=_FORMAT, handlers=handlers)
 
 # At this point, this is just an alias for compatibility’s sake
 get_logger = getLogger

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -448,9 +448,9 @@ if [ "$surf_only" == "0" ]; then
   echo "" |& tee -a $seg_log
 
   pushd $fastsurfercnndir
-  cmd="$python run_prediction.py --orig_name $t1 --pred_name $seg --conf_name $conformed_name $hires --ckpt_sag $weights_sag --ckpt_ax $weights_ax --ckpt_cor $weights_cor --batch_size $batch_size --cfg_cor $config_cor --cfg_ax $config_ax --cfg_sag $config_sag --run_viewagg_on $viewagg --device $device"
+  cmd="$python run_prediction.py --orig_name $t1 --pred_name $seg --conf_name $conformed_name --log_name $seg_log $hires --ckpt_sag $weights_sag --ckpt_ax $weights_ax --ckpt_cor $weights_cor --batch_size $batch_size --cfg_cor $config_cor --cfg_ax $config_ax --cfg_sag $config_sag --run_viewagg_on $viewagg --device $device"
   echo $cmd |& tee -a $seg_log
-  $cmd |& tee -a $seg_log
+  $cmd
   if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   popd
 fi

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -443,7 +443,7 @@ if [ "$surf_only" == "0" ]; then
   # "============= Running FastSurferCNN (Creating Segmentation aparc.DKTatlas.aseg.mgz) ==============="
   # use FastSurferCNN to create cortical parcellation + anatomical segmentation into 95 classes.
   mkdir -p "$(dirname "$seg_log")"
-  echo "Log file for fastsurfercnn eval.py" > $seg_log
+  echo "Log file for fastsurfercnn run_prediction.py" > $seg_log
   date  |& tee -a $seg_log
   echo "" |& tee -a $seg_log
 


### PR DESCRIPTION
## Description

In the current `feature/vinn` implementation, `run_prediction.py` (inference) logs are saved in `./FastSurferVINN/logs/expr_fastsurfer.log`. The main directory (`FastSurferVINN`) only can be changed by modifying the `LOG_DIR` variable in the model config files (such as [this one](https://github.com/Deep-MI/FastSurfer/blob/feature/vinn/FastSurferCNN/config/FastSurferVINN_axial.yaml)) or setting the `out_dir` argument. If FastSurfer is run multiple times with the same config, the same file is appended to.
In addition, a separate log file is already saved within `run_fastsurfer.sh` under `$SUBJECT_DIR/scripts/deep-seg.log`.

Following some discussions with @m-reuter, we decided it would be better to log to one file  within `run_prediction.py`, whose path should be specified through an argument: `log_name`. If not provided, the logs will not be written to a file; this will be the default behaviour.
In the call to `run_prediction.py` in `run_fastsurfer.sh`, this argument will be set to `$SUBJECT_DIR/scripts/deep-seg.log`.
One advantage of writing the logs within the python script instead of dumping the output of its command within the shell script (`run_fastsurfer.sh`) is that the tqdm output is skipped. In the latter case, the output is included but is not formatted properly (see example below in screenshot below).

## Changes
This PR applies these changes, which involve the following:
* In `logging.py`: Modifying the `setup_logging` function to accept a single argument: `log_file_path`. If an empty string is provided, logging messages are only printed on screen and not saved to a file. **The `LOG_DIR` variable is not used in this function anymore.**
* In `run_prediction.py`: implementing the optional arg `log_name` and adapting the `setup_logging` call.
* In `run_fastsurfer`: adding `log_name` arg to the `run_prediction.py` call and removing the piping of its output to the log file.

Note: 
* If multiple subjects are processed using `run_prediction.py` in a single, all logs are saved to the same file (if specified).
* If the specified `log_name` file exists, it is overwritten.
--------

## Extra
#### `tqdm` output in `deep-seg.log` when written from `run_fastsurfer.sh`
![Screenshot from 2022-09-22 15-24-17](https://user-images.githubusercontent.com/37597383/191761273-e2e07774-864a-48fa-8a8c-8de6c1c40764.png)
