### PR TITLE
Robustify `mris_info` string comparison to number of spaces (for FS741)

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -712,7 +712,7 @@ else
     RunIt "$cmd" $LF $CMDF
 
     # Check if the surfaceRAS was correctly set and exit otherwise (sanity check in case nibabel changes their default header behaviour)
-    cmd="mris_info $outmesh | grep -q 'vertex locs : surfaceRAS'"
+    cmd="mris_info $outmesh | tr -s ' ' | grep -q 'vertex locs : surfaceRAS'"
     echo "echo \"$cmd\" " |& tee -a $CMDF
     echo "$timecmd $cmd " |& tee -a $CMDF
     echo "if [ \${PIPESTATUS[1]} -ne 0 ] ; then echo \"Incorrect header information detected in $outmesh: vertex locs is not set to surfaceRAS. Exiting... \"; exit 1 ; fi" >> $CMDF


### PR DESCRIPTION
## Description

The `mris_info` SurfaceRAS check in `recon-surf.sh` (see [here](https://github.com/Deep-MI/FastSurfer/blob/eb79b7f0b2284b03ff86baa2246bd59dfd8f4869/recon_surf/recon-surf.sh#L715)) expects the hard-coded "vertex locs : surfaceRAS" string in the output of `mris_info`, shown below:
```
...
ctr         : (-28, -14.5, 16.5)
vertex locs : surfaceRAS
...
```

The string was modified in Freesurfer 7.4.1 by adding more spaces:
```
...
ctr                     : (-28, -14.5, 16.5)
original vertex space   : surfaceRAS
vertex locs             : surfaceRAS
...
```

This breaks the check which fails with the following error:
```
Incorrect header information detected in /subject_dir/surf/lh.orig.nofix: vertex locs is not set to surfaceRAS. Exiting...
```

This PR makes the check robust to the number of spaces within the string by compressing all consecutive spaces to a single space before `grep`ing for "vertex locs : surfaceRAS". Therefore, the same check can be used with both Freesurfer 7.3.2 or 7.4.1 (and, hopefully, subsequent versions).

Tested with both Freesurfer versions on a 1mm case.