### PR TITLE
 Voxel size passing and hires pipeline selection changes to allow consistent processing

### DIFF
--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -53,8 +53,9 @@ def load_and_conform_image(img_filename, interpol=1, logger=LOGGER, conform_min 
     :return: nibabel.MGHImage orig: conformed image
     """
     orig = nib.load(img_filename)
-
-    if not is_conform(orig, conform_min=conform_min):
+    # is_conform and conform accept numeric values and the string 'min' instead of the bool value
+    _conform_vox_size = 'min' if conform_min else 1.
+    if not is_conform(orig, conform_vox_size=_conform_vox_size):
 
         logger.info('Conforming image to UCHAR, RAS orientation, and minimum isotropic voxels')
 
@@ -67,7 +68,7 @@ def load_and_conform_image(img_filename, interpol=1, logger=LOGGER, conform_min 
                 sys.exit("ERROR: inconsistency in nifti-header. Exiting now.\n")
 
         # conform
-        orig = conform(orig, interpol, conform_min=conform_min)
+        orig = conform(orig, interpol, conform_vox_size=_conform_vox_size)
 
     # Collect header and affine information
     header_info = orig.header

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -85,7 +85,7 @@ class RunModelOnData:
     current_plane: str
     models: Dict[str, Inference]
     view_ops: Dict[str, Dict[str, Any]]
-    conform_to_1_threshold: Optional[float]
+    conform_to_1mm_threshold: Optional[float]
 
     def __init__(self, args):
         self.pred_name = args.pred_name
@@ -146,7 +146,7 @@ class RunModelOnData:
             self.vox_size = float(vox_size)
         else:
             raise ValueError(f"Invalid value for vox_size, must be between 0 and 1 or 'min', was {vox_size}.")
-        self.conform_to_1_threshold = args.conform_to_1_threshold
+        self.conform_to_1mm_threshold = args.conform_to_1mm_threshold
 
     def set_and_create_outdir(self, out_dir: str) -> str:
         if os.path.isabs(self.pred_name):
@@ -172,9 +172,10 @@ class RunModelOnData:
         self.save_img(self.input_img_name, orig_data, orig)
 
         if not conf.is_conform(orig, conform_vox_size=self.vox_size, check_dtype=True, verbose=False,
-                               conform_to_1_threshold=self.conform_to_1_threshold):
+                               conform_to_1mm_threshold=self.conform_to_1mm_threshold):
             LOGGER.info("Conforming image")
-            orig = conf.conform(orig, conform_vox_size=self.vox_size, conform_to_1_threshold=self.conform_to_1_threshold)
+            orig = conf.conform(orig,
+                                conform_vox_size=self.vox_size, conform_to_1mm_threshold=self.conform_to_1mm_threshold)
             orig_data = np.asanyarray(orig.dataobj)
 
         # Save conformed input image
@@ -293,7 +294,7 @@ if __name__ == "__main__":
                                               "sagittal": "FastSurferCNN/config/FastSurferVINN_sagittal.yaml"})
 
     # 5. technical parameters
-    parser = parser_defaults.add_arguments(parser, ["vox_size", "conform_to_1_threshold", "device", "viewagg_device",
+    parser = parser_defaults.add_arguments(parser, ["vox_size", "conform_to_1mm_threshold", "device", "viewagg_device",
                                                     "batch_size", "allow_root"])
 
     args = parser.parse_args()

--- a/FastSurferCNN/utils/arg_types.py
+++ b/FastSurferCNN/utils/arg_types.py
@@ -32,8 +32,8 @@ def vox_size(a: str) -> VoxSizeOption:
         raise argparse.ArgumentError(f"'{a}' is not 'min' or a float between 0 and 1 (vox_size).")
 
 
-def conform_to_one(a: str) -> Optional[float]:
-    """Helper function to convert conform_to_1 thresholds to numbers."""
+def conform_to_one_mm(a: str) -> Optional[float]:
+    """Helper function to convert conform_to_1mm thresholds to numbers."""
     if a is None or a.lower() in ["none", "infinity"]:
         return None
     a_float = float(a)

--- a/FastSurferCNN/utils/arg_types.py
+++ b/FastSurferCNN/utils/arg_types.py
@@ -1,0 +1,60 @@
+# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import Union, Literal, Optional
+
+import nibabel as nib
+import numpy as np
+
+VoxSizeOption = Union[float, Literal["min"]]
+
+
+def vox_size(a: str) -> VoxSizeOption:
+    """Helper function to convert the vox_size argument to 'min' or a valid voxel size."""
+    if a.lower() in ["auto", "min"]:
+        return "min"
+    a_float = float(a)
+    if 0. < a_float <= 1.0:
+        return a_float
+    else:
+        raise argparse.ArgumentError(f"'{a}' is not 'min' or a float between 0 and 1 (vox_size).")
+
+
+def conform_to_one(a: str) -> Optional[float]:
+    """Helper function to convert conform_to_1 thresholds to numbers."""
+    if a is None or a.lower() in ["none", "infinity"]:
+        return None
+    a_float = float(a)
+    if 0. < a_float <= 1.0:
+        return a_float
+    else:
+        raise argparse.ArgumentError(f"'{a}' is not between 0 and 1.")
+
+
+def target_dtype(a: str) -> str:
+    """Helper function to check for valid dtypes."""
+    dtypes = nib.freesurfer.mghformat.data_type_codes.value_set('label')
+    dtypes.add("any")
+    _a = a.lower()
+    if _a in dtypes:
+        return _a
+    msg = "The following dtypes are verified: " + ", ".join(dtypes)
+    if np.dtype(_a).name == _a:
+        # numpy recognizes the dtype, but nibabel probably does not.
+        print(f"WARNING: While numpy recognizes the dtype {a}, nibabel might not and this might lead to compatibility "
+              f"issues. {msg}")
+        return _a
+    else:
+        raise argparse.ArgumentError(f"Invalid dtype {a}. {msg}")

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -2,7 +2,7 @@ from typing import Iterable, Mapping, Union, Literal
 import argparse
 from os import path
 
-from FastSurferCNN.utils.arg_types import vox_size as __vox_size, conform_to_one as __conform_to_one
+from FastSurferCNN.utils.arg_types import vox_size as __vox_size, conform_to_one_mm as __conform_to_one_mm
 
 FASTSURFER_ROOT = path.dirname(path.dirname(path.dirname(__file__)))
 PLANE_SHORT = {"checkpoint": "ckpt", "config": "cfg"}
@@ -95,8 +95,8 @@ ALL_FLAGS = {
              "experimental) or 'min' (default). A number forces processing at that specific voxel size, 'min' "
              "determines the voxel size from the image itself (conforming to the minimum voxel size, or 1 if "
              "the minimum voxel size is above 0.95mm). "),
-    "conform_to_1_threshold": __arg(
-        '--conform_to_1_threshold', type=__conform_to_one, default=0.95, dest="conform_to_1_threshold",
+    "conform_to_1mm_threshold": __arg(
+        '--conform_to_1mm_threshold', type=__conform_to_one_mm, default=0.95, dest="conform_to_1mm_threshold",
         help="The voxelsize threshold, above which images will be conformed to 1mm isotropic, if the --vox_size "
              "argument is also 'min' (the --vox_size default setting). Contrary to conform.py, the default behavior"
              "of %(prog)s is to resample all images _above 0.95mm_ to 1mm."),

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -30,13 +30,12 @@ fssurfreg=0           # run FS surface registration to fsaverage, if 0 omit this
 python="python3.8"    # python version
 DoParallel=0          # if 1, run hemispheres in parallel
 threads="1"           # number of threads to use for running FastSurfer
-vox_size="auto"       # hires processing
-hiresflag=""          # flag for recon-all calls for hires (default empty)
 allow_root=""         # flag for allowing execution as root user
 
 # Dev flags default
 check_version=1;    # Check for supported FreeSurfer version (terminate if not detected)
 get_t1=1;           # Generate T1.mgz from nu.mgz and brainmask from it (default)
+hires_voxsize_threshold=0.999  # Threshold below which the hires options are passed.
 
 if [ -z "$FASTSURFER_HOME" ]
 then
@@ -105,9 +104,6 @@ FLAGS:
                             is faster, and usually these mapped ones are fine)
   --surfreg               Run Surface registration with FreeSurfer (for
                             cross-subject correspondence)
-  --vox_size auto|1       Run FastSurfer recon-surf stream for 1mm (1) or in the
-                            hires stream (auto) at the voxel size conformed to
-                            the minimum voxel edge.
   --parallel              Run both hemispheres in parallel
   --threads <int>         Set openMP and ITK threads to <int>
   --py <python_cmd>       Command for python, default $python
@@ -286,24 +282,6 @@ case $key in
     fssurfreg=1
     shift # past argument
     ;;
-    --hires)
-    echo "WARNING: --hires is deprecated, use --vox_size auto."
-    vox_size="auto"
-    hiresflag="-hires"
-    shift # past argument
-    ;;
-    --vox_size)
-    if [ "$2" == "auto" ]; then
-      hiresflag="-hires"
-    elif [ "$2" == "1" ]; then
-      hiresflag=""
-    else
-      exit "Invalid option for --vox_size, only 1 or 'auto' are valid."
-    fi
-    vox_size=$2
-    shift # past argument
-    shift # past value
-    ;;
     --parallel)
     DoParallel=1
     shift # past argument
@@ -442,7 +420,7 @@ then
 fi
 
 # set threads for openMP and itk
-# if OMP_NUM_THREADS is not set and available ressources are too vast, mc will fail with segmentation fault!
+# if OMP_NUM_THREADS is not set and available resources are too vast, mc will fail with segmentation fault!
 # Therefore we set it to 1 as default above, if nothing is specified.
 fsthreads=""
 export OMP_NUM_THREADS=$threads
@@ -540,18 +518,31 @@ echo " " |& tee -a $LF
 echo "================== Creating orig and rawavg from input =========================" |& tee -a $LF
 echo " " |& tee -a $LF
 
+CONFORM_LF=$SUBJECTS_DIR/$subject/scripts/conform.log
+if [ $CONFORM_LF != /dev/null ] ; then  rm -f $CONFORM_LF ; fi
+echo "Log file for Conform test" > $CONFORM_LF
+
 # check for input conformance
-cmin=""
-if  [ "$vox_size" == "auto" ]
-then
-  cmin="--conform_min"
-  hiresflag="-hires"
-fi
-cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only $cmin --verbose"
+cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $t1 --check_only --vox_size min --verbose"
+RunIt "$cmd" "$LF -a $CONFORM_LF"
+
+# look into the CONFORM_LF to find the voxel sizes, the second conform.py call will check the legality of vox_size
+vox_size=`cat $CONFORM_LF | grep -E " - Voxel Size " | cut -d' ' -f5 | cut -d'x' -f1`
+# remove the temporary conform_log (all info is also in the recon-surf logfile)
+if [ -f "$CONFORM_LF" ]; then rm -f $CONFORM_LF ; fi
+
+# here, we check the correct vox_size by passing it to the next conform, so errors in this line might be caused above
+cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $aparc_aseg_segfile --check_only --vox_size $vox_size --dtype any --verbose"
 RunIt "$cmd" $LF
 
-cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $aparc_aseg_segfile --check_only $cmin --seg_input --verbose"
-RunIt "$cmd" $LF
+if [ "$vox_size" -lt "$hires_voxsize_threshold" ]
+then
+  echo "The voxel size $vox_size is less than $hires_voxsize_threshold, so we are proceeding with hires options." |& tee -a $LF
+  hiresflag="-hires"
+else
+  echo "The voxel size $vox_size is not less than $hires_voxsize_threshold, so we are proceeding with standard options." |& tee -a $LF
+  hiresflag=""
+fi
 
 # create orig.mgz and aparc.DKTatlas+aseg.orig.mgz (copy of segmentation)
 cmd="mri_convert $t1 $mdir/orig.mgz"
@@ -641,7 +632,7 @@ if [ "$get_t1" == "1" ]
 then
   # create T1.mgz from nu (!! here we could also try passing aseg?)
   cmd="mri_normalize -g 1 -seed 1234 -mprage $mdir/nu.mgz $mdir/T1.mgz"
-  if [ "$vox_size" == "auto" ]
+  if [ "$vox_size" -lt "$hires_voxsize_threshold" ]
   then
     cmd="$cmd -noconform"
   fi
@@ -732,7 +723,7 @@ else
 
     # Marching cube does not return filename and wrong volume info!
     outmesh=$sdir/$hemi.orig.nofix
-    if [ "$vox_size" == "auto" ]; then
+    if [ "$vox_size" -lt "$hires_voxsize_threshold" ]; then
       outmesh=$sdir/$hemi.orig.nofix.predec
     fi
     cmd="mri_mc $mdir/filled-pretess$hemivalue.mgz $hemivalue $outmesh"
@@ -753,7 +744,7 @@ else
     RunIt "$cmd" $LF $CMDF
     
     # for hires decimate mesh 
-    if [ "$vox_size" == "auto" ]; then
+    if [ "$vox_size" -lt "$hires_voxsize_threshold" ]; then
       DecimationFaceArea="0.5"
       # Reduce the number of faces such that the average face area is
       # DecimationFaceArea.  If the average face area is already more

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -44,7 +44,7 @@ fstess=""
 fsqsphere=""
 fsaparc=""
 fssurfreg=""
-vox_size="auto"
+vox_size="min"
 doParallel=""
 run_aparc_module="1"
 threads="1"
@@ -75,13 +75,22 @@ FLAGS:
   --sid <subjectID>       Subject ID to create directory inside \$SUBJECTS_DIR
   --sd  <subjects_dir>    Output directory \$SUBJECTS_DIR (or pass via env var)
   --t1  <T1_input>        T1 full head input (not bias corrected)
-  --vox_size 1|auto       Force processing at a specific voxel size. Only "auto"
-                            and "1" are supported values. If "1" is specified,
-                            the T1w image will be conformed to 1mm voxel size
-                            and processed, if "auto" is specified (default),
-                            the T1w image will be conformed isometric voxels
-                            of the smallest voxel edge in the image for highres
-                            processing.
+  --vox_size <0.7-1|min>  Forces processing at a specific voxel size.
+                            If a number between 0.7 and 1 is specified (below
+                            is experimental) the T1w image is conformed to
+                            that voxel size and processed.
+                            If "min" is specified (default), the voxel size is
+                            read from the size of the minimal voxel size
+                            (smallest per-direction voxel size) in the T1w
+                            image:
+                              If the minimal voxel size is bigger than 0.98mm,
+                                the image is conformed to 1mm isometric.
+                              If the minimal voxel size is smaller or equal to
+                                0.98mm, the T1w image will be conformed to
+                                isometric voxels of that voxel size.
+                            The voxel size (whether set manually or derived)
+                            determines whether the surfaces are processed with
+                            highres options (below 1mm) or not.
   -h --help               Print Help
 
   PIPELINES:
@@ -418,6 +427,23 @@ else
   export PYTHONPATH="$FASTSURFER_HOME:$PYTHONPATH"
 fi
 
+# check the vox_size setting
+if [[ "$vox_size" =~ "^[01](\.[0-9]*)?$" ]]
+then
+  # a number
+  if [ "$vox_size" -lt "0" ] || [ "$vox_size" -gt "1" ]
+  then
+    exit "ERROR: negative voxel sizes and voxel sizes beyond 1 are not supported."
+  elif [ "$vox_size" -lt "0.7" ]
+  then
+    echo "WARNING: support for voxel sizes smaller than 0.7mm iso. is experimental."
+  fi
+elif [ "$vox_size" != "min" ]
+then
+  # not a number or "min"
+  exit "Invalid option for --vox_size, only a number or 'min' are valid."
+fi
+
 if [ "${aparc_aseg_segfile: -3}" != "${main_segfile: -3}" ]
   then
     # This is because we currently only do a symlink
@@ -472,10 +498,6 @@ if [ "$run_surf_pipeline" == "0" ] && [ ! -z "$vol_segstats" ]
     echo "The stats will be stored as (\$SUBJECTS_DIR/\$SID/stats/aparc.DKTatlas+aseg.deep.volume.stats). "
 fi
 
-if [ "$vox_size" != "auto" ] && [ "$vox_size" != "1" ]
-  then
-    echo "You passed '$vox_size' as the voxel size to conform to, but this is an invalid value. It must be '1' or 'auto'."
-fi
 ########################################## START ########################################################
 
 if [ "$run_seg_pipeline" == "1" ]
@@ -509,7 +531,7 @@ if [ "$run_surf_pipeline" == "1" ]
     # ============= Running recon-surf (surfaces, thickness etc.) ===============
     # use recon-surf to create surface models based on the FastSurferCNN segmentation.
     pushd $reconsurfdir
-    cmd="./recon-surf.sh --sid $subject --sd $sd --t1 $conformed_name --aparc_aseg_segfile $aparc_aseg_segfile $vol_segstats $fstess $fsqsphere $fsaparc $fssurfreg --vox_size $vox_size $doParallel --threads $threads --py $python $vcheck $vfst1 $allow_root"
+    cmd="./recon-surf.sh --sid $subject --sd $sd --t1 $conformed_name --aparc_aseg_segfile $aparc_aseg_segfile $vol_segstats $fstess $fsqsphere $fsaparc $fssurfreg $doParallel --threads $threads --py $python $vcheck $vfst1 $allow_root"
     echo $cmd
     $cmd
     if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi


### PR DESCRIPTION
Interface change to conform.py
- Adds new flag: --conform-size, analogeous to mri_convert --conform_size
Interface change to recon-surf.sh, run_prediction.py and run_fastsurfer.sh.
- Remove --vox_size from recon-surf.sh, vox-size is automatically extracted from the image file
- Add additional options to --vox_size in run_prediction.py and run_fastsurfer.sh:
  Now accepts a voxel size between 0.7 and 1 (which forces that specific voxel size)
  or 'min' (default), which performs conforming to the minimal voxel size (akin to mri_convert --conform_min).
  Note: the naming 'auto' has been removed in favor of 'min'.
  Lower than 0.7 prints a experimental warning.
  Higher than 1 exists with an error.

The function in conform.py have been adapted/extended to allow the passing of the 'target voxel size'.
The conform_min argument was therefore superceeded by a conform_vox_size argument, which can also be 'min'
to get the conform_min behavior.