### PR TITLE
Fix: 3D interact showing white screen

### DIFF
--- a/Tutorial/Complete_FastSurfer_Tutorial.ipynb
+++ b/Tutorial/Complete_FastSurfer_Tutorial.ipynb
@@ -149,6 +149,7 @@
     "\n",
     "! pip install torchio==0.18.83\n",
     "! pip install yacs==0.1.8\n",
+    "! pip install plotly==5.9.0\n",
     "\n",
     "print(\"Finished setup\")\n",
     "print(\"----------------------------------------------\")"

--- a/Tutorial/Tutorial_FastSurferCNN_QuickSeg.ipynb
+++ b/Tutorial/Tutorial_FastSurferCNN_QuickSeg.ipynb
@@ -100,6 +100,7 @@
     "\n",
     "! pip install torchio==0.18.83\n",
     "! pip install yacs==0.1.8\n",
+    "! pip install plotly==5.9.0\n",
     "\n",
     "print(\"Finished setup\")\n",
     "print(\"----------------------------------------------\")"


### PR DESCRIPTION
This PR fixes the 3D interact, that has shown a white screen/no image before.

The bug was discussed in #280 and occurred because GoogleCollab upgraded its preinstalled packages.
The only change is to downgrade the **plotly** version back to 5.9.0 (was 5.13.1), the same version that is required by FastSurfer anyways.

An alternative fix is possible, where the requirements.txt is installed instead, which could make this more stable for future changes to our FastSurfer dependencies and Collabs changes. But it takes several minutes to install and I recommend doing this only if necessary.