### PR TITLE
Fix: NIFTI image support issues

### DIFF
--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -79,7 +79,7 @@ def load_and_conform_image(img_filename, interpol=1, logger=LOGGER, conform_min 
 
 
 # Save image routine
-def save_image(header_info, affine_info, img_array, save_as):
+def save_image(header_info, affine_info, img_array, save_as, dtype=None):
     """
     Save an image (nibabel MGHImage), according to the desired output file format.
     Supported formats are defined in supported_output_file_formats.
@@ -87,6 +87,7 @@ def save_image(header_info, affine_info, img_array, save_as):
     :param numpy.ndarray affine_info: image affine information
     :param nibabel.freesurfer.mghformat.MGHHeader header_info: image header information
     :param str save_as: name under which to save prediction; this determines output file format
+    :param type dtype: image array type; if provided, the image object is explicitly set to match this type
     :return None: saves predictions to save_as
     """
 
@@ -99,6 +100,9 @@ def save_image(header_info, affine_info, img_array, save_as):
         mgh_img = nib.MGHImage(img_array, affine_info, header_info)
     elif any(save_as.endswith(file_ext) for file_ext in ['nii', 'nii.gz']):
         mgh_img = nib.nifti1.Nifti1Pair(img_array, affine_info, header_info)
+
+    if dtype is not None:
+        mgh_img.set_data_dtype(dtype)
 
     if any(save_as.endswith(file_ext) for file_ext in ['mgz', 'nii']):
         nib.save(mgh_img, save_as)

--- a/FastSurferCNN/quick_qc.py
+++ b/FastSurferCNN/quick_qc.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     inseg = nib.load(options.aparc_aseg_segfile)
     inseg_data = np.asanyarray(inseg.dataobj)
     inseg_header = inseg.header
-    inseg_voxvol = np.product(inseg_header["delta"])
+    inseg_voxvol = np.product(inseg_header.get_zooms())
 
     if not check_volume(inseg_data, inseg_voxvol):
     	sys.exit('ERROR: Total segmentation volume is too small. Segmentation may be corrupted.')

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -395,7 +395,7 @@ if __name__ == "__main__":
 
             # Run QC check
             LOGGER.info("Running volume-based QC check on segmentation...")
-            seg_voxvol = np.product(orig_img.header["delta"])
+            seg_voxvol = np.product(orig_img.header.get_zooms())
             if not check_volume(pred_data, seg_voxvol):
                 LOGGER.warning("Total segmentation volume is too small. Segmentation may be corrupted.")
                 if qc_file_handle is not None:

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -179,7 +179,8 @@ class RunModelOnData:
             orig_data = np.asanyarray(orig.dataobj)
 
         # Save conformed input image
-        self.save_img(self.subject_conf_name, orig_data, orig)
+        self.save_img(self.subject_conf_name, orig_data, orig, dtype=np.uint8)
+
         return orig, orig_data
 
     def set_subject(self, subject: str, sid: Union[str, None]):
@@ -242,7 +243,7 @@ class RunModelOnData:
         else:
             header = orig.header
 
-        du.save_image(header, orig.affine, np_data, save_as)
+        du.save_image(header, orig.affine, np_data, save_as, dtype=dtype)
         LOGGER.info("Successfully saved image as {}".format(save_as))
 
     def set_up_model_params(self, plane, cfg, ckpt):


### PR DESCRIPTION
## Description

This PR addresses some issues encountered when testing with nifti input images:
- The volume-based QC check routine (in `quick_qc.py` and `run_prediction.py`) fails since the `delta` attribute is not present in the `NIFTI1` headers. This has been changed to use `get_zooms()` header function instead, which returns the same values and supports both `MGH` and `NIFTI1` formats.
- After conforming and saving certain nifti images, their data types are set to `FLOAT`, despite the image arrays and headers being explicitly set to `UCHAR`, leading to the image failing the conform check in the surface pipeline. This was resolved by ensuring that `set_data_dtype()` is used on the image object itself in the `save_image` function of `data_utils.py`; in these cases, doing that for the data array and the header only is not sufficient.