### PR TITLE
Fix: Prevent running on existing directories

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -406,6 +406,13 @@ then
   exit 1
 fi
 
+# Check if running on an existing subject directory
+if [ -f "$SUBJECTS_DIR/$subject/mri/wm.mgz" ] || [ -f "$SUBJECTS_DIR/$subject/mri/aparc.DKTatlas+aseg.orig.mgz" ]; then
+  echo "ERROR: running on top of an existing subject directory!"
+  echo "The output directory must not contain data from a previous invocation of recon-surf."
+  exit 1
+fi
+
 
 # collect info
 StartTime=`date`;


### PR DESCRIPTION
## Description

Running `recon-surf` on existing subject directories can have unintended consequences, especially if the same subject is processed with different streams/models (for e.g. FastSurferCNN and high-res FastSurferVINN), since some files carry over and are not overwritten upon a second invocation.
This was observed in the mentioned case particularly with `wm.mgz`.

## Solution

To prevent such incidents, the change in this PR ensures that an error is raised if `recon-surf.sh` is run on an existing subject directory. At the moment, this is determined through the existence of the two files: `$SUBJECTS_DIR/$subject/mri/wm.mgz` and `$SUBJECTS_DIR/$subject/mri/aparc.DKTatlas+aseg.orig.mgz`.
This condition may be modified/refined.

The user is responsible for making sure that the specified output directory does not already contain old `recon-surf` data.