### PR TITLE
Define global ckptdir in checkpoint.py and import from there in run_p…

### DIFF
--- a/Docker/Dockerfile_FastSurferCNN
+++ b/Docker/Dockerfile_FastSurferCNN
@@ -63,13 +63,12 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Copy venv and FastSurferCNN 
 COPY --from=build /venv /venv
 COPY ./FastSurferCNN /fastsurfer/FastSurferCNN/
-COPY ./recon_surf/reduce_to_aseg.py /fastsurfer/recon_surf/reduce_to_aseg.py
 COPY ./checkpoints /fastsurfer/FastSurferCNN/checkpoints/
 COPY ./Docker/entrypoint.sh /fastsurfer/Docker/entrypoint.sh
 
 # Download all remote network checkpoints already
 ENV PYTHONPATH=/fastsurfer:$PYTHONPATH
-RUN cd /fastsurfer ; python3 FastSurferCNN/download_checkpoints.py --all; chmod +r -R checkpoints
+RUN python3 /fastsurfer/FastSurferCNN/download_checkpoints.py --all; chmod +r -R /fastsurfer/FastSurferCNN/checkpoints
 
 # Set FastSurferCNN workdir and entrypoint
 #  the script entrypoint ensures that our conda env is active

--- a/FastSurferCNN/download_checkpoints.py
+++ b/FastSurferCNN/download_checkpoints.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-import os
 
 from FastSurferCNN.utils.checkpoint import check_and_download_ckpts, get_checkpoints, VINN_AXI, VINN_COR, VINN_SAG, URL
 
@@ -26,9 +25,9 @@ if __name__ == "__main__":
                         help="Check and download all default checkpoints")
     parser.add_argument("--vinn", default=False, action="store_true",
                         help="Check and download VINN default checkpoints")
-    parser.add_argument("--url", type=str, default=URL, 
+    parser.add_argument("--url", type=str, default=URL,
                         help="Specify you own base URL. Default: {}".format(URL))
-    parser.add_argument('files', nargs='*', 
+    parser.add_argument('files', nargs='*',
                         help="Checkpoint file paths to download, e.g. checkpoints/aparc_vinn_axial_v2.0.0.pkl ...")
     args = parser.parse_args()
 
@@ -40,13 +39,8 @@ if __name__ == "__main__":
         print("Specify either files to download or --vinn, see help -h.")
         exit(1)
 
-    # use default location in ../checkpoints/...
-    axi = os.path.join(os.path.dirname(__file__), VINN_AXI)
-    cor = os.path.join(os.path.dirname(__file__), VINN_COR)
-    sag = os.path.join(os.path.dirname(__file__), VINN_SAG)
-
     if args.vinn or args.all:
-        get_checkpoints(axi, cor, sag, args.url)
+        get_checkpoints(VINN_AXI, VINN_COR, VINN_SAG, args.url)
 
     # later we can add more defaults here (for other sub-segmentation networks, or old CNN)
 

--- a/FastSurferCNN/utils/checkpoint.py
+++ b/FastSurferCNN/utils/checkpoint.py
@@ -26,9 +26,9 @@ LOGGER = logging.getLogger(__name__)
 
 # Defaults
 URL = "https://b2share.fz-juelich.de/api/files/a423a576-220d-47b0-9e0c-b5b32d45fc59"
-VINN_AXI = "checkpoints/aparc_vinn_axial_v2.0.0.pkl"
-VINN_COR = "checkpoints/aparc_vinn_coronal_v2.0.0.pkl"
-VINN_SAG = "checkpoints/aparc_vinn_sagittal_v2.0.0.pkl"
+VINN_AXI = os.path.join(os.path.dirname(os.path.dirname(__file__)), "checkpoints/aparc_vinn_axial_v2.0.0.pkl")
+VINN_COR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "checkpoints/aparc_vinn_coronal_v2.0.0.pkl")
+VINN_SAG = os.path.join(os.path.dirname(os.path.dirname(__file__)), "checkpoints/aparc_vinn_sagittal_v2.0.0.pkl")
 
 
 def create_checkpoint_dir(expr_dir, expr_num):
@@ -175,4 +175,3 @@ def get_checkpoints(axi, cor, sag, url=URL):
     check_and_download_ckpts(axi, url)
     check_and_download_ckpts(cor, url)
     check_and_download_ckpts(sag, url)
-


### PR DESCRIPTION
…rediction.py and download_checkpoints.py to avoid mismatch and double download. Also fixed Dockerfile for FastSurferCNN only.

Previously, download_checkpoints.py and run_prediction.py would download the checkpoints into different directories! By default, the FastSurferCNN subdirectory would be the parent dir for download_checkpoints.py while the current working dir would be the parent dir for run_prediction.py. 

To avoid this confusion:
- checkpoints are now always downloaded into FastSurferCNN/checkpoints by default
- path is completely defined via global variables AXI, SAG, COR in checkpoints.py
- Issues with duplicate download when running run_prediction.py with the FastSurferCNN seg-only docker are avoided this way