### PR TITLE
Feature/qc

### DIFF
--- a/recon_surf/quick_qc.py
+++ b/recon_surf/quick_qc.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# IMPORTS
+import optparse
+import sys
+import numpy as np
+import nibabel as nib
+
+
+HELPTEXT = """
+Script to perform quick qualtiy checks for the input segmentation to identify gross errors.
+
+USAGE:
+quick_qc.py --seg <aparc+aseg.mgz>
+
+
+"""
+
+def options_parse():
+    """
+    Command line option parser
+    """
+    parser = optparse.OptionParser(version='$Id: quick_qc,v 1.0 2022/09/28 11:34:08 mreuter Exp $', usage=HELPTEXT)
+    parser.add_option('--seg',  dest='seg', help="Input aparc+aseg segmentation to be checked")
+
+    (options, args) = parser.parse_args()
+
+    if options.seg is None:
+        sys.exit('ERROR: Please specify input segmentation --seg <filename>')
+
+    return options
+
+
+def check_volume(seg, voxvol, thres=0.6):
+    print("Checking total volume ...")
+    mask = (seg > 0)
+    total_vol = np.sum(mask) * voxvol / 1000000
+    print("Voxel size in mm3: {}".format(voxvol))
+    print("Total segmentation volume in liter: {}".format(np.round(total_vol,2)))
+    if (total_vol < thres):
+    	sys.exit('ERROR: Total segmentation volume is too small. Segmentation may be corrupted.')
+    return
+
+
+if __name__ == "__main__":
+    # Command Line options are error checking done here
+    options = options_parse()
+    print("Reading in aparc+aseg: {} ...".format(options.seg))
+    inseg = nib.load(options.seg)
+    inseg_data = np.asanyarray(inseg.dataobj)
+    inseg_header = inseg.header
+    inseg_voxvol = np.product(inseg_header["delta"])
+
+    check_volume(inseg_data, inseg_voxvol)
+    
+    sys.exit(0)


### PR DESCRIPTION
This PR adds:

- a quick_qc.py script for recon-surf.sh to quickly check if the incoming segmentation is severely broken. It checks if the total segmentation volume is less than half of its usual size. A more precise threshold can be set later, once we know better the distribution of correct seg volumes.
- time does not work on a mac, in that case we just skip the timing 
- added a check for the right bash version (> 4.0) which usually is much older on a mac and lead to issues #7 and #24 . Some of those issues could be solved by installing the newer bash and running `bash run_fastsrufer.sh ...` or `bash recon-surf ...`
- fixed binpath if $FASTSURFER_HOME is not set (setting it to ./ did not work, as we are changing directories later in the pipeline). Now it finds the global path of the recon_surf.sh script and uses that directory. 