### PR TITLE
Added CerebNet, removed copying empty dir and corrected ckpt downloaddir

### DIFF
--- a/Docker/Dockerfile_FastSurferCNN
+++ b/Docker/Dockerfile_FastSurferCNN
@@ -63,13 +63,13 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Copy venv and FastSurferCNN 
 COPY --from=build /venv /venv
 COPY ./FastSurferCNN /fastsurfer/FastSurferCNN/
-COPY ./checkpoints /fastsurfer/FastSurferCNN/checkpoints/
+COPY ./CerebNet /fastsurfer/CerebNet
 COPY ./Docker/entrypoint.sh /fastsurfer/Docker/entrypoint.sh
 
 # Download all remote network checkpoints already
 ENV PYTHONPATH=/fastsurfer:$PYTHONPATH \
     MPLCONFIGDIR=/tmp
-RUN python3 /fastsurfer/FastSurferCNN/download_checkpoints.py --all; chmod +r -R /fastsurfer/FastSurferCNN/checkpoints
+RUN python3 /fastsurfer/FastSurferCNN/download_checkpoints.py --all
 
 # Set FastSurfer workdir and entrypoint
 #  the script entrypoint ensures that our conda env is active

--- a/Docker/Dockerfile_FastSurferCNN_AMD
+++ b/Docker/Dockerfile_FastSurferCNN_AMD
@@ -20,13 +20,14 @@ RUN pip3 install \
      
 
 # Copy FastSurferCNN 
-COPY ./FastSurferCNN /FastSurferCNN/
+COPY ./FastSurferCNN /fastsurfer/FastSurferCNN/
+COPY ./CerebNet /fastsurfer/CerebNet
 
 # Download all remote network checkpoints already
-RUN cd /FastSurferCNN/ ; python3 download_checkpoints.py --all --vinn
+RUN python3 /fastsurfer/FastSurferCNN/download_checkpoints.py --all
 
 # Set FastSurferCNN workdir and entrypoint
 #  the script entrypoint ensures that our conda env is active
-WORKDIR "/FastSurferCNN"
-ENTRYPOINT ["python3.7", "run_prediction.py"]
+WORKDIR "/fastsurfer"
+ENTRYPOINT ["python3.7", "./FastSurferCNN/run_prediction.py"]
 CMD ["--help"]

--- a/Docker/Dockerfile_FastSurferCNN_CPU
+++ b/Docker/Dockerfile_FastSurferCNN_CPU
@@ -63,13 +63,13 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Copy venv and FastSurferCNN 
 COPY --from=build /venv /venv
 COPY ./FastSurferCNN /fastsurfer/FastSurferCNN/
-COPY ./checkpoints /fastsurfer/FastSurferCNN/checkpoints/
+COPY ./CerebNet /fastsurfer/CerebNet
 COPY ./Docker/entrypoint.sh /fastsurfer/Docker/entrypoint.sh
 
 # Download all remote network checkpoints already
 ENV PYTHONPATH=/fastsurfer:$PYTHONPATH \
     MPLCONFIGDIR=/tmp
-RUN python3 /fastsurfer/FastSurferCNN/download_checkpoints.py --all; chmod +r -R /fastsurfer/FastSurferCNN/checkpoints
+RUN python3 /fastsurfer/FastSurferCNN/download_checkpoints.py --all
 
 # Set FastSurfer workdir and entrypoint
 #  the script entrypoint ensures that our conda env is active


### PR DESCRIPTION
Inference with Dockerfiles_FastSurferCNN and _CPU failed because ckpts were not downloaded correctly during the build phase. In the Dockerfile, the checkpoint dir (which no longer exists) was copied, and the download was not run at all. During the docker run, attempts to download the checkpoints failed due to 
1.) No write access to the directory
2.) CerebNet directory missing (module could hence not be loaded)

Both points are fixed by removing the checkpoints copy command and adding the cerebnet copy command. 

Tested for CPU and GPU on one image. AMD was not tested, as I do not have access to a compatible computer.