### PR TITLE
[FastSurferCNN/run_prediction] revert change of s_dir -> subjects

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -368,7 +368,7 @@ if __name__ == "__main__":
         qc_file_handle.close()
 
     # Batch case: report ratio of QC warnings
-    if len(s_dirs) > 1:
+    if len(subjects) > 1:
         LOGGER.info("Segmentations from {} out of {} processed cases failed the volume-based QC check.".format(
             qc_failed_subject_count, len(subjects)))
 


### PR DESCRIPTION
`s_dir` was undefined in current dev, now this should be correct.

This was introduced by commit 2fd4fa7f030327ab6415bcb56ef82491796c0988.