### PR TITLE
Feature/set t1 to default if empty

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -288,7 +288,7 @@ case $key in
     ;;
     --hires)
     echo "WARNING: --hires is deprecated, use --vox_size auto."
-    vox_size=1
+    vox_size="auto"
     hiresflag="-hires"
     shift # past argument
     ;;
@@ -545,7 +545,7 @@ cmin=""
 if  [ "$vox_size" == "auto" ]
 then
   cmin="--conform_min"
-  hiresflag="--hires"
+  hiresflag="-hires"
 fi
 cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only $cmin --verbose"
 RunIt "$cmd" $LF

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -545,6 +545,7 @@ cmin=""
 if  [ "$vox_size" == "auto" ]
 then
   cmin="--conform_min"
+  hiresflag="--hires"
 fi
 cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only $cmin --verbose"
 RunIt "$cmd" $LF

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -372,10 +372,10 @@ fi
 
 
 # CHECKS
-if [ -z "$t1" ] || [ ! -f "$t1" ]
+if [ "$run_seg_pipeline" == "1" ] && { [ -z "$t1" ] || [ ! -f "$t1" ]; }
   then
-    echo "ERROR: T1 image ($t1) could not be found. Must supply an existing T1 input (conformed, full head) via --t1 (absolute path and name)."
-    # needed to create orig.mgz and to get file name. This will eventually be changed.
+    echo "ERROR: T1 image ($t1) could not be found. Must supply an existing T1 input (full head) via "
+    echo "--t1 (absolute path and name) for generating the segmentation."
     exit 1;
 fi
 


### PR DESCRIPTION
Change behaviour of run_fastsurfer.sh
- t1 does not need to be defined when running the surface pipeline only. In this case a conformed image should/can already exist from running the segmentation pipeline. Check if this exists, is already done
- call for seg-only simplifies to defining --sd and --sid when segmentation was already generated with default arguments for --conformed_name and --aparc_aseg_segfile

Fix error in recon-surf.sh
- hires flag was not turned on, when recon-surf was called directly without any argument to --vox_size. Hires flag is now turned on when --vox_size is set to auto, independent if this was explicitly passed as a flag or not (vox_size is set to auto by default).