### PR TITLE
Fix: Misleading QC failure message in `run_fastsurfer.sh`

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -413,7 +413,7 @@ if __name__ == "__main__":
     if len(s_dirs) == 1:
         if qc_failed_subject_count:
             LOGGER.error("Single subject failed the volume-based QC check.")
-            sys.exit(1)
+            sys.exit(2)
     else:
         LOGGER.info("Segmentations from {} out of {} processed cases failed the volume-based QC check.".format(
             qc_failed_subject_count, len(s_dirs)))

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -499,9 +499,13 @@ if [ "$run_seg_pipeline" == "1" ]
     cmd="$python $fastsurfercnndir/run_prediction.py --t1 $t1 --aparc_aseg_segfile $aparc_aseg_segfile --conformed_name $conformed_name --sid $subject --seg_log $seg_log --vox_size $vox_size --batch_size $batch_size --viewagg_device $viewagg --device $device $allow_root"
     echo $cmd |& tee -a $seg_log
     $cmd
-    if [ ${PIPESTATUS[0]} -ne 0 ]
+    exit_code=${PIPESTATUS[0]}
+    if [ ${exit_code} -ne 0 ]
     then
-      echo "ERROR: Segmentation failed QC checks."
+      if [ ${exit_code} == 2 ]
+      then
+        echo "ERROR: Segmentation failed QC checks."
+      fi
       exit 1
     fi
 


### PR DESCRIPTION
## Description

At the moment, _any_ failure of `run_prediction.py` when executing from `run_fastsurfer.sh` triggers an error message indicating a failed QC check because of the following condition:
https://github.com/Deep-MI/FastSurfer/blob/54bd98f46571c23b43590cad3733fdaeba8d2337/run_fastsurfer.sh#L502-L506

This leads to confusing cases where an insufficient memory failure, for example, is followed by this error message, such as in the following example:
```
[CRITICAL: run_prediction.py:  262]: ERROR - INSUFFICIENT GPU MEMORY
[INFO: run_prediction.py:  263]: The memory requirements exceeds the available GPU memory, try using a smaller batch size (--batch_size <int>) and/or view aggregation on the cpu (--viewagg_device 'cpu').Note: View Aggregation on the GPU is particularly memory-hungry at approx. 5 GB for standard 256x256x256 images.
[INFO: run_prediction.py:  268]: Using GPU 0; 7.79 GiB total capacity; 21.57 MiB already allocated; 6.58 GiB free; 22.00 MiB reserved in total by PyTorch.
----------------------------
ERROR: INSUFFICIENT GPU MEMORY

ERROR: Segmentation failed QC checks.
```

This PR simply assigns a specific error code to the QC check error, such that `run_fastsurfer.sh` prints that error message in response only to this failure.
