### PR TITLE
Refactoring of features impacted by CerebNet

### DIFF
--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+# Copyright 2023 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,16 @@
 
 
 # IMPORTS
-import sys
+from typing import Optional, Tuple
 
 import numpy as np
+from numpy import typing as npt
 import torch
 from skimage.measure import label, regionprops
 from scipy.ndimage import binary_erosion, binary_closing, filters, uniform_filter, generate_binary_structure
 import scipy.ndimage.morphology as morphology
 import nibabel as nib
+from nibabel.filebasedimages import FileBasedHeader as _Header
 import pandas as pd
 
 from FastSurferCNN.utils import logging
@@ -40,17 +42,22 @@ LOGGER = logging.getLogger(__name__)
 
 
 # Conform an MRI brain image to UCHAR, RAS orientation, and 1mm or minimal isotropic voxels
-def load_and_conform_image(img_filename, interpol=1, logger=LOGGER, conform_min = False):
+def load_and_conform_image(img_filename: str, interpol: int = 1, logger: logging.Logger = LOGGER,
+                           conform_min: bool = False) -> Tuple[_Header, np.ndarray, np.ndarray]:
     """
     Function to load MRI image and conform it to UCHAR, RAS orientation and 1mm or minimum isotropic voxels size
     (if it does not already have this format)
-    :param str img_filename: path and name of volume to read
-    :param int interpol: interpolation order for image conformation (0=nearest,1=linear(default),2=quadratic,3=cubic)
-    :param logger logger: Logger to write output to (default = STDOUT)
-    :param: boolean: conform_min: conform image to minimal voxel size (for high-res) (Default = False)
-    :return: nibabel.MGHImage header_info: header information of the conformed image
-    :return: np.ndarray affine_info: affine information of the conformed image
-    :return: nibabel.MGHImage orig: conformed image
+
+    Args:
+        img_filename: path and name of volume to read
+        interpol: interpolation order for image conformation (0=nearest,1=linear(default),2=quadratic,3=cubic)
+        logger: Logger to write output to (default = STDOUT)
+        conform_min: conform image to minimal voxel size (for high-res) (Default = False)
+
+    Returns:
+        nibabel.Header header_info: header information of the conformed image
+        numpy.ndarray affine_info: affine information of the conformed image
+        numpy.ndarray orig_data: conformed image data
     """
     orig = nib.load(img_filename)
     # is_conform and conform accept numeric values and the string 'min' instead of the bool value
