### PR TITLE
Fix: `recon_surf` voxel size argument

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -296,6 +296,8 @@ case $key in
     if [ "$2" == "auto" ]; then
       hiresflag="-hires"
     elif [ "$2" == "1" ]; then
+      hiresflag=""
+    else
       exit "Invalid option for --vox_size, only 1 or 'auto' are valid."
     fi
     vox_size=$2


### PR DESCRIPTION
## Decsription

Fixes a bug in the `vox_size` argument in `recon-surf.sh`, where the supposedly admissible value, 1, was erroneously flagged as an invalid option.

Previously, setting the argument to 1 (integer or string), leads to the error:

```
./recon_surf/recon-surf.sh: line 297: exit: Invalid option for --vox_size, only 1 or 'auto' are valid.: numeric argument required
```

