### PR TITLE
Fix: Include mask creation in `recon-surf`

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -545,6 +545,18 @@ cmd="ln -sf orig.mgz rawavg.mgz"
 RunIt "$cmd" $LF
 popd
 
+if [ ! -f "$mask" ] || [ ! -f "$mdir/aseg.auto_noCCseg.mgz" ] ; then
+  # Mask or aseg.auto_noCCseg not found; create them
+  echo " " |& tee -a $LF
+  echo "============= Creating aseg.auto_noCCseg (map aparc labels back) ===============" |& tee -a $LF
+  echo " " |& tee -a $LF
+
+  # reduce labels to aseg, then create mask (dilate 5, erode 4, largest component), also mask aseg to remove outliers
+  # output will be uchar (else mri_cc will fail below)
+  cmd="$python ${binpath}/../FastSurferCNN/reduce_to_aseg.py -i $mdir/aparc.DKTatlas+aseg.orig.mgz -o $mdir/aseg.auto_noCCseg.mgz --outmask $mask --fixwm"
+  RunIt "$cmd" $LF
+fi
+
 echo " " |& tee -a $LF
 echo "============= Computing Talairach Transform and NU (bias corrected) ============" |& tee -a $LF
 echo " " |& tee -a $LF


### PR DESCRIPTION
## Description

This PR restores the call to `reduce_to_aseg.py` (recently moved to the segmentation stage) in `recon_surf.sh` to handle the case when the surface pipeline is run without the segmentation, and thus the `mask.mgz` and `aseg.auto_noCCseg.mgz` are not created.

This step is run only if either file is not already present in the output directory.