### PR TITLE
Fix: `vox_size` argument checks

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -142,7 +142,7 @@ class RunModelOnData:
         vox_size = args.vox_size
         if vox_size == "min":
             self.vox_size = "min"
-        elif isinstance(vox_size, str) and vox_size.isnumeric() and (0. < float(vox_size) <= 1.):
+        elif 0. < float(vox_size) <= 1.:
             self.vox_size = float(vox_size)
         else:
             raise ValueError(f"Invalid value for vox_size, must be between 0 and 1 or 'min', was {vox_size}.")

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -537,7 +537,7 @@ if [ -f "$CONFORM_LF" ]; then rm -f $CONFORM_LF ; fi
 cmd="$python ${binpath}../FastSurferCNN/data_loader/conform.py -i $aparc_aseg_segfile --check_only --vox_size $vox_size --dtype any --verbose"
 RunIt "$cmd" $LF
 
-if [ "$vox_size" -lt "$hires_voxsize_threshold" ]
+if (( $(echo "$vox_size < $hires_voxsize_threshold" | bc -l) ))
 then
   echo "The voxel size $vox_size is less than $hires_voxsize_threshold, so we are proceeding with hires options." |& tee -a $LF
   hiresflag="-hires"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -420,10 +420,10 @@ fi
 if [[ "$vox_size" =~ ^[0-9]+([.][0-9]+)?$ ]]
 then
   # a number
-  if [ "$vox_size" -lt "0" ] || [ "$vox_size" -gt "1" ]
+  if (( $(echo "$vox_size < 0" | bc -l) || $(echo "$vox_size > 1" | bc -l) ))
   then
     exit "ERROR: negative voxel sizes and voxel sizes beyond 1 are not supported."
-  elif [ "$vox_size" -lt "0.7" ]
+  elif (( $(echo "$vox_size < 0.7" | bc -l) ))
   then
     echo "WARNING: support for voxel sizes smaller than 0.7mm iso. is experimental."
   fi

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -417,7 +417,7 @@ else
 fi
 
 # check the vox_size setting
-if [[ "$vox_size" =~ "^[01](\.[0-9]*)?$" ]]
+if [[ "$vox_size" =~ ^[0-9]+([.][0-9]+)?$ ]]
 then
   # a number
   if [ "$vox_size" -lt "0" ] || [ "$vox_size" -gt "1" ]


### PR DESCRIPTION
## Description

This fixes a few bugs related to the `vox_size` argument and its interpretation, particularly for float inputs:

### In `run_fastsurfer.sh` 
- The regex condition to check whether `vox_size` is a number did not work as intended when the expression was surrounded with double quotes (no number is recognized).
- The regex expression had to also be modified to allow arbitrary floats in the outer condition, not only 0.X and 1.X (since checking for 0 < x < 1 is done in the inner condition already).
- Subsequent conditionals comparing float numbers were ineffective for sub-1 inputs since since bash's -lt and -gt only work on integers; now using a combination of string parsing and `bc` instead.

### In `recon_surf.sh` 
- The same fix to a conditional expression comparing (potential) floats.

### In `run_prediction.py` 
- Had to remove the `vox_size` `isnumeric()` and `isinstance(x, str)` checks. The first does not recognize floats within strings (e.g. "0.8"). For the second, the definition of the `vox_size` function in `arg_types.py` means that the `vox_size` could be a float (e.g. when "0.8" is passed in) and not necessarily always a string. Consquently, this condition leads to any float value to be flagged as an invalid value.

Tested on 1mm, 0.8mm, and 0.7mm input images.