### PR TITLE
Replaced !cd  with %cd (!cd does not work in colab anymore)

### DIFF
--- a/Tutorial/Complete_FastSurfer_Tutorial.ipynb
+++ b/Tutorial/Complete_FastSurfer_Tutorial.ipynb
@@ -361,7 +361,7 @@
    },
    "source": [
     "#@title Click the run button to upload your T1-weighted MRI image (will be deleted after the session is over; make sure you have the permissions to do this for the image in question).\n",
-    "!cd \"{SETUP_DIR}\"\n",
+    "%cd \"{SETUP_DIR}\"\n",
     "\n",
     "from google.colab import files\n",
     "uploaded = files.upload()\n",

--- a/Tutorial/Tutorial_FastSurferCNN_QuickSeg.ipynb
+++ b/Tutorial/Tutorial_FastSurferCNN_QuickSeg.ipynb
@@ -289,7 +289,7 @@
    "outputs": [],
    "source": [
     "#@title Click the run button to upload your T1-weighted MRI image (will be deleted after the session is over; make sure you have the permissions to do this for the image in question).\n",
-    "!cd \"{SETUP_DIR}\"\n",
+    "%cd \"{SETUP_DIR}\"\n",
     "\n",
     "from google.colab import files\n",
     "uploaded = files.upload()\n",


### PR DESCRIPTION
In the image loading call, the line !cd $SETUP_DIR was replaced with %cd $SETUP_DIR as Google Colab does not support ! cd magic (see https://github.com/googlecolab/colabtools/issues/40).

"...Commands prefixed with ! are run in a new subshell -- so you're starting a new shell, changing directories, and ... letting the shell process quit. ..."