### PR TITLE
Fix: `run_fastsurfer.sh` missing whitespace

### DIFF
--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -505,7 +505,7 @@ if [ "$run_seg_pipeline" == "1" ]
       exit 1
     fi
 
-    if [ ! -f "$main_file"]
+    if [ ! -f "$main_file" ]
       then
         ln -s -r "$aparc_aseg_segfile" "$main_segfile"
     fi


### PR DESCRIPTION
## Description

Quick-fix for a missing space in an if conditional. FastSurfer still runs through successfully but always prints the warning message:
```
/fastsurfer/run_fastsurfer.sh: line 512: [: missing `]'
```