### PR TITLE
QC check: Ventricle-bg intersection volume

### DIFF
--- a/FastSurferCNN/quick_qc.py
+++ b/FastSurferCNN/quick_qc.py
@@ -19,6 +19,8 @@ import sys
 import numpy as np
 import nibabel as nib
 
+from skimage.morphology import binary_dilation
+
 
 HELPTEXT = """
 Script to perform quick qualtiy checks for the input segmentation to identify gross errors.
@@ -28,6 +30,12 @@ quick_qc.py --asegdkt_segfile <aparc+aseg.mgz>
 
 
 """
+
+VENT_LABELS = {'Left-Lateral-Ventricle': 4,
+               'Right-Lateral-Ventricle': 43,
+               'Left-choroid-plexus': 31,
+               'Right-choroid-plexus': 63}
+BG_LABEL = 0
 
 def options_parse():
     """
@@ -55,6 +63,67 @@ def check_volume(asegdkt_segfile, voxvol, thres=0.70):
 
     return True
 
+def get_region_bg_intersection_mask(seg_array, region_labels=VENT_LABELS, bg_label=BG_LABEL):
+    """
+    Returns a mask of the intersection between the voxels of a given region and background voxels.
+
+    This is obtained by dilating the region by 1 voxel and computing the intersection with the 
+    background mask.
+
+    The region can be defined by passing in the region_labels dict.
+
+    Parameters
+    ----------
+    seg_array: numpy.ndarray
+        Segmentation array
+    region_labels: dict
+        dict whose values correspond to the desired region's labels 
+    bg_labels: int
+        Background label integer
+
+    Returns
+    -------
+    bg_intersect: numpy.ndarray
+        Region and background intersection mask array
+    """
+
+    region_array = seg_array.copy()
+    conditions = np.all(np.array([(region_array != value) for value in region_labels.values()]), axis=0)
+    region_array[conditions] = 0
+    region_array[region_array != 0] = 1
+
+    bg_array = seg_array.copy()
+    bg_array[bg_array != bg_label] = -1.
+    bg_array[bg_array == bg_label] = 1
+    bg_array[bg_array != 1] = 0
+
+    region_array_dilated = binary_dilation(region_array)
+
+    bg_intersect = np.bitwise_and(region_array_dilated.astype(int), bg_array.astype(int))
+
+    return bg_intersect
+
+def get_ventricle_bg_intersection_volume(seg_array, voxvol):
+    """
+    Returns a volume estimate for the intersection of ventricle voxels with background voxels.
+
+    Parameters
+    ----------
+    seg_array: numpy.ndarray
+        Segmentation array
+    voxvol: float
+        Voxel volume
+
+    Returns
+    -------
+    intersection_volume: float
+        Estimated volume of voxels in ventricle and background intersection
+    """
+    bg_intersect_mask = get_region_bg_intersection_mask(seg_array)
+    intersection_volume = bg_intersect_mask.sum() * voxvol
+
+    return intersection_volume
+
 
 if __name__ == "__main__":
     # Command Line options are error checking done here
@@ -65,6 +134,11 @@ if __name__ == "__main__":
     inseg_header = inseg.header
     inseg_voxvol = np.product(inseg_header.get_zooms())
 
+    # Ventricle-BG intersection volume check:
+    print("Estimating ventricle-background intersection volume...")
+    print("Ventricle-background intersection volume in mm3: {:.2f}".format(get_ventricle_bg_intersection_volume(inseg_data, inseg_voxvol)))
+
+    # Total volume check:
     if not check_volume(inseg_data, inseg_voxvol):
         print('WARNING: Total segmentation volume is very small. Segmentation may be corrupted! Please check.')
         sys.exit(0)


### PR DESCRIPTION
## Description

This PR adds a QC check in [quick_qc.py](https://github.com/Deep-MI/FastSurfer/compare/dev...AhmedFaisal95:feature/qc-check-vent-holes?expand=1#diff-0636140249733376e0adfa52c772f245bac3777305fd9bbdb53a2e743ba40414) which computes the volume of intersecting ventricle and background region voxels. This was originally developed to detect cases in which the segmented ventricle region contained large holes (labeled as background), which consequently lead to long topology fixing times in the surface pipeline.

The volume is estimated by dilating the ventricle region by 1 voxel, computing the intersection with the background mask, and computing the sum (multiplied by voxel volume). By default, this region includes the choroid plexuses and ventricles of both hemispheres.

The result is only printed out i.e. no error is raised. In the future, a threshold may be added to flag some cases and possibly warn or fail.