### PR TITLE
Fix: Padding size type

### DIFF
--- a/FastSurferCNN/data_loader/augmentation.py
+++ b/FastSurferCNN/data_loader/augmentation.py
@@ -15,6 +15,8 @@
 
 
 # IMPORTS
+from numbers import Number
+
 import numpy as np
 import torch
 
@@ -48,8 +50,8 @@ class ZeroPad2DTest(object):
         :param output_size:
         :param pos: position to put the input
         """
-        if isinstance(output_size, int):
-            output_size = (output_size, ) * 2
+        if isinstance(output_size, Number):
+            output_size = (int(output_size), ) * 2
         self.output_size = output_size
         self.pos = pos
 
@@ -107,8 +109,8 @@ class ZeroPad2D(object):
         :param output_size:
         :param pos: position to put the input
         """
-        if isinstance(output_size, int):
-            output_size = (output_size, ) * 2
+        if isinstance(output_size, Number):
+            output_size = (int(output_size), ) * 2
         self.output_size = output_size
         self.pos = pos
 

--- a/FastSurferCNN/data_loader/augmentation.py
+++ b/FastSurferCNN/data_loader/augmentation.py
@@ -48,7 +48,7 @@ class ZeroPad2DTest(object):
         :param output_size:
         :param pos: position to put the input
         """
-        if isinstance(output_size, float):
+        if isinstance(output_size, int):
             output_size = (output_size, ) * 2
         self.output_size = output_size
         self.pos = pos
@@ -107,7 +107,7 @@ class ZeroPad2D(object):
         :param output_size:
         :param pos: position to put the input
         """
-        if isinstance(output_size, float):
+        if isinstance(output_size, int):
             output_size = (output_size, ) * 2
         self.output_size = output_size
         self.pos = pos


### PR DESCRIPTION
## Description

This PR makes a small modification in the behaviour of the `ZeroPad2D` and `ZeroPad2DTest` objects in `augmentation.py`: both now expect integers instead of floats in the specified tensor sizes passes in as inputs.

This avoids an error when concatenating the tensor sizes with the input image's number of channels returned by `numpy`, which is an integer, in the following line: https://github.com/Deep-MI/FastSurfer/blob/55d20b831b3a8349e49e81229b7a0a0381bf55e1/FastSurferCNN/data_loader/augmentation.py#L121

If the input tuple to `np.zeros()` has a combination of integers and floats, it raises the following error, which is avoided with this fix:
```
TypeError: 'float' object cannot be interpreted as an integer
```