### PR TITLE
Added optional LUT to map sagittal view to other classes

### DIFF
--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -682,8 +682,7 @@ def map_prediction_sagittal2full(prediction_sag, num_classes=51, lut=None):
         idx_list = np.asarray([0, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 1, 2, 3, 15, 16, 4,
                                17, 18, 19, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
                                19, 20], dtype=np.int16)
-    elif num_classes == 1:
-        idx_list = np.asarray([0, 1, 1])
+
     else:
         assert lut is not None, 'lut is not defined!'
         idx_list = infer_mapping_from_lut(num_classes, lut)

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -123,7 +123,7 @@ class RunModelOnData:
         self.models = {}
         for plane, view in self.view_ops.items():
             if view["cfg"] is not None and view["ckpt"] is not None:
-                self.models[plane] = Inference(view["cfg"], ckpt=view["ckpt"], device=device)
+                self.models[plane] = Inference(view["cfg"], ckpt=view["ckpt"], device=device, lut=self.lut)
 
         vox_size = args.vox_size
         if vox_size == "min":


### PR DESCRIPTION
- Instead of relying on num_classes, lut can be passed to run_prediction.py and inference.py class to automatically infer correct mapping from sagittal to full classes. 