### PR TITLE
Added call to create jacobian_white measure directly in fastsurfer

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -884,6 +884,8 @@ else
 
     echo "pushd $mdir" >> $CMDF
     # these are run automatically in fs7* recon-all and cannot be called directly without -pial flag (or other t2 flags)
+    cmd="mris_jacobian $hemi.white $hemi.sphere.reg $hemi.jacobian_white"
+    RunIt "$cmd" $LF $CMDF
     cmd="mris_place_surface --curv-map ../surf/$hemi.white 2 10 ../surf/$hemi.curv"
     RunIt "$cmd" $LF $CMDF
     cmd="mris_place_surface --area-map ../surf/$hemi.white ../surf/$hemi.area"

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -884,8 +884,11 @@ else
 
     echo "pushd $mdir" >> $CMDF
     # these are run automatically in fs7* recon-all and cannot be called directly without -pial flag (or other t2 flags)
-    cmd="mris_jacobian $hemi.white $hemi.sphere.reg $hemi.jacobian_white"
-    RunIt "$cmd" $LF $CMDF
+    if [ "$fssurfreg" == "1" ] ; then
+      # jacobian needs sphere reg which might be turned off by user (on by default)
+      cmd="mris_jacobian ../surf/$hemi.white ../surf/$hemi.sphere.reg ../surf/$hemi.jacobian_white"
+      RunIt "$cmd" $LF $CMDF
+    fi
     cmd="mris_place_surface --curv-map ../surf/$hemi.white 2 10 ../surf/$hemi.curv"
     RunIt "$cmd" $LF $CMDF
     cmd="mris_place_surface --area-map ../surf/$hemi.white ../surf/$hemi.area"


### PR DESCRIPTION
Previously jacobian_white was not created in FastSurfer (as pointed out by @pavgreen9 in #281 ). If --surf-reg was run (on by default) this can be easily generated in less than a second. Command is added after white and pial are generated (grouped with other surface measures e.g. curvature, area and thickness). 