### PR TITLE
Fix: Potential buffer overflow errors

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -398,6 +398,14 @@ then
   fsthreads="-threads $threads -itkthreads $threads"
 fi
 
+if [ $(echo -n "${SUBJECTS_DIR}/${subject}" | wc -m) -gt 185 ]
+then
+  echo "ERROR: subject directory path is very long."
+  echo "This is known to cause errors due to some commands run by freesurfer versions built for Ubuntu."
+  echo "--sd + --sid should be less than 185 characters long."
+  exit 1
+fi
+
 
 # collect info
 StartTime=`date`;


### PR DESCRIPTION
## Description

We observed buffer overflow errors due to certain freesurfer commands that are executed in `recon-surf` (`mri_label2vol` and `mris_anatomical_stats`) when subject directory paths are too long.
This particulary occurs when a freesurfer version built for Ubuntu is run on a Centos machine, but may happen in other cases.

The following is an example of the error message (from `recon-surf.log`):
```
mri_label2vol --defects $SUBJECTS_DIR/$SUBJECT_ID/surf/lh.defect_labels \
    $SUBJECTS_DIR/$SUBJECT_ID/mri/orig.mgz 1000 0 \
    $SUBJECTS_DIR/$SUBJECT_ID/mri/lh.surface.defects.mgz
*** buffer overflow detected ***: terminated
Abort (core dumped)
```
This was the case when `$SUBJECTS_DIR/$SUBJECT_ID` was at least 192 characters long.

## Solution

This PR adds a check in `recon-surf.sh` for the length of `$SUBJECTS_DIR/$SUBJECT_ID`, then raises an error and exits if it exceeds 185 characters.