### PR TITLE
Fix: getuser failure for non-root Docker

### DIFF
--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -260,8 +260,12 @@ def write_statsfile(segstatsfile: str, dataframe: pd.DataFrame, vox_vol: float, 
             fp.write(f"# platform {sys.platform}\n"
                      f"# hostname {gethostname()}\n")
         from getpass import getuser
-        fp.write(f"# user       {getuser()}\n"
-                 f"# anatomy_type volume\n#\n")
+        try:
+            fp.write(f"# user       {getuser()}\n")
+        except KeyError:
+            fp.write(f"# user       UNKNOWN\n")
+
+        fp.write(f"# anatomy_type volume\n#\n")
 
         file_annotation(fp, "SegVolFile", segfile)
         file_annotation(fp, "ColorTable", lut)


### PR DESCRIPTION
## Description

This PR avoids the following error in `segstats.py`, which occurs when `recon-surf.sh` is run from within a Docker container that is not run as root (where USER_ID refers to the user's id):
```
ERROR: asegdkt statsfile generation failed
KeyError: 'getpwuid(): uid not found: USER_ID'
```

If the user name can not be retrieved using `getpass.getuser`, the relevant field in the stats file is populated with "UNKNOWN" instead (similar to freesurfer stats files).