### PR TITLE
add dockerhub deployment workflow 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: deploy-docker
 
-on: [workflow_dispatch]
+on:
+  release:
+    types:
+      - published
 
 jobs:
   deploy-gpu:
@@ -18,15 +21,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: get version
-        id: get_tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: "dev"
       - name: Build Docker image GPU
-        run: python Docker/build.py --device cuda --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+        run: python Docker/build.py --device cuda --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ github.event.release.tag_name }}
+      - name: Add additional tags
+        run: |
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ github.event.release.tag_name }} ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-latest
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ github.event.release.tag_name }} ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:latest
       - name: Push Docker image GPU
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+        run: docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ github.event.release.tag_name }}
   deploy-cpu:
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -42,13 +44,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: get version
-        id: get_tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: "dev"
       - name: Build Docker image CPU
         run: python Docker/build.py --device cpu --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+      - name: Add additional tags
+        run: |
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ github.event.release.tag_name }} ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-latest
       - name: Push Docker image CPU
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+        run: docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: deploy-docker
+
+on: [workflow_dispatch]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Login to Docker
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: get version
+        id: get_tag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          fallback: "dev"
+      - name: Build Docker image GPU
+        run: python Docker/build.py --device gpu --tag girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+      - name: Build Docker image CPU
+        run: python Docker/build.py --device cpu --tag girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+      - name: Push Docker image GPU
+        run: docker push girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+      - name: Push Docker image CPU
+        run: docker push girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build Docker image CPU
-        run: python Docker/build.py --device cpu --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+        run: python Docker/build.py --device cpu --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ github.event.release.tag_name }}
       - name: Add additional tags
         run: |
           docker tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ github.event.release.tag_name }} ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-latest
       - name: Push Docker image CPU
-        run: docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+        run: docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ github.event.release.tag_name }}
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,8 @@ on: [workflow_dispatch]
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest 
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy-docker
 on: [workflow_dispatch]
 
 jobs:
-  deploy:
+  deploy-gpu:
     runs-on: ubuntu-latest 
     timeout-minutes: 120
     steps:
@@ -25,10 +25,30 @@ jobs:
           fallback: "dev"
       - name: Build Docker image GPU
         run: python Docker/build.py --device cuda --tag girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
-      - name: Build Docker image CPU
-        run: python Docker/build.py --device cpu --tag girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
       - name: Push Docker image GPU
         run: docker push girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+  deploy-cpu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Login to Docker
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: get version
+        id: get_tag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          fallback: "dev"
+      - name: Build Docker image CPU
+        run: python Docker/build.py --device cpu --tag girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
       - name: Push Docker image CPU
         run: docker push girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           fallback: "dev"
       - name: Build Docker image GPU
-        run: python Docker/build.py --device cuda --tag girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+        run: python Docker/build.py --device cuda --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
       - name: Push Docker image GPU
-        run: docker push girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
   deploy-cpu:
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -48,7 +48,7 @@ jobs:
         with:
           fallback: "dev"
       - name: Build Docker image CPU
-        run: python Docker/build.py --device cpu --tag girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+        run: python Docker/build.py --device cpu --tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
       - name: Push Docker image CPU
-        run: docker push girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fallback: "dev"
       - name: Build Docker image GPU
-        run: python Docker/build.py --device gpu --tag girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
+        run: python Docker/build.py --device cuda --tag girodia/fastsurfer:gpu-${{ steps.get_tag.outputs.tag }}
       - name: Build Docker image CPU
         run: python Docker/build.py --device cpu --tag girodia/fastsurfer:cpu-${{ steps.get_tag.outputs.tag }}
       - name: Push Docker image GPU


### PR DESCRIPTION
This PR adds a GitHub Actions workflow, for building all the Docker images and pushing them to the Dockerhub. 
* Triggered by a manual dispatch (Can be changed if desired)
* Steps:
  * Checkout and fetching repo
  * Logins to Dockerhub
  * Gets the latest used Tag
  * Builds and pushes all images for every Dockerfile (Except experimental AMD)
    * uses the latest tag for the docker version as in `deepmit/fastsurfer:gpu-[TAG]`. So consistent tagging is needed.

#
This should work, but I would recommend, first getting a local runner, as it put out a warning last time about lack of disk space:
 > You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 82 MB

The workflow then needs to be updated to use the new runner.


Also, there needs to be a GitHub [secret](https://github.com/Deep-MI/FastSurfer/settings/secrets/actions) for the username and token in able for this to work.

To check the latest functioning run of this Workflow, see [here](https://github.com/agirodi/FastSurfer/actions/runs/4467717898)