### PR TITLE
Fix: `imageio` bug

### DIFF
--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -22,7 +22,7 @@ import sys
 import SimpleITK as sitk
 import nibabel as nib
 from nibabel.freesurfer.mghformat import MGHHeader
-from typing import Union, Any, Optional
+from typing import Union, Any, Optional, Tuple
 
 
 def mgh_from_sitk(
@@ -103,7 +103,7 @@ def readITKimage(
         filename: str,
         vox_type: Optional[Any] = None,
         with_header: bool = False
-) -> Union[sitk.Image, tuple[sitk.Image, Any]]:
+) -> Union[sitk.Image, Tuple[sitk.Image, Any]]:
     """
     reads the itk image
 


### PR DESCRIPTION
## Description

Running `recon-surf.sh` when the BF-corrected image does not already exist currently fails due to the following error from `N4_bias_correct.py`:
```
Traceback (most recent call last):
  File "/FastSurfer/recon_surf//N4_bias_correct.py", line 27, in <module>
    import image_io as iio
  File "/FastSurfer/recon_surf/image_io.py", line 106, in <module>
    ) -> Union[sitk.Image, tuple[sitk.Image, Any]]:
TypeError: 'type' object is not subscriptable
Command exited with non-zero status 1
```

This PR fixes the bug which causes this (which seems to have been introduced in https://github.com/Deep-MI/FastSurfer/pull/308) in the function declaration: using the `typing` module's `Tuple` instead of `tuple`. 

Tested on one 1mm case.