@@ -60,12 +67,12 @@ def load_and_conform_image(img_filename, interpol=1, logger=LOGGER, conform_min 
         logger.info('Conforming image to UCHAR, RAS orientation, and minimum isotropic voxels')
 
         if len(orig.shape) > 3 and orig.shape[3] != 1:
-            sys.exit('ERROR: Multiple input frames (' + format(orig.shape[3]) + ') not supported!')
+            raise RuntimeError(f'ERROR: Multiple input frames ({orig.shape[3]}) not supported!')
 
         # Check affine if image is nifti image
-        if img_filename[-7:] == ".nii.gz" or img_filename[-4:] == ".nii":
+        if any(img_filename.endswith(ext) for ext in (".nii.gz", ".nii")):
             if not check_affine_in_nifti(orig, logger=logger):
-                sys.exit("ERROR: inconsistency in nifti-header. Exiting now.\n")
+                raise RuntimeError("ERROR: inconsistency in nifti-header. Exiting now.")
 
         # conform
         orig = conform(orig, interpol, conform_vox_size=_conform_vox_size)
@@ -73,22 +80,54 @@ def load_and_conform_image(img_filename, interpol=1, logger=LOGGER, conform_min 
     # Collect header and affine information
     header_info = orig.header
     affine_info = orig.affine
-    orig = np.asanyarray(orig.dataobj)
+    orig_data = np.asanyarray(orig.dataobj)
 
-    return header_info, affine_info, orig
+    return header_info, affine_info, orig_data
+
+
+def load_image(file: str, name: str = "image", **kwargs) -> Tuple[nib.analyze.SpatialImage, np.ndarray]:
+    """Load file 'file' with nibabel, including all data.
+
+    Args:
+        file: path to the file to load.
+        name: name of the file (optional), only effects error messages.
+        kwargs: Additional kwargs to nibabel.load().
+
+    Returns:
+        The nibabel image object and a numpy array of the data.
+
+    nibabel releases the GIL, so the following is a parallel example.
+    >>> from concurrent.futures import ThreadPoolExecutor
+    >>> with ThreadPoolExecutor() as pool:
+    >>>     future1 = pool.submit(load_image, filename1)
+    >>>     future2 = pool.submit(load_image, filename2)
+    >>>     image, data = future1.result()
+    >>>     image2, data2 = future2.result()
+
+    """
+    try:
+        img = nib.load(file, **kwargs)
+    except (IOError, FileNotFoundError) as e:
+        raise IOError(f"Failed loading the {name} '{file}' with error: {e.args[0]}") from e
+    data = np.asarray(img.dataobj)
+    return img, data
 
 
 # Save image routine
-def save_image(header_info, affine_info, img_array, save_as, dtype=None):
+def save_image(header_info: _Header, affine_info: np.ndarray, img_array: np.ndarray, save_as: str,
+               dtype: Optional[npt.DTypeLike] = None):
     """
     Save an image (nibabel MGHImage), according to the desired output file format.
     Supported formats are defined in supported_output_file_formats.
-    :param numpy.ndarray img_array: an array containing image data
-    :param numpy.ndarray affine_info: image affine information
-    :param nibabel.freesurfer.mghformat.MGHHeader header_info: image header information
-    :param str save_as: name under which to save prediction; this determines output file format
-    :param type dtype: image array type; if provided, the image object is explicitly set to match this type
-    :return None: saves predictions to save_as
+
+    Args:
+        header_info: image header information
+        affine_info: image affine information
+        img_array: an array containing image data
+        save_as: name under which to save prediction; this determines output file format
+        dtype: image array type; if provided, the image object is explicitly set to match this type
+
+    Returns: nothing/None, saves predictions to save_as
     """
 
     assert any(save_as.endswith(file_ext) for file_ext in SUPPORTED_OUTPUT_FILE_FORMATS), \
@@ -112,13 +151,16 @@ def save_image(header_info, affine_info, img_array, save_as, dtype=None):
 
 
 # Transformation for mapping
-def transform_axial(vol, coronal2axial=True):
+def transform_axial(vol: np.ndarray, coronal2axial: bool = True) -> np.ndarray:
     """
     Function to transform volume into Axial axis and back
-    :param np.ndarray vol: image volume to transform
-    :param bool coronal2axial: transform from coronal to axial = True (default),
-                               transform from axial to coronal = False
-    :return:
+
+    Args:
+        vol: image volume to transform
+        coronal2axial: transform from coronal to axial = True (default),
+                       transform from axial to coronal = False
+    Returns:
+        the transformed image
     """
     if coronal2axial:
         return np.moveaxis(vol, [0, 1, 2], [1, 2, 0])
@@ -126,13 +168,16 @@ def transform_axial(vol, coronal2axial=True):
         return np.moveaxis(vol, [0, 1, 2], [2, 0, 1])
 
 
-def transform_sagittal(vol, coronal2sagittal=True):
+def transform_sagittal(vol: np.ndarray, coronal2sagittal: bool = True) -> np.ndarray:
     """
     Function to transform volume into Sagittal axis and back
-    :param np.ndarray vol: image volume to transform
-    :param bool coronal2sagittal: transform from coronal to sagittal = True (default),
-                                transform from sagittal to coronal = False
-    :return:
+
+    Args:
+        vol: image volume to transform
+        coronal2sagittal: transform from coronal to sagittal = True (default),
+                          transform from sagittal to coronal = False
+    Returns:
+        the transformed image
     """
     if coronal2sagittal:
         return np.moveaxis(vol, [0, 1, 2], [2, 1, 0])
@@ -141,24 +186,24 @@ def transform_sagittal(vol, coronal2sagittal=True):
 
 
 # Thick slice generator (for eval) and blank slices filter (for training)
-def get_thick_slices(img_data, slice_thickness=3):
+def get_thick_slices(img_data: np.ndarray, slice_thickness: int = 3) -> np.ndarray:
     """
     Function to extract thick slices from the image
     (feed slice_thickness preceeding and suceeding slices to network,
     label only middle one)
-    :param np.ndarray img_data: 3D MRI image read in with nibabel
-    :param int slice_thickness: number of slices to stack on top and below slice of interest (default=3)
-    :return:
+
+    Args:
+        img_data: 3D MRI image read in with nibabel
+        slice_thickness: number of slices to stack on top and below slice of interest (default=3)
+
+    Returns:
+        image data with the thick slices of the n-th axis appended into the n+1-th axis.
     """
-    h, w, d = img_data.shape
-    img_data_pad = np.expand_dims(np.pad(img_data, ((0, 0), (0, 0), (slice_thickness, slice_thickness)), mode='edge'),
-                                  axis=3)
-    img_data_thick = np.ndarray((h, w, d, 0), dtype=np.uint8)
-
-    for slice_idx in range(2 * slice_thickness + 1):
-        img_data_thick = np.append(img_data_thick, img_data_pad[:, :, slice_idx:d + slice_idx, :], axis=3)
-
-    return img_data_thick
+    img_data_pad = np.pad(img_data, ((0, 0), (0, 0), (slice_thickness, slice_thickness)), mode='edge')
+    from numpy.lib.stride_tricks import sliding_window_view
+    # sliding_window_view will automatically create thick slices through a sliding window, but as this in only a view,
+    # less memory copies are required
+    return sliding_window_view(img_data_pad, 2*slice_thickness+1, axis=2)
 
 
 def filter_blank_slices_thick(img_vol, label_vol, weight_vol, threshold=50):

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -128,9 +128,8 @@ def loadfile_full(file: str, name: str) \
 
 def main(args):
     import os
-    # TODO: Testing of allow_root should a shared FastSurfer function.
-    if os.getuid() == 0 and hasattr(args, 'allow_root') and getattr(args, 'allow_root') is not True:
-        return "Trying to run script as root without passing --allow_root."
+    from FastSurferCNN.utils.common import assert_no_root
+    getattr(args, "allow_root", False) or assert_no_root()
 
     if not hasattr(args, 'segfile') or not os.path.exists(args.segfile):
         return "No segfile was passed or it does not exist."

--- a/FastSurferCNN/utils/checkpoint.py
+++ b/FastSurferCNN/utils/checkpoint.py
@@ -16,19 +16,22 @@
 # IMPORTS
 import os
 import glob
+from typing import Union, Iterable, Optional, Collection, MutableSequence
 
 import requests
 import torch
 
 from FastSurferCNN.utils import logging
 
+Scheduler = 'torch.optim.lr_scheduler'
 LOGGER = logging.getLogger(__name__)
 
 # Defaults
 URL = "https://b2share.fz-juelich.de/api/files/a423a576-220d-47b0-9e0c-b5b32d45fc59"
-VINN_AXI = os.path.join(os.path.dirname(os.path.dirname(__file__)), "checkpoints/aparc_vinn_axial_v2.0.0.pkl")
-VINN_COR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "checkpoints/aparc_vinn_coronal_v2.0.0.pkl")
-VINN_SAG = os.path.join(os.path.dirname(os.path.dirname(__file__)), "checkpoints/aparc_vinn_sagittal_v2.0.0.pkl")
+FASTSURFER_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+VINN_AXI = os.path.join(FASTSURFER_ROOT, "checkpoints/aparc_vinn_axial_v2.0.0.pkl")
+VINN_COR = os.path.join(FASTSURFER_ROOT, "checkpoints/aparc_vinn_coronal_v2.0.0.pkl")
+VINN_SAG = os.path.join(FASTSURFER_ROOT, "checkpoints/aparc_vinn_sagittal_v2.0.0.pkl")
 
 
 def create_checkpoint_dir(expr_dir, expr_num):
@@ -42,27 +45,36 @@ def create_checkpoint_dir(expr_dir, expr_num):
     os.makedirs(checkpoint_dir, exist_ok=True)
     return checkpoint_dir
 
-def get_checkpoint(ckpt_dir, epoch):
+
+def get_checkpoint(ckpt_dir: str, epoch: int) -> str:
+    """Find the standardizes checkpoint name for the checkpoint in the directory ckpt_dir for the given epoch."""
     checkpoint_dir = os.path.join(ckpt_dir, 'Epoch_{:05d}_training_state.pkl'.format(epoch))
     return checkpoint_dir
 
-def get_checkpoint_path(log_dir, resume_expr_num):
-    """
 
-    :param log_dir:
-    :param resume_expr_num:
-    :return:
+def get_checkpoint_path(log_dir: str, resume_experiment: Union[str, int, None] = None) -> Optional[MutableSequence[str]]:
+    """Find the paths to checkpoints from the experiment directory.
+
+    Args:
+        log_dir: experiment directory
+        resume_experiment: sub-experiment to search in for a model
+
+    Returns:
+        None, if no models are found, or a list of filenames for checkpoints.
     """
-    if resume_expr_num == "Default":
+    if resume_experiment == "Default" or resume_experiment is None:
         return None
-    checkpoint_path = os.path.join(log_dir, "checkpoints", str(resume_expr_num))
+    checkpoint_path = os.path.join(log_dir, "checkpoints", str(resume_experiment))
     prior_model_paths = sorted(glob.glob(os.path.join(checkpoint_path, 'Epoch_*')), key=os.path.getmtime)
     if len(prior_model_paths) == 0:
         return None
     return prior_model_paths
 
 
-def load_from_checkpoint(checkpoint_path, model, optimizer=None, scheduler=None, fine_tune=False):
+def load_from_checkpoint(checkpoint_path: str, model: torch.nn.Module,
+                         optimizer: Optional[torch.optim.Optimizer] = None, scheduler: Optional[Scheduler] = None,
+                         fine_tune: bool = False,
+                         drop_classifier: bool = False):
     """
      Loading the model from the given experiment number
     :param checkpoint_path:
@@ -70,23 +82,29 @@ def load_from_checkpoint(checkpoint_path, model, optimizer=None, scheduler=None,
     :param optimizer:
     :param scheduler:
     :param fine_tune:
+    :param drop_classifier:
     :return:
         epoch number
     """
     checkpoint = torch.load(checkpoint_path, map_location='cpu')
 
-    try:
-        model.load_state_dict(checkpoint['model_state'])
-    except RuntimeError:
-        model.module.load_state_dict(checkpoint['model_state'])
+    if drop_classifier:
+        classifier_conv = ['classifier.conv.weight', 'classifier.conv.bias']
+        for key in classifier_conv:
+            if key in checkpoint['model_state']:
+                del checkpoint['model_state'][key]
+
+    # if this is a multi-gpu model, get the underlying model
+    mod = model.module if hasattr(model, "module") else model
+    mod.load_state_dict(checkpoint['model_state'], strict=not drop_classifier)
 
     if not fine_tune:
-        if optimizer:
+        if optimizer is not None:
             optimizer.load_state_dict(checkpoint['optimizer_state'])
-        if scheduler and "scheduler_state" in checkpoint.keys():
+        if scheduler is not None and "scheduler_state" in checkpoint.keys():
             scheduler.load_state_dict(checkpoint["scheduler_state"])
 
-    return checkpoint['epoch']+1, checkpoint['best_metric']
+    return checkpoint['epoch']+1, checkpoint.get('best_metric', None)
 
 
 def save_checkpoint(checkpoint_dir, epoch, best_metric, num_gpus, cfg, model,  optimizer, scheduler=None, best=False):

--- a/FastSurferCNN/utils/common.py
+++ b/FastSurferCNN/utils/common.py
@@ -1,0 +1,38 @@
+import os
+
+from FastSurferCNN.utils import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def assert_no_root() -> bool:
+    """Checks whether the user is the root user and raises an error message is so"""
+
+    if os.name == 'posix' and os.getuid() == 0:
+        import sys, __main__
+        sys.exit(
+            """----------------------------
+            ERROR: You are trying to run 'run_prediction.py' as root. We advice to avoid running 
+            FastSurfer as root, because it will lead to files and folders created as root.
+            If you are running FastSurfer in a docker container, you can specify the user with 
+            '-u $(id -u):$(id -g)' (see https://docs.docker.com/engine/reference/run/#user).
+            If you want to force running as root, you may pass --allow_root to %s.
+            """ % os.path.basename(__main__.__file__))
+    return True
+
+
+def handle_cuda_memory_exception(exception: RuntimeError, exit_on_out_of_memory: bool = True) -> bool:
+    if not isinstance(exception, RuntimeError):
+        return False
+    message = exception.args[0]
+    if message.startswith("CUDA out of memory. "):
+        LOGGER.critical("ERROR - INSUFFICIENT GPU MEMORY")
+        LOGGER.info("The memory requirements exceeds the available GPU memory, try using a smaller batch size "
+                    "(--batch_size <int>) and/or view aggregation on the cpu (--viewagg_device 'cpu')."
+                    "Note: View Aggregation on the GPU is particularly memory-hungry at approx. 5 GB for standard "
+                    "256x256x256 images.")
+        memory_message = message[message.find("(") + 1:message.find(")")]
+        LOGGER.info(f"Using {memory_message}.")
+        return True
+    else:
+        return False

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -129,7 +129,7 @@ def add_arguments(parser: argparse.ArgumentParser, flags: Iterable[str]) -> argp
     return parser
 
 
-def add_plane_flags(parser: argparse.ArgumentParser, type: str, files: Mapping[str, str]) -> argparse.ArgumentParser:
+def add_plane_flags(parser: argparse.ArgumentParser, type: Literal["checkpoint", "config"], files: Mapping[str, str]) -> argparse.ArgumentParser:
     """
     Helper function to add plane arguments. Arguments will be added for each entry in files, where the key is the "plane"
     and the values is the file name (relative for path relative to FASTSURFER_HOME.
@@ -137,7 +137,7 @@ def add_plane_flags(parser: argparse.ArgumentParser, type: str, files: Mapping[s
     Args:
         parser: The parser to add flags to.
         type: The type of files (for help text and prefix from "checkpoint" and "config".
-            "checkpoint" will lead to flags like "--ckpt_{plane}", "config" to "--cfg_ {plane}"
+            "checkpoint" will lead to flags like "--ckpt_{plane}", "config" to "--cfg_{plane}"
         files: A dictionary of plane to filename. Relative files are assumed to be relative to the FastSurfer root
             directory.
 


### PR DESCRIPTION
- data_loader/data_utils:
  - loading and conforming: documentation and Exceptions instead of sys.exit
  - add load_image for parallelization of IO
  - save_image: typing
  - transform_axis: updated docstrings
  - get_thick_slices: change to sliding_window_view over memory copies, docstring
- utils/checkpoint:
  - typing, docstrings
  - add additional capabilities required for CerebNet for load_from_checkpoint
- utils/common:
  - assert_no_root: centralize the definition of the code that checks if the current user is root
  - handle_cuda_memory_exeption: move the function to handle cuda memory errors to this common file
- utils/misc:
  - find_device: add general function to search for and select the torch device (including minimal memory requirements)
- utils/parser_defaults:
  - doc and typing updates
- run_prediction:
  - refactor code that was moved to utils/common (find devices, handle cuda errors and allow_root)
  - fix a bug in removesuffix that broke subject names when the suffix was empty
  - add messages and code to use the file name as subject, when all T1 images are in a folder (not subject folders)
- segstats:
  - move allow_root to utils/common

Features tested on 1mm subects.