### PR TITLE
Reformat docstrings to Numpy style guide

### DIFF
--- a/FastSurferCNN/config/global_var.py
+++ b/FastSurferCNN/config/global_var.py
@@ -143,17 +143,18 @@ CLASS_DICT = {
 
 
 def get_class_names(plane, options):
-    """
+    """Get the class names
 
     Parameters
     ----------
     plane :
-        
+        [MISSING]
     options :
-        
+        [MISSING]
 
     Returns
     -------
+        [MISSING]
 
     """
     selection = []

--- a/FastSurferCNN/data_loader/augmentation.py
+++ b/FastSurferCNN/data_loader/augmentation.py
@@ -25,8 +25,7 @@ import torch
 # Transformations for evaluation
 ##
 class ToTensorTest(object):
-    """
-    Convert np.ndarrays in sample to Tensors
+    """Convert np.ndarrays in sample to Tensors.
 
     Methods
     -------
@@ -35,8 +34,7 @@ class ToTensorTest(object):
     """
 
     def __call__(self, img: npt.NDArray) -> np.ndarray:
-        """
-        Convertes the image to float within range [0, 1] and make it torch compatible
+        """Convert the image to float within range [0, 1] and make it torch compatible.
 
         Parameters
         ----------
@@ -47,8 +45,8 @@ class ToTensorTest(object):
         -------
         img : np.ndarray
             Conformed image
-        """
 
+        """
         img = img.astype(np.float32)
 
         # Normalize and clamp between 0 and 1
@@ -63,8 +61,7 @@ class ToTensorTest(object):
 
 
 class ZeroPad2DTest(object):
-    """
-    Pad the input with zeros to get output size
+    """Pad the input with zeros to get output size.
 
     Attributes
     ----------
@@ -73,9 +70,12 @@ class ZeroPad2DTest(object):
     pos : str
         position to put the input
 
-    Methods:
-        pad: pads zeroes of image
-        call: calls _pad()
+    Methods
+    -------
+    pad
+        pad zeroes of image
+    call
+        call _pad()
     """
 
     def __init__(
@@ -83,23 +83,23 @@ class ZeroPad2DTest(object):
             output_size: Union[Number, Tuple[Number, Number]],
             pos: str = 'top_left'
     ):
-        """ Constructor
+        """Construct object.
 
         Parameters
         ----------
         output_size : Union[Number, Tuple[Number, Number]]
             size of the output image either as Number or tuple of two Number
-         pos : Union[Number, Tuple[Number, Number]]
+        pos : Union[Number, Tuple[Number, Number]]
             position to put the input. Defaults to 'top_left'
+
         """
-        
         if isinstance(output_size, Number):
             output_size = (int(output_size),) * 2
         self.output_size = output_size
         self.pos = pos
 
     def _pad(self, image: npt.NDArray) -> np.ndarray:
-        """Pads with zeros of the input image
+        """Pad with zeros of the input image.
 
         Parameters
         ----------
@@ -112,7 +112,6 @@ class ZeroPad2DTest(object):
             original image with padded zeros
         
         """
-
         if len(image.shape) == 2:
             h, w = image.shape
             padded_img = np.zeros(self.output_size, dtype=image.dtype)
@@ -126,16 +125,19 @@ class ZeroPad2DTest(object):
         return padded_img
 
     def __call__(self, img: npt.NDArray) -> np.ndarray:
-        """
-        Calls the _pad() function
+        """Call the _pad() function.
 
-        Args:
-            img: the image to pad
+        Parameters
+        ----------
+        img : npt.NDArray
+            the image to pad
 
-        Returns:
+        Returns
+        -------
+        img : np.ndarray
             original image with padded zeros
-        """
 
+        """
         img = self._pad(img)
 
         return img
@@ -150,23 +152,24 @@ class ToTensor(object):
     Methods
     -------
     __call__
-        Converts image
+        Convert image
+
     """
 
     def __call__(self, sample: npt.NDArray) -> Dict[str, Any]:
-        """
-        Convertes the image to float within range [0, 1] and make it torch compatible
+        """Convert the image to float within range [0, 1] and make it torch compatible.
 
-        Args
-        ----
+        Parameters
+        ----------
         sample : npt.NDArray
             sample image
 
-        Returns:
-       Dict[str, Any]
+        Returns
+        -------
+        Dict[str, Any]
             Converted image
-        """
 
+        """
         img, label, weight, sf = (
             sample["img"],
             sample["label"],
@@ -193,7 +196,7 @@ class ToTensor(object):
 
 
 class ZeroPad2D(object):
-    """Pad the input with zeros to get output size
+    """Pad the input with zeros to get output size.
 
     Attributes
     ----------
@@ -208,6 +211,7 @@ class ZeroPad2D(object):
         Pads zeroes of image
     __call__
         Cals _pad for sample
+
     """
 
     def __init__(
@@ -215,7 +219,7 @@ class ZeroPad2D(object):
             output_size: Union[Number, Tuple[Number, Number]],
             pos: Union[None, str] = 'top_left'
     ):
-        """Initializes position and output_size (as Tuple[float])
+        """Initialize position and output_size (as Tuple[float]).
 
         Parameters
         ----------
@@ -224,15 +228,15 @@ class ZeroPad2D(object):
             tuple of two Number
         pos : str, Optional
             Position to put the input. Default = 'top_left'
-        """
 
+        """
         if isinstance(output_size, Number):
             output_size = (int(output_size),) * 2
         self.output_size = output_size
         self.pos = pos
 
     def _pad(self, image: npt.NDArray) -> np.ndarray:
-        """Pads the input image with zeros
+        """Pad the input image with zeros.
 
         Parameters
         ----------
@@ -244,9 +248,7 @@ class ZeroPad2D(object):
         padded_img : np.ndarray
             Original image with padded zeros
 
-        
         """
-
         if len(image.shape) == 2:
             h, w = image.shape
             padded_img = np.zeros(self.output_size, dtype=image.dtype)
@@ -260,19 +262,19 @@ class ZeroPad2D(object):
         return padded_img
 
     def __call__(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Pads the image, label and weights
+        """Pad the image, label and weights.
 
         Parameters
-        -------
+        ----------
         sample :Dict[str, Any]
             Sample image
 
         Returns
         -------
-       Dict[str, Any]
+        Dict[str, Any]
             Dictionary including the padded image, label, weight and scale factor
-        """
 
+        """
         img, label, weight, sf = (
             sample["img"],
             sample["label"],
@@ -288,18 +290,23 @@ class ZeroPad2D(object):
 
 
 class AddGaussianNoise(object):
-    """Add gaussian noise to sample
+    """Add gaussian noise to sample.
 
-    Attributes:
-        std: Standard deviation
-        mean: Gaussian mean
+    Attributes
+    ----------
+    std
+        Standard deviation
+    mean
+        Gaussian mean
 
-    Methods:
-        __call__: Adds noise to scale factor
+    Methods
+    -------
+    __call__
+        Adds noise to scale factor
     """
 
     def __init__(self, mean: Real = 0, std: Real = 0.1):
-        """Constructor
+        """Construct object.
 
         Parameters
         ----------
@@ -307,26 +314,25 @@ class AddGaussianNoise(object):
             Standard deviation. Default = 0
         std : Real
             Gaussian mean. Default = 0.1
-        """
 
+        """
         self.std = std
         self.mean = mean
 
     def __call__(self, sample: Dict[str, Real]) -> Dict[str, Real]:
-        """Adds gaussian noise to scalefactor
+        """Add gaussian noise to scalefactor.
 
-        Parameters:
-        -------
+        Parameters
+        ----------
         sample :Dict[str, Real]
             Sample data to add noise
 
-        Returns:
+        Returns
         -------
-       Dict[str, Real]
+        Dict[str, Real]
             Sample with noise
 
-         """
-
+        """
         img, label, weight, sf = (
             sample["img"],
             sample["label"],
@@ -339,8 +345,7 @@ class AddGaussianNoise(object):
 
 
 class AugmentationPadImage(object):
-    """
-    Pad Image with either zero padding or reflection padding of img, label and weight
+    """Pad Image with either zero padding or reflection padding of img, label and weight.
 
     Attributes
     ----------
@@ -348,10 +353,12 @@ class AugmentationPadImage(object):
         [missing]
     pad_size_mask
         [missing]
+
     Methods
     -------
      __call
-        ads zeroes
+        add zeroes
+
     """
 
     def __init__(
@@ -360,16 +367,16 @@ class AugmentationPadImage(object):
             Tuple[int, int]] = ((16, 16), (16, 16)),
             pad_type: str = "edge"
     ):
-        """ Constructor
+        """Construct object.
 
         Attributes
-        -------
+        ----------
         pad_size
             [MISSING]
         pad_type
             [MISSING]
-        """
 
+        """
         assert isinstance(pad_size, (int, tuple))
 
         if isinstance(pad_size, int):
@@ -384,13 +391,14 @@ class AugmentationPadImage(object):
         self.pad_type = pad_type
 
     def __call__(self, sample: Dict[str, Number]):
-        """
-        Pads zeroes of sample image, label and weight
+        """Pad zeroes of sample image, label and weight.
 
-        Args:
+        Attributes
+        ----------
+        sample : Dict[str, Number]
             Sample image and data
-        """
 
+        """
         img, label, weight, sf = (
             sample["img"],
             sample["label"],
@@ -406,10 +414,10 @@ class AugmentationPadImage(object):
 
 
 class AugmentationRandomCrop(object):
-    """Randomly Crop Image to given size"""
+    """Randomly Crop Image to given size."""
 
     def __init__(self, output_size: Union[int, Tuple], crop_type: str = 'Random'):
-        """Consturctor
+        """Construct object.
 
         Attributes
         ----------
@@ -418,7 +426,6 @@ class AugmentationRandomCrop(object):
         crop_type
             [MISSING]
         """
-
         assert isinstance(output_size, (int, tuple))
 
         if isinstance(output_size, int):
@@ -430,7 +437,7 @@ class AugmentationRandomCrop(object):
         self.crop_type = crop_type
 
     def __call__(self, sample: Dict[str, Number]) -> Dict[str, Number]:
-        """Crops the augmentation
+        """Crops the augmentation.
 
         Attributes
         ----------
@@ -441,8 +448,8 @@ class AugmentationRandomCrop(object):
         -------
         Dict[str, Number]
             Cropped sample image
-        """
 
+        """
         img, label, weight, sf = (
             sample["img"],
             sample["label"],

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -436,7 +436,7 @@ def conform(
         dtype: Optional[Type] = None,
         conform_to_1mm_threshold: Optional[float] = None
 ) -> nib.MGHImage:
-    f"""Python version of mri_convert -c, which by default turns image intensity values
+    """Python version of mri_convert -c, which by default turns image intensity values
     into UCHAR, reslices images to standard position, fills up slices to standard
     256x256x256 format and enforces 1mm or minimum isotropic voxel sizes.
     
@@ -551,7 +551,7 @@ def is_conform(
         verbose: bool = True,
         conform_to_1mm_threshold: Optional[float] = None
 ) -> bool:
-    f"""Function to check if an image is already conformed or not (Dimensions: 256x256x256,
+    """Function to check if an image is already conformed or not (Dimensions: 256x256x256,
     Voxel size: 1x1x1, LIA orientation, and data type UCHAR).
 
     Parameters
@@ -647,7 +647,7 @@ def get_conformed_vox_img_size(
         conform_vox_size: VoxSizeOption,
         conform_to_1mm_threshold: Optional[float] = None
 ) -> Tuple[float, int]:
-    f"""Extract the voxel size and the image size. This function only needs the header (not the data).
+    """Extract the voxel size and the image size. This function only needs the header (not the data).
 
     Parameters
     ----------
@@ -688,7 +688,7 @@ def check_affine_in_nifti(
         img: Union[nib.Nifti1Image, nib.Nifti2Image],
         logger: Optional[logging.Logger] = None
 ) -> bool:
-    f"""Function to check the affine in nifti Image. Sets affine with qform, if it exists
+    """Function to check the affine in nifti Image. Sets affine with qform, if it exists
     and differs from sform. If qform does not exist, voxel sizes between header
     information and information in affine are compared. In case these do not match,
     the function returns False (otherwise True).

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -51,7 +51,14 @@ h_order = "order of interpolation (0=nearest,1=linear(default),2=quadratic,3=cub
 
 
 def options_parse():
-    """Command line argument parser"""
+    """Command line option parser.
+
+    Returns
+    -------
+    options
+        object holding options
+
+    """
     parser = argparse.ArgumentParser(usage=HELPTEXT)
     parser.add_argument(
         "--version",
@@ -138,7 +145,7 @@ def map_image(
         order: int = 1,
         dtype: Optional[Type] = None
 ) -> np.ndarray:
-    """Function to map image to new voxel space (RAS orientation)
+    """Map image to new voxel space (RAS orientation).
 
     Parameters
     ----------
@@ -161,7 +168,6 @@ def map_image(
         mapped image data array
     
     """
-
     from scipy.ndimage import affine_transform
     from numpy.linalg import inv
 
@@ -197,7 +203,8 @@ def getscale(
         f_low: float = 0.0,
         f_high: float = 0.999
 ) -> Tuple[float, float]:
-    """Function to get offset and scale of image intensities to robustly rescale to range dst_min..dst_max.
+    """Get offset and scale of image intensities to robustly rescale to range dst_min..dst_max.
+
     Equivalent to how mri_convert conforms images.
 
     Parameters
@@ -220,7 +227,6 @@ def getscale(
     float
         scale factor
 
-    
     """
     # get min and max from source
     src_min = np.min(data)
@@ -296,7 +302,7 @@ def scalecrop(
         src_min: float,
         scale: float
 ) -> np.ndarray:
-    """Function to crop the intensity ranges to specific min and max values
+    """Crop the intensity ranges to specific min and max values.
 
     Parameters
     ----------
@@ -317,7 +323,6 @@ def scalecrop(
         scaled image data
     
     """
-
     data_new = dst_min + scale * (data - src_min)
 
     # clip
@@ -336,7 +341,7 @@ def rescale(
         f_low: float = 0.0,
         f_high: float = 0.999
 ) -> np.ndarray:
-    """Function to rescale image intensity values (0-255).
+    """Rescale image intensity values (0-255).
 
     Parameters
     ----------
@@ -357,14 +362,13 @@ def rescale(
         scaled image data
     
     """
-
     src_min, scale = getscale(data, dst_min, dst_max, f_low, f_high)
     data_new = scalecrop(data, dst_min, dst_max, src_min, scale)
     return data_new
 
 
 def find_min_size(img: nib.analyze.SpatialImage, max_size: float = 1) -> float:
-    """Function to find minimal voxel size <= 1mm.
+    """Find minimal voxel size <= 1mm.
 
     Parameters
     ----------
@@ -377,12 +381,12 @@ def find_min_size(img: nib.analyze.SpatialImage, max_size: float = 1) -> float:
     -------
     float
         Rounded minimal voxel size
+
     Notes
-    -------
+    -----
     This function only needs the header (not the data).
 
     """
-
     # find minimal voxel side length
     sizes = np.array(img.header.get_zooms()[:3])
     min_vox_size = np.round(np.min(sizes) * 10000) / 10000
@@ -395,8 +399,9 @@ def find_img_size_by_fov(
         vox_size: float,
         min_dim: int = 256
 ) -> int:
-    """Function to find the cube dimension (>= 256) to cover the field of view of img. If vox_size is one, the img_size
-    MUST always be min_dim (the FreeSurfer standard).
+    """Find the cube dimension (>= 256) to cover the field of view of img.
+
+    If vox_size is one, the img_size MUST always be min_dim (the FreeSurfer standard).
 
     Parameters
     ----------
@@ -411,11 +416,12 @@ def find_img_size_by_fov(
     -------
     int
         The number of voxels needed to cover field of view.
-    Notes
-    -------
-    This function only needs the header (not the data).
-    """
 
+    Notes
+    -----
+    This function only needs the header (not the data).
+
+    """
     if vox_size == 1.0:
         return min_dim
     # else (other voxel sizes may use different sizes)
@@ -436,14 +442,11 @@ def conform(
         dtype: Optional[Type] = None,
         conform_to_1mm_threshold: Optional[float] = None
 ) -> nib.MGHImage:
-    """Python version of mri_convert -c, which by default turns image intensity values
+    """Python version of mri_convert -c.
+
+    mri_convert -c by default turns image intensity values
     into UCHAR, reslices images to standard position, fills up slices to standard
     256x256x256 format and enforces 1mm or minimum isotropic voxel sizes.
-    
-    Notes:
-        Unlike mri_convert -c, we first interpolate (float image), and then rescale
-        to uchar. mri_convert is doing it the other way around. However, we compute
-        the scale factor from the input to increase similarity.
 
     Parameters
     ----------
@@ -466,9 +469,14 @@ def conform(
     -------
     nib.MGHImage
         conformed image
-    
-    """
 
+    Notes
+    -----
+    Unlike mri_convert -c, we first interpolate (float image), and then rescale
+    to uchar. mri_convert is doing it the other way around. However, we compute
+    the scale factor from the input to increase similarity.
+
+    """
     from nibabel.freesurfer.mghformat import MGHHeader
 
     conformed_vox_size, conformed_img_size = get_conformed_vox_img_size(
@@ -551,8 +559,9 @@ def is_conform(
         verbose: bool = True,
         conform_to_1mm_threshold: Optional[float] = None
 ) -> bool:
-    """Function to check if an image is already conformed or not (Dimensions: 256x256x256,
-    Voxel size: 1x1x1, LIA orientation, and data type UCHAR).
+    """Check if an image is already conformed or not.
+
+    Dimensions: 256x256x256, Voxel size: 1x1x1, LIA orientation, and data type UCHAR.
 
     Parameters
     ----------
@@ -585,10 +594,10 @@ def is_conform(
         Whether the image is already conformed.
 
     Notes
-    -------
+    -----
     This function only needs the header (not the data).
-    """
 
+    """
     conformed_vox_size, conformed_img_size = get_conformed_vox_img_size(
         img, conform_vox_size, conform_to_1mm_threshold=conform_to_1mm_threshold
     )
@@ -647,7 +656,9 @@ def get_conformed_vox_img_size(
         conform_vox_size: VoxSizeOption,
         conform_to_1mm_threshold: Optional[float] = None
 ) -> Tuple[float, int]:
-    """Extract the voxel size and the image size. This function only needs the header (not the data).
+    """Extract the voxel size and the image size.
+
+    This function only needs the header (not the data).
 
     Parameters
     ----------
@@ -660,10 +671,9 @@ def get_conformed_vox_img_size(
 
     Returns
     -------
-        [MISSING]
+    [MISSING]
     
     """
-
     # this is similar to mri_convert --conform_min
     if isinstance(conform_vox_size, str) and conform_vox_size.lower() in [
         "min",
@@ -688,10 +698,12 @@ def check_affine_in_nifti(
         img: Union[nib.Nifti1Image, nib.Nifti2Image],
         logger: Optional[logging.Logger] = None
 ) -> bool:
-    """Function to check the affine in nifti Image. Sets affine with qform, if it exists
-    and differs from sform. If qform does not exist, voxel sizes between header
-    information and information in affine are compared. In case these do not match,
-    the function returns False (otherwise True).
+    """Check the affine in nifti Image.
+
+    Sets affine with qform, if it exists and differs from sform.
+    If qform does not exist, voxel sizes between header information and information
+    in affine are compared.
+    In case these do not match, the function returns False (otherwise True).
 
     Parameters
     ----------
@@ -709,9 +721,7 @@ def check_affine_in_nifti(
     False, if
         voxel sizes in affine and header differ
 
-    
     """
-
     check = True
     message = ""
 

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -54,7 +54,8 @@ def load_and_conform_image(
         logger: logging.Logger = LOGGER,
         conform_min: bool = False
 ) -> Tuple[_Header, np.ndarray, np.ndarray]:
-    """Function to load MRI image and conform it to UCHAR, RAS orientation and 1mm or minimum isotropic voxels size.
+    """Load MRI image and conform it to UCHAR, RAS orientation and 1mm or minimum isotropic voxels size.
+
     Only, if it does not already have this format.
 
     Parameters
@@ -84,10 +85,7 @@ def load_and_conform_image(
     RuntimeError
         Inconsistency in nifti-header
 
-
-
     """
-
     orig = nib.load(img_filename)
     # is_conform and conform accept numeric values and the string 'min' instead of the bool value
     _conform_vox_size = "min" if conform_min else 1.0
@@ -132,7 +130,6 @@ def load_image(
     name : str
         name of the file (optional), only effects error messages. (Default value = "image")
     **kwargs :
-
 
     Returns
     -------
@@ -247,6 +244,7 @@ def save_image(
         dtype: Optional[npt.DTypeLike] = None
 ) -> None:
     """Save an image (nibabel MGHImage), according to the desired output file format.
+
     Supported formats are defined in supported_output_file_formats. Saves predictions to save_as
 
     Parameters
@@ -264,7 +262,6 @@ def save_image(
          (Default value = None)
 
     """
-
     assert any(
         save_as.endswith(file_ext) for file_ext in SUPPORTED_OUTPUT_FILE_FORMATS
     ), (
@@ -294,7 +291,7 @@ def transform_axial(
         vol: npt.NDArray,
         coronal2axial: bool = True
 ) -> np.ndarray:
-    """Function to transform volume into Axial axis and back
+    """Transform volume into Axial axis and back.
 
     Parameters
     ----------
@@ -307,8 +304,8 @@ def transform_axial(
     -------
     np.ndarray
         Transformed image
-    """
 
+    """
     if coronal2axial:
         return np.moveaxis(vol, [0, 1, 2], [1, 2, 0])
     else:
@@ -319,7 +316,7 @@ def transform_sagittal(
         vol: npt.NDArray,
         coronal2sagittal: bool = True
 ) -> np.ndarray:
-    """Function to transform volume into Sagittal axis and back
+    """Transform volume into Sagittal axis and back.
 
     Parameters
     ----------
@@ -333,9 +330,7 @@ def transform_sagittal(
     np.ndarray:
         transformed image
 
-
     """
-
     if coronal2sagittal:
         return np.moveaxis(vol, [0, 1, 2], [2, 1, 0])
     else:
@@ -347,9 +342,10 @@ def get_thick_slices(
         img_data: npt.NDArray,
         slice_thickness: int = 3
 ) -> np.ndarray:
-    """Function to extract thick slices from the image
-    (feed slice_thickness preceding and succeeding slices to network,
-    label only middle one)
+    """Extract thick slices from the image.
+
+    Feed slice_thickness preceding and succeeding slices to network,
+    label only middle one
 
     Parameters
     ----------
@@ -360,8 +356,9 @@ def get_thick_slices(
 
     Returns
     -------
-        np.ndarray
-            image data with the thick slices of the n-th axis appended into the n+1-th axis.
+    np.ndarray
+        image data with the thick slices of the n-th axis appended into the n+1-th axis.
+
     """
     img_data_pad = np.pad(
         img_data, ((0, 0), (0, 0), (slice_thickness, slice_thickness)), mode="edge"
@@ -379,7 +376,7 @@ def filter_blank_slices_thick(
         weight_vol: npt.NDArray,
         threshold: int = 50
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Function to filter blank slices from the volume using the label volume
+    """Filter blank slices from the volume using the label volume.
 
     Parameters
     ----------
@@ -400,8 +397,8 @@ def filter_blank_slices_thick(
         [MISSING]
     weight_vol : np.ndarray
         [MISSING]
-    """
 
+    """
     # Get indices of all slices with more than threshold labels/pixels
     select_slices = np.sum(label_vol, axis=(0, 1)) > threshold
 
@@ -424,7 +421,7 @@ def create_weight_mask(
         cortex_mask: bool = True,
         gradient: bool = True
 ) -> np.ndarray:
-    """Function to create weighted mask - with median frequency balancing and edge-weighting
+    """Create weighted mask - with median frequency balancing and edge-weighting.
 
     Parameters
     ----------
@@ -451,7 +448,6 @@ def create_weight_mask(
         Weights
 
     """
-
     unique, counts = np.unique(mapped_aseg, return_counts=True)
 
     # Median Frequency Balancing
@@ -499,8 +495,7 @@ def cortex_border_mask(
         structure: npt.NDArray,
         ctx_thresh: int = 33
 ) -> np.ndarray:
-    """Function to erode the cortex of a given mri image to create
-    the inner gray matter mask (outer most cortex voxels)
+    """Erode the cortex of a given mri image to create the inner gray matter mask (outer most cortex voxels).
 
     Parameters
     ----------
@@ -516,9 +511,7 @@ def cortex_border_mask(
     np.ndarray
         inner grey matter layer
 
-
     """
-
     # create aseg brainmask, erode it and subtract from itself
     bm = np.clip(label, a_max=1, a_min=0)
     eroded = binary_erosion(bm, structure=structure)
@@ -536,8 +529,7 @@ def deep_sulci_and_wm_strand_mask(
         iteration: int = 1,
         ctx_thresh: int = 33
 ) -> np.ndarray:
-    """Function to get a binary mask of deep sulci and small white matter strands
-     by using binary closing (erosion and dilation)
+    """Get a binary mask of deep sulci and small white matter strands by using binary closing (erosion and dilation).
 
     Parameters
     ----------
@@ -556,7 +548,6 @@ def deep_sulci_and_wm_strand_mask(
         sulcus + wm mask
 
     """
-
     # Binarize label image (cortex = 1, everything else = 0)
     empty_im = np.zeros(shape=volume.shape)
     empty_im[volume > ctx_thresh] = 1  # > 33 (>19) = >1002 in FS LUT (full (sag))
@@ -574,7 +565,7 @@ def deep_sulci_and_wm_strand_mask(
 
 # Label mapping functions (to aparc (eval) and to label (train))
 def read_classes_from_lut(lut_file: str) -> pd.DataFrame:
-    """Function to read in FreeSurfer-like LUT table
+    """Read in FreeSurfer-like LUT table.
 
     Parameters
     ----------
@@ -590,7 +581,6 @@ def read_classes_from_lut(lut_file: str) -> pd.DataFrame:
     pd.Dataframe
         DataFrame with ids present, name of ids, color for plotting
 
-
     """
     # Read in file
     separator = {"tsv": "\t", "csv": ",", "txt": " "}
@@ -601,7 +591,7 @@ def map_label2aparc_aseg(
         mapped_aseg: torch.Tensor,
         labels: Union[torch.Tensor, npt.NDArray]
 ) -> torch.Tensor:
-    """Function to perform look-up table mapping from sequential label space to LUT space
+    """Perform look-up table mapping from sequential label space to LUT space.
 
     Parameters
     ----------
@@ -616,7 +606,6 @@ def map_label2aparc_aseg(
         labels in LUT space
 
     """
-
     if isinstance(labels, np.ndarray):
         labels = torch.from_numpy(labels)
     labels = labels.to(mapped_aseg.device)
@@ -624,12 +613,13 @@ def map_label2aparc_aseg(
 
 
 def clean_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
-    """Function to clean up aparc segmentations:
-        Map undetermined and optic chiasma to BKG
-        Map Hypointensity classes to one
-        Vessel to WM
-        5th Ventricle to CSF
-        Remaining cortical labels to BKG
+    """Clean up aparc segmentations.
+
+    Map undetermined and optic chiasma to BKG
+    Map Hypointensity classes to one
+    Vessel to WM
+    5th Ventricle to CSF
+    Remaining cortical labels to BKG
 
     Parameters
     ----------
@@ -642,7 +632,6 @@ def clean_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
         cleaned aparc
 
     """
-
     aparc[aparc == 80] = 77  # Hypointensities Class
     aparc[aparc == 85] = 0  # Optic Chiasma to BKG
     aparc[aparc == 62] = 41  # Right Vessel to Right WM
@@ -661,7 +650,7 @@ def fill_unknown_labels_per_hemi(
         unknown_label: int,
         cortex_stop: int
 ) -> np.ndarray:
-    """Function to replace label 1000 (lh unknown) and 2000 (rh unknown) with closest class for each voxel.
+    """Replace label 1000 (lh unknown) and 2000 (rh unknown) with closest class for each voxel.
 
     Parameters
     ----------
@@ -674,11 +663,10 @@ def fill_unknown_labels_per_hemi(
 
     Returns
     -------
-        np.ndarray
-            ground truth segmentation with all classes
+    np.ndarray
+        ground truth segmentation with all classes
 
     """
-
     # Define shape of image and dilation element
     h, w, d = gt.shape
     struct1 = generate_binary_structure(3, 2)
@@ -712,7 +700,7 @@ def fill_unknown_labels_per_hemi(
 
 
 def fuse_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
-    """Fuse cortical parcels on left/right hemisphere (reduce aparc classes)
+    """Fuse cortical parcels on left/right hemisphere (reduce aparc classes).
 
     Parameters
     ----------
@@ -725,7 +713,6 @@ def fuse_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
         anatomical segmentation with reduced number of cortical parcels
 
     """
-
     aparc_temp = aparc.copy()
 
     # Map undetermined classes
@@ -761,7 +748,7 @@ def fuse_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
 
 
 def split_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
-    """Splot cortex labels to completely de-lateralize structures
+    """Splot cortex labels to completely de-lateralize structures.
 
     Parameters
     ----------
@@ -774,7 +761,6 @@ def split_cortex_labels(aparc: npt.NDArray) -> np.ndarray:
         re-lateralized aparc
 
     """
-
     # Post processing - Splitting classes
     # Quick Fix for 2026 vs 1026; 2029 vs. 1029; 2025 vs. 1025
     rh_wm = get_largest_cc(aparc == 41)
@@ -854,7 +840,7 @@ def unify_lateralized_labels(
         lut: Union[str, pd.DataFrame],
         combi: Tuple[str, str] = ("Left-", "Right-")
 ) -> Mapping:
-    """Function to generate lookup dictionary of left-right labels
+    """Generate lookup dictionary of left-right labels.
 
     Parameters
     ----------
@@ -873,7 +859,6 @@ def unify_lateralized_labels(
         dictionary mapping between left and right hemispheres
 
     """
-
     if isinstance(lut, str):
         lut = read_classes_from_lut(lut)
     left = lut[["ID", "LabelName"]][lut["LabelName"].str.startswith(combi[0])]
@@ -888,7 +873,7 @@ def get_labels_from_lut(
         lut: Union[str, pd.DataFrame],
         label_extract: Tuple[str, str] = ("Left-", "ctx-rh")
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Function to extract labels from the lookup tables
+    """Extract labels from the lookup tables.
 
     Parameters
     ----------
@@ -911,7 +896,6 @@ def get_labels_from_lut(
         sagittal label list
 
     """
-
     if isinstance(lut, str):
         lut = read_classes_from_lut(lut)
     mask = lut["LabelName"].str.startswith(label_extract)
@@ -926,7 +910,7 @@ def map_aparc_aseg2label(
         aseg_nocc: Optional[npt.NDArray] = None,
         processing:  str = "aparc"
 ) ->  Tuple[np.ndarray, np.ndarray]:
-    """Function to perform look-up table mapping of aparc.DKTatlas+aseg.mgz data to label space
+    """Perform look-up table mapping of aparc.DKTatlas+aseg.mgz data to label space.
 
     Parameters
     ----------
@@ -953,7 +937,6 @@ def map_aparc_aseg2label(
         mapped aseg for sagital
 
     """
-
     # If corpus callosum is not removed yet, do it now
     if aseg_nocc is not None:
         cc_mask = (aseg >= 251) & (aseg <= 255)
@@ -1018,7 +1001,7 @@ def map_aparc_aseg2label(
 
 
 def sagittal_coronal_remap_lookup(x: int) -> int:
-    """Dictionary mapping to convert left labels to corresponding right labels for aseg
+    """Convert left labels to corresponding right labels for aseg with dictionary mapping.
 
     Parameters
     ----------
@@ -1031,7 +1014,6 @@ def sagittal_coronal_remap_lookup(x: int) -> int:
         mapped label
 
     """
-
     return {
         2: 41,
         3: 42,
@@ -1055,7 +1037,7 @@ def infer_mapping_from_lut(
         num_classes_full: int,
         lut: Union[str, pd.DataFrame]
 ) -> np.ndarray:
-    """[MISSING]
+    """[MISSING].
 
     Parameters
     ----------
@@ -1070,7 +1052,6 @@ def infer_mapping_from_lut(
         list of indexes for
 
     """
-
     labels, labels_sag = unify_lateralized_labels(lut)
     idx_list = np.ndarray(shape=(num_classes_full,), dtype=np.int16)
     for idx in range(len(labels)):
@@ -1091,8 +1072,9 @@ def map_prediction_sagittal2full(
         num_classes: int = 51,
         lut: Optional[str] = None
 ) -> np.ndarray:
-    """Function to remap the prediction on the sagittal network to full label space used by coronal and axial networks
-    Creates full aparc.DKTatlas+aseg.mgz.
+    """Remap the prediction on the sagittal network to full label space used by coronal and axial networks.
+
+    Create full aparc.DKTatlas+aseg.mgz.
 
     Parameters
     ----------
@@ -1109,7 +1091,6 @@ def map_prediction_sagittal2full(
         Remapped prediction
 
     """
-
     if num_classes == 96:
         idx_list = np.asarray(
             [
@@ -1353,8 +1334,7 @@ def map_prediction_sagittal2full(
 def bbox_3d(
         img: npt.NDArray
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """[MISSING]
-    Function to extract the three-dimensional bounding box coordinates.
+    """Extract the three-dimensional bounding box coordinates.
 
     Parameters
     ----------
@@ -1377,7 +1357,6 @@ def bbox_3d(
         zmax
 
     """
-
     r = np.any(img, axis=(1, 2))
     c = np.any(img, axis=(0, 2))
     z = np.any(img, axis=(0, 1))
@@ -1390,7 +1369,7 @@ def bbox_3d(
 
 
 def get_largest_cc(segmentation: npt.NDArray) -> np.ndarray:
-    """Function to find largest connected component of segmentation.
+    """Find the largest connected component of segmentation.
 
     Parameters
     ----------
@@ -1402,9 +1381,7 @@ def get_largest_cc(segmentation: npt.NDArray) -> np.ndarray:
     np.ndarray
         largest connected component of segmentation (binary mask)
 
-
     """
-
     labels = label(segmentation, connectivity=3, background=0)
 
     bincount = np.bincount(labels.flat)

--- a/FastSurferCNN/data_loader/dataset.py
+++ b/FastSurferCNN/data_loader/dataset.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 # Operator to load imaged for inference
 class MultiScaleOrigDataThickSlices(Dataset):
-    """Class to load MRI-Image and process it to correct format for network inference"""
+    """Load MRI-Image and process it to correct format for network inference."""
 
     def __init__(
             self,
@@ -42,7 +42,7 @@ class MultiScaleOrigDataThickSlices(Dataset):
             cfg: yacs.config.CfgNode,
             transforms: Optional = None
     ):
-        """Constructor
+        """Construct object.
 
         Parameters
         ----------
@@ -54,8 +54,8 @@ class MultiScaleOrigDataThickSlices(Dataset):
             Configuration Node
         transforms : Optional
             Transformer for the image. Defaults to None
-        """
 
+        """
         assert (
                 orig_data.max() > 0.8
         ), f"Multi Dataset - orig fail, max removed {orig_data.max()}"
@@ -85,10 +85,9 @@ class MultiScaleOrigDataThickSlices(Dataset):
         self.transforms = transforms
 
     def _get_scale_factor(self) -> npt.NDArray[float]:
-        """Get scaling factor to match original resolution of input image to
-        final resolution of FastSurfer base network. Input resolution is
-        taken from voxel size in image header.
-        
+        """Get scaling factor to match original resolution of input image to final resolution of FastSurfer base network.
+
+        Input resolution is taken from voxel size in image header.
         ToDO: This needs to be updated based on the plane we are looking at in case we
         are dealing with non-isotropic images as inputs.
 
@@ -98,13 +97,12 @@ class MultiScaleOrigDataThickSlices(Dataset):
             scale factor along x and y dimension
         
         """
-
         scale = self.base_res / np.asarray(self.zoom)
 
         return scale
 
     def __getitem__(self, index: int) -> Dict:
-        """Returns a single image and its scale factor
+        """Return a single image and its scale factor.
 
         Parameters
         ----------
@@ -126,13 +124,19 @@ class MultiScaleOrigDataThickSlices(Dataset):
         return {"image": img, "scale_factor": scale_factor}
 
     def __len__(self) -> int:
-        # Returns count
+        """Return length.
+
+        Returns
+        -------
+        int
+            count
+        """
         return self.count
 
 
 # Operator to load hdf5-file for training
 class MultiScaleDataset(Dataset):
-    """Class for loading aseg file with augmentations (transforms)"""
+    """Class for loading aseg file with augmentations (transforms)."""
 
     def __init__(
             self,
@@ -141,7 +145,7 @@ class MultiScaleDataset(Dataset):
             gn_noise: bool = False,
             transforms: Optional = None
     ):
-        """Constructor
+        """Construct object.
 
         Parameters
         ----------
@@ -153,8 +157,8 @@ class MultiScaleDataset(Dataset):
             Whether to add gaussian noise (Default value = False)
         transforms : Optional
             Transformer to apply to the image (Default value = None)
-        """
 
+        """
         self.max_size = cfg.DATA.PADDED_SIZE
         self.base_res = cfg.MODEL.BASE_RES
         self.gn_noise = gn_noise
@@ -221,6 +225,13 @@ class MultiScaleDataset(Dataset):
             )
 
     def get_subject_names(self):
+        """Get the subject name.
+
+        Returns
+        -------
+        list
+            list of subject names
+        """
         return self.subjects
 
     def _get_scale_factor(
@@ -228,9 +239,9 @@ class MultiScaleDataset(Dataset):
             img_zoom: torch.Tensor,
             scale_aug: torch.Tensor
     ) -> npt.NDArray[float]:
-        """Get scaling factor to match original resolution of input image to
-        final resolution of FastSurfer base network. Input resolution is
-        taken from voxel size in image header.
+        """Get scaling factor to match original resolution of input image to final resolution of FastSurfer base network.
+
+        Input resolution is taken from voxel size in image header.
         
         ToDO: This needs to be updated based on the plane we are looking at in case we
         are dealing with non-isotropic images as inputs.
@@ -248,7 +259,6 @@ class MultiScaleDataset(Dataset):
             scale factor along x and y dimension
         
         """
-
         if torch.all(scale_aug > 0):
             img_zoom *= 1 / scale_aug
 
@@ -266,7 +276,7 @@ class MultiScaleDataset(Dataset):
             self,
             image: npt.NDArray
     ) ->  np.ndarray:
-        """Pads the image with zeros
+        """Pad the image with zeros.
 
         Parameters
         ----------
@@ -278,9 +288,7 @@ class MultiScaleDataset(Dataset):
         padded_image
             Padded image
 
-        
         """
-
         if len(image.shape) == 2:
             h, w = image.shape
             padded_img = np.zeros((self.max_size, self.max_size), dtype=image.dtype)
@@ -302,7 +310,7 @@ class MultiScaleDataset(Dataset):
             label: npt.NDArray,
             weight: npt.NDArray
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """Pads img, label and weight
+        """Pad img, label and weight.
 
         Parameters
         ----------
@@ -323,7 +331,6 @@ class MultiScaleDataset(Dataset):
             weight
         
         """
-
         img = self._pad(img)
         label = self._pad(label)
         weight = self._pad(weight)
@@ -331,7 +338,18 @@ class MultiScaleDataset(Dataset):
         return img, label, weight
 
     def __getitem__(self, index):
+        """[MISSING].
 
+        Parameters
+        ----------
+        index :
+            [MISSING]
+
+        Returns
+        -------
+        [MISSING]
+
+        """
         padded_img, padded_label, padded_weight = self.unify_imgs(
             self.images[index], self.labels[index], self.weights[index]
         )
@@ -378,12 +396,13 @@ class MultiScaleDataset(Dataset):
         }
 
     def __len__(self):
+        """Return count."""
         return self.count
 
 
 # Operator to load hdf5-file for validation
 class MultiScaleDatasetVal(Dataset):
-    """Class for loading aseg file with augmentations (transforms)"""
+    """Class for loading aseg file with augmentations (transforms)."""
 
     def __init__(self, dataset_path, cfg, transforms=None):
 
@@ -451,12 +470,13 @@ class MultiScaleDatasetVal(Dataset):
         )
 
     def get_subject_names(self):
+        """Get subject names."""
         return self.subjects
 
     def _get_scale_factor(self, img_zoom):
-        """Get scaling factor to match original resolution of input image to
-        final resolution of FastSurfer base network. Input resolution is
-        taken from voxel size in image header.
+        """Get scaling factor to match original resolution of input image to final resolution of FastSurfer base network.
+
+        Input resolution is taken from voxel size in image header.
         
         ToDO: This needs to be updated based on the plane we are looking at in case we
         are dealing with non-isotropic images as inputs.
@@ -471,13 +491,12 @@ class MultiScaleDatasetVal(Dataset):
         np.ndarray : float32
             scale factor along x and y dimension
 
-        
         """
         scale = self.base_res / img_zoom
         return scale
 
     def __getitem__(self, index):
-
+        """Get item."""
         img = self.images[index]
         label = self.labels[index]
         weight = self.weights[index]
@@ -506,4 +525,5 @@ class MultiScaleDatasetVal(Dataset):
         }
 
     def __len__(self):
+        """Get count."""
         return self.count

--- a/FastSurferCNN/data_loader/loader.py
+++ b/FastSurferCNN/data_loader/loader.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_dataloader(cfg: yacs.config.CfgNode, mode: str):
-    """Creating the dataset and pytorch data loader
+    """Create the dataset and pytorch data loader.
 
     Parameters
     ----------

--- a/FastSurferCNN/generate_hdf5.py
+++ b/FastSurferCNN/generate_hdf5.py
@@ -42,41 +42,68 @@ LOGGER = logging.getLogger(__name__)
 
 
 class H5pyDataset:
-    """Functions:
-        __init__(params, processing): Consturctor
-        _load_volumes(subject_path): load image and segmentation volume
-        transform(plane, imgs, zoom): transform image along axis
-        _pad_image(img, max_out): pads image with zeroes
-        create_hdf5_dataset(plane): creates a hdf5 file
+    """Class representing H5py Dataset.
+
+    Methods
+    -------
+    __init__
+        Consturctor
+    _load_volumes
+        load image and segmentation volume
+    transform
+        Transform image along axis
+    _pad_image
+        Pad image with zeroes
+    create_hdf5_dataset
+        Create a hdf5 file
     
-    Variables:
-        dataset_name (str): path and name of hdf5-data_loader
-        data_path (str): Directory with images to load
-        slice_thickness (int): Number of pre- and succeeding slices
-        orig_name (str): Default name of original images
-        aparc_name (str): Default name for ground truth segmentations.
-        aparc_nocc (str): Segmentation without corpus callosum (used to mask this segmentation in ground truth).
-                        If the used segmentation was already processed, do not set this argument
-        available_sizes (int): Sizes of images in the dataset.
-        max_weight (int): Overall max weight for any voxel in weight mask.
-        edge_weight (int): Weight for edges in weight mask.
-        hires_weight (int): Weight for hires elements (sulci, WM strands, cortex border) in weight mask.
-        gradient (bool): Turn on to only use median weight frequency (no gradient)
-        gm_mask (bool): Turn on to add cortex mask for hires-processing.
-        lut (pd.Dataframe): DataFrame with ids present, name of ids, color for plotting
-        labels (np.ndarray): full label list
-        labels_sag (np.ndarray): sagittal label list
-        lateralization (Dict): dictionary mapping between left and right hemispheres
-        subject_dirs (list[str]): list ob subject directory names
-        search_pattern (str): Pattern to match files in directory
-        data_set_size (int): number of subjects
-        processing (str): Use aseg, aparc or no specific mapping processing (Default: "aparc")
+    Attributes
+    ----------
+    dataset_name : str
+        Path and name of hdf5-data_loader
+    data_path : str
+        Directory with images to load
+    slice_thickness : int
+        Number of pre- and succeeding slices
+    orig_name : str
+        Default name of original images
+    aparc_name : str
+        Default name for ground truth segmentations.
+    aparc_nocc : str
+        Segmentation without corpus callosum (used to mask this segmentation in ground truth).
+        If the used segmentation was already processed, do not set this argument
+    available_sizes : int
+        Sizes of images in the dataset.
+    max_weight : int
+        Overall max weight for any voxel in weight mask.
+    edge_weight : int
+        Weight for edges in weight mask.
+    hires_weight : int
+        Weight for hires elements (sulci, WM strands, cortex border) in weight mask.
+    gradient : bool
+        Turn on to only use median weight frequency (no gradient)
+    gm_mask : bool
+        Turn on to add cortex mask for hires-processing.
+    lut : pd.Dataframe
+        DataFrame with ids present, name of ids, color for plotting
+    labels : np.ndarray
+        full label list
+    labels_sag : np.ndarray
+        sagittal label list
+    lateralization : Dict
+        dictionary mapping between left and right hemispheres
+    subject_dirs : List[str]
+        list ob subject directory names
+    search_pattern : str
+        Pattern to match files in directory
+    data_set_size : int
+        Number of subjects
+    processing : str
+        Use aseg, aparc or no specific mapping processing (Default: "aparc")
     """
 
     def __init__(self, params: Dict, processing: str = "aparc"):
-        """Constructor
-        
-        Args:
+        """Construct H5pyDataset object.
 
         Parameters
         ----------
@@ -103,7 +130,6 @@ class H5pyDataset:
             Use aseg (Default value = "aparc")
 
         """
-
         self.dataset_name = params["dataset_name"]
         self.data_path = params["data_path"]
         self.slice_thickness = params["thickness"]
@@ -136,7 +162,8 @@ class H5pyDataset:
 
     def _load_volumes(self, subject_path: str
                       ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Tuple]:
-        """load the given image and segmentation and gets the zoom values.
+        """Load the given image and segmentation and gets the zoom values.
+
         Checks if an aseg-nocc file is set and loads it instead
 
         Parameters
@@ -156,7 +183,6 @@ class H5pyDataset:
             zoom values
         
         """
-
         # Load the orig and extract voxel spacing information (x, y, and z dim)
         LOGGER.info(
             "Processing intensity image {} and ground truth segmentation {}".format(
@@ -182,7 +208,7 @@ class H5pyDataset:
 
     def transform(self, plane: str, imgs: npt.NDArray, zoom: npt.NDArray
                   ) -> Tuple[npt.NDArray, npt.NDArray]:
-        """Function to transform the image and zoom along the given axis
+        """Transform the image and zoom along the given axis.
 
         Parameters
         ----------
@@ -200,9 +226,7 @@ class H5pyDataset:
         npt.NDArray
             transformed zoom facors
 
-        
         """
-
         for i in range(len(imgs)):
             if self.plane == "sagittal":
                 imgs[i] = transform_sagittal(imgs[i])
@@ -215,7 +239,7 @@ class H5pyDataset:
         return imgs, zooms
 
     def _pad_image(self, img: npt.NDArray, max_out: int) -> np.ndarray:
-        """Pads the margins of the input image with zeros
+        """Pad the margins of the input image with zeros.
 
         Parameters
         ----------
@@ -230,7 +254,6 @@ class H5pyDataset:
             0-padded image to the given size
         
         """
-
         # Get correct size = max along shape
         h, w, d = img.shape
         LOGGER.info("Padding image from {0} to {1}x{1}x{1}".format(img.shape, max_out))
@@ -239,7 +262,7 @@ class H5pyDataset:
         return padded_img
 
     def create_hdf5_dataset(self, blt: int):
-        """Create a hdf5 dataset
+        """Create a hdf5 dataset.
 
         Parameters
         ----------
@@ -247,7 +270,6 @@ class H5pyDataset:
             Blank sliec threshold
 
         """
-
         data_per_size = defaultdict(lambda: defaultdict(list))
         start_d = time.time()
 

--- a/FastSurferCNN/inference.py
+++ b/FastSurferCNN/inference.py
@@ -36,28 +36,43 @@ logger = logging.getLogger(__name__)
 
 
 class Inference:
-    """Model evaluation class to run inference using FastSurferCNN
+    """Model evaluation class to run inference using FastSurferCNN.
     
-    Functions:
-        __init__(cfg, device, ckpt): Constructor
-        setup_model(cfg, device): Set up the initial model
-        set_cfg(cfg): Set configuration node
-        to(device): Moves and/or casts the parameters and buffers.
-        load_checkpoint(ckpt): function to load the checkpoint
-        eval(init_pred, val_loader, *, out_scale, out): evaluate predictions
-        run(init_pred, img_filename, orig_data, orig_zoom, out, out_res, batch_size): run the loaded model
+    Methods
+    -------
+    setup_model
+        Set up the initial model
+    set_cfg
+        Set configuration node
+    to
+        Moves and/or casts the parameters and buffers.
+    load_checkpoint
+        Load the checkpoint
+    eval
+        Evaluate predictions
+    run
+        Run the loaded model
 
-    Attributes:
-        permute_order (Dict[str, Tuple[int, int, int, int]]): permutation order for axial, coronal, and sagittal
-        device (Optional[torch.device]): device specification for distributed computation usage.
-        default_device (torch.device): default device specification for distributed computation usage.
-        cfg (yacs.config.CfgNode): configuration Node
-        model_parallel (bool): option for parallel run
-        model (torch.nn.Module): neural network model
-        model_name (str): name of the model
-        alpha (Dict[str, float]): [MISSING]
-        post_prediction_mapping_hook (): [MISSING]
-
+    Attributes
+    ----------
+    permute_order : Dict[str, Tuple[int, int, int, int]]
+        Permutation order for axial, coronal, and sagittal
+    device : Optional[torch.device])
+        Device specification for distributed computation usage.
+    default_device : torch.device
+        Default device specification for distributed computation usage.
+    cfg : yacs.config.CfgNode
+        Configuration Node
+    model_parallel : bool
+        Option for parallel run
+    model : torch.nn.Module
+        Neural network model
+    model_name : str
+        Name of the model
+    alpha : Dict[str, float]
+        [MISSING]
+    post_prediction_mapping_hook
+        [MISSING]
     """
 
     permute_order: Dict[str, Tuple[int, int, int, int]]
@@ -71,7 +86,7 @@ class Inference:
             ckpt: str = "",
             lut: Union[None, str, np.ndarray, DataFrame] = None
     ):
-        """Constructor
+        """Construct Inference object.
 
         Parameters
         ----------
@@ -82,10 +97,9 @@ class Inference:
         ckpt : str
             string or os.PathLike object containing the name to the checkpoint file (Default value = "")
         lut : Union[None, str, np.ndarray, DataFrame]
-             (Default value = None)
+             [MISSING] (Default value = None)
 
         """
-
         # Set random seed from configs.
         np.random.seed(cfg.RNG_SEED)
         torch.manual_seed(cfg.RNG_SEED)
@@ -124,7 +138,7 @@ class Inference:
             self.load_checkpoint(ckpt)
 
     def setup_model(self, cfg=None, device: torch.device = None):
-        """function to set up the model
+        """Set up the model.
 
         Parameters
         ----------
@@ -134,7 +148,6 @@ class Inference:
             device specification for distributed computation usage. (Default value = None)
 
         """
-
         if cfg is not None:
             self.cfg = cfg
         if device is None:
@@ -148,18 +161,18 @@ class Inference:
         self.device = None
 
     def set_cfg(self, cfg: yacs.config.CfgNode):
-        """[MISSING]
+        """[MISSING].
 
         Parameters
         ----------
         cfg : yacs.config.CfgNode
-            
+            Configuration node
 
         """
         self.cfg = cfg
 
     def to(self, device: Optional[torch.device] = None):
-        """Moves and/or casts the parameters and buffers.
+        """Move and/or cast the parameters and buffers.
 
         Parameters
         ----------
@@ -167,7 +180,6 @@ class Inference:
             the desired device of the parameters and buffers in this module (Default value = None)
 
         """
-
         if self.model_parallel:
             raise RuntimeError(
                 "Moving the model to other devices is not supported for multi-device models."
@@ -177,7 +189,7 @@ class Inference:
         self.model.to(device=_device)
 
     def load_checkpoint(self, ckpt: Union[str, os.PathLike]):
-        """function to load the checkpoint and set device and model
+        """Load the checkpoint and set device and model.
 
         Parameters
         ----------
@@ -185,7 +197,6 @@ class Inference:
             string or os.PathLike object containing the name to the checkpoint file
 
         """
-
         logger.info("Loading checkpoint {}".format(ckpt))
 
         self.model = self._model_not_init
@@ -213,30 +224,38 @@ class Inference:
             self.model = torch.nn.DataParallel(self.model)
 
     def get_modelname(self):
+        """Return the model name."""
         return self.model_name
 
     def get_cfg(self):
+        """Return the configurations."""
         return self.cfg
 
     def get_num_classes(self):
+        """Return the number of classes."""
         return self.cfg.MODEL.NUM_CLASSES
 
     def get_plane(self):
+        """Return the plane."""
         return self.cfg.DATA.PLANE
 
     def get_model_height(self):
+        """Return the model height."""
         return self.cfg.MODEL.HEIGHT
 
     def get_model_width(self):
+        """Return the model width."""
         return self.cfg.MODEL.WIDTH
 
     def get_max_size(self):
+        """Return the max size."""
         if self.cfg.MODEL.OUT_TENSOR_WIDTH == self.cfg.MODEL.OUT_TENSOR_HEIGHT:
             return self.cfg.MODEL.OUT_TENSOR_WIDTH
         else:
             return self.cfg.MODEL.OUT_TENSOR_WIDTH, self.cfg.MODEL.OUT_TENSOR_HEIGHT
 
     def get_device(self):
+        """Return the device."""
         return self.device
 
     @torch.no_grad()
@@ -269,7 +288,6 @@ class Inference:
             prediction probability tensor
         
         """
-
         self.model.eval()
         # we should check here, whether the DataLoader is a Random or a SequentialSampler, but we cannot easily.
         if not isinstance(val_loader.sampler, torch.utils.data.SequentialSampler):
@@ -350,8 +368,7 @@ class Inference:
             out_res: Optional[int] = None,
             batch_size: int = None
     ) -> torch.Tensor:
-        """[MISSING]
-        Run the loaded model on the data (T1) from orig_data and img_filename (for messages only)  with scale factors orig_zoom.
+        """Run the loaded model on the data (T1) from orig_data and img_filename (for messages only)  with scale factors orig_zoom.
 
         Parameters
         ----------
@@ -376,7 +393,6 @@ class Inference:
             prediction probability tensor
         
         """
-
         # Set up DataLoader
         test_dataset = MultiScaleOrigDataThickSlices(
             orig_data,

--- a/FastSurferCNN/models/losses.py
+++ b/FastSurferCNN/models/losses.py
@@ -24,10 +24,12 @@ from numbers import Real
 
 
 class DiceLoss(_Loss):
-    """Dice Loss
+    """Calculate Dice Loss.
     
-    Methods:
-        forward: Calulates the DiceLoss
+    Methods
+    -------
+    forward
+        Calulate the DiceLoss
     """
 
     def forward(
@@ -37,7 +39,7 @@ class DiceLoss(_Loss):
             weights: Optional[int] = None,
             ignore_index: Optional[int] = None
     ) -> float:
-        """Calulates the DiceLoss
+        """Calulate the DiceLoss.
 
         Parameters
         ----------
@@ -90,7 +92,7 @@ class DiceLoss(_Loss):
 
 
 class CrossEntropy2D(nn.Module):
-    """2D Cross-entropy loss implemented as negative log likelihood
+    """2D Cross-entropy loss implemented as negative log likelihood.
 
     Attributes
     ----------
@@ -104,7 +106,7 @@ class CrossEntropy2D(nn.Module):
     """
 
     def __init__(self, weight: Optional[Tensor] =None, reduction: str = "none"):
-        """Initialization of CrossEntropy2D
+        """Construct CrossEntropy2D object.
 
         Parameters
         ----------
@@ -114,7 +116,6 @@ class CrossEntropy2D(nn.Module):
             Specifies the reduction to apply to the output, as in nn.CrossEntropyLoss. Defaults to 'None'
 
         """
-
         super(CrossEntropy2D, self).__init__()
         self.nll_loss = nn.CrossEntropyLoss(weight=weight, reduction=reduction)
         print(
@@ -122,11 +123,12 @@ class CrossEntropy2D(nn.Module):
         )
 
     def forward(self, inputs, targets):
+        """Feedforward."""
         return self.nll_loss(inputs, targets)
 
 
 class CombinedLoss(nn.Module):
-    """For CrossEntropy the input has to be a long tensor
+    """For CrossEntropy the input has to be a long tensor.
 
     Attributes
     ----------
@@ -141,7 +143,7 @@ class CombinedLoss(nn.Module):
     """
 
     def __init__(self, weight_dice: Real = 1, weight_ce: Real = 1):
-        """Initialization of CobinedLoss
+        """Construct CobinedLoss object.
 
         Parameters
         ----------
@@ -151,7 +153,6 @@ class CombinedLoss(nn.Module):
             Weight for cross entropy loss. Defaults to 1
 
         """
-
         super(CombinedLoss, self).__init__()
         self.cross_entropy_loss = CrossEntropy2D()
         self.dice_loss = DiceLoss()
@@ -164,7 +165,7 @@ class CombinedLoss(nn.Module):
             target: Tensor,
             weight: Tensor
     ) -> Tuple[Tensor, Tensor, Tensor]:
-        """[MISSING]
+        """[MISSING].
 
         Parameters
         ----------
@@ -185,7 +186,6 @@ class CombinedLoss(nn.Module):
             Cross entropy value
 
         """
-
         # Typecast to long tensor --> labels are bytes initially (uint8),
         # index operations require LongTensor in pytorch
         target = target.type(torch.LongTensor)
@@ -208,7 +208,7 @@ class CombinedLoss(nn.Module):
 def get_loss_func(
         cfg: yacs.config.CfgNode
 ) -> Union[CombinedLoss, CrossEntropy2D, DiceLoss]:
-    """Gives a default object of the loss function
+    """Give a default object of the loss function.
 
     Parameters
     ----------
@@ -230,9 +230,7 @@ def get_loss_func(
     NotImplementedError
         Requested loss function is not implemented
 
-    
     """
-
     if cfg.MODEL.LOSS_FUNC == "combined":
         return CombinedLoss()
     elif cfg.MODEL.LOSS_FUNC == "ce":

--- a/FastSurferCNN/models/networks.py
+++ b/FastSurferCNN/models/networks.py
@@ -24,7 +24,8 @@ import FastSurferCNN.models.interpolation_layer as il
 
 
 class FastSurferCNNBase(nn.Module):
-    """Network Definition of Fully Competitive Network network
+    """Network Definition of Fully Competitive Network network.
+
     * Spatial view aggregation (input 7 slices of which only middle one gets segmented)
     * Same Number of filters per layer (normally 64)
     * Dense Connections in blocks
@@ -45,13 +46,11 @@ class FastSurferCNNBase(nn.Module):
     Methods
     -------
     forward
-        Computational graph
+        Feedforward through graph.
     """
 
     def __init__(self, params: Dict, padded_size: int = 256):
-        """Initialization of FastSurferCNNBase
-
-        Args:
+        """Construct FastSurferCNNBase object.
 
         Parameters
         ----------
@@ -61,7 +60,6 @@ class FastSurferCNNBase(nn.Module):
             size of image when padded (Default value = 256)
 
         """
-
         super(FastSurferCNNBase, self).__init__()
 
         # Parameters for the Descending Arm
@@ -96,7 +94,7 @@ class FastSurferCNNBase(nn.Module):
             scale_factor: Optional[Tensor] = None,
             scale_factor_out: Optional[Tensor] =None
     ) -> Tensor:
-        """Computational graph
+        """Feedforward through graph.
 
         Parameters [MISSING]
         ----------
@@ -113,7 +111,6 @@ class FastSurferCNNBase(nn.Module):
             prediction logits
 
         """
-
         encoder_output1, skip_encoder_1, indices_1 = self.encode1.forward(x)
         encoder_output2, skip_encoder_2, indices_2 = self.encode2.forward(
             encoder_output1
@@ -142,8 +139,7 @@ class FastSurferCNNBase(nn.Module):
 
 
 class FastSurferCNN(FastSurferCNNBase):
-    """
-    Main Fastsurfer CNN Network
+    """Main Fastsurfer CNN Network.
 
     Attributes
     ----------
@@ -153,11 +149,12 @@ class FastSurferCNN(FastSurferCNNBase):
     Methods
     -------
     forward
-        Computational graph
+        Feedforward through graph
+
     """
 
     def __init__(self, params: Dict, padded_size: int):
-        """Initialization of FastSurferCNN
+        """Construct FastSurferCNN object.
 
         Parameters
         ----------
@@ -167,7 +164,6 @@ class FastSurferCNN(FastSurferCNNBase):
             size of image when padded
 
         """
-
         super(FastSurferCNN, self).__init__(params)
         params["num_channels"] = params["num_filters"]
         self.classifier = sm.ClassifierBlock(params)
@@ -188,7 +184,7 @@ class FastSurferCNN(FastSurferCNNBase):
             scale_factor: Optional[Tensor] = None,
             scale_factor_out: Optional[Tensor] = None
     ) -> Tensor:
-        """Computational graph
+        """Feedforward through graph.
 
         Parameters
         ----------
@@ -204,9 +200,7 @@ class FastSurferCNN(FastSurferCNNBase):
         output : Tensor
             Prediction logits
 
-
         """
-
         net_out = super().forward(x, scale_factor)
         output = self.classifier.forward(net_out)
 
@@ -214,7 +208,8 @@ class FastSurferCNN(FastSurferCNNBase):
 
 
 class FastSurferVINN(FastSurferCNNBase):
-    """Network Definition of Fully Competitive Network
+    """Network Definition of Fully Competitive Network.
+
     * Spatial view aggregation (input 7 slices of which only middle one gets segmented)
     * Same Number of filters per layer (normally 64)
     * Dense Connections in blocks
@@ -250,11 +245,11 @@ class FastSurferVINN(FastSurferCNNBase):
     Methods
     -------
     forward
-        computational graph
+        Feedforward through graph.
     """
 
     def __init__(self, params: Dict, padded_size: int = 256):
-        """Initialization of FastSurferVINN
+        """Construct FastSurferVINN object.
 
         Parameters
         ----------
@@ -264,7 +259,6 @@ class FastSurferVINN(FastSurferCNNBase):
             size of image when padded (Default value = 256)
 
         """
-
         num_c = params["num_channels"]
         params["num_channels"] = params["num_filters_interpol"]
         super(FastSurferVINN, self).__init__(params)
@@ -337,7 +331,7 @@ class FastSurferVINN(FastSurferCNNBase):
             scale_factor: Tensor,
             scale_factor_out: Optional[Tensor]  = None
     ) -> Tensor:
-        """Computational graph
+        """Feedforward through graph.
 
         Parameters
         ----------
@@ -354,7 +348,6 @@ class FastSurferVINN(FastSurferCNNBase):
             prediction logits
 
         """
-
         # Input block + Flex to 1 mm
         skip_encoder_0 = self.inp_block(x)
         encoder_output0, rescale_factor = self.interpol1(skip_encoder_0, scale_factor)
@@ -395,7 +388,7 @@ _MODELS = {
 
 
 def build_model(cfg: yacs.config.CfgNode) -> Union[FastSurferCNN, FastSurferVINN]:
-    """Builds requested model
+    """Build requested model.
 
     Parameters
     ----------
@@ -407,9 +400,7 @@ def build_model(cfg: yacs.config.CfgNode) -> Union[FastSurferCNN, FastSurferVINN
     model
         Object of the initialized model
 
-
     """
-
     assert (
             cfg.MODEL.MODEL_NAME in _MODELS.keys()
     ), f"Model {cfg.MODEL.MODEL_NAME} not supported"

--- a/FastSurferCNN/models/optimizer.py
+++ b/FastSurferCNN/models/optimizer.py
@@ -20,7 +20,7 @@ import yacs
 from networks import FastSurferCNN, FastSurferVINN
 
 def get_optimizer(model: Union[FastSurferCNN, FastSurferVINN, torch.nn.DataParallel], cfg: yacs.config.CfgNode) -> torch.optim.optimizer.Optimizer:
-    """get an instance of requested optimizer
+    """Get an instance of requested optimizer.
 
     Parameters
     ----------
@@ -39,9 +39,7 @@ def get_optimizer(model: Union[FastSurferCNN, FastSurferVINN, torch.nn.DataParal
     NotImplementedError
         Optimizer is not supported
 
-    
     """
-
     if cfg.OPTIMIZER.OPTIMIZING_METHOD == "sgd":
         return torch.optim.SGD(
             model.parameters(),

--- a/FastSurferCNN/models/sub_module.py
+++ b/FastSurferCNN/models/sub_module.py
@@ -20,7 +20,7 @@ from torch import nn, Tensor
 
 # Building Blocks
 class InputDenseBlock(nn.Module):
-    """Input Dense Block
+    """Input Dense Block.
 
     Attributes
     ----------
@@ -36,18 +36,17 @@ class InputDenseBlock(nn.Module):
     Methods
     -------
     forward
-        Computational graph
+        Feedforward through graph.
     """
 
     def __init__(self, params: Dict):
-        """Initialization of InputDenseBlock
+        """Construct InputDenseBlock object.
 
         Parameters
         ----------
         params : Dict
 
         """
-
         super(InputDenseBlock, self).__init__()
         # Padding to get output tensor of same dimensions
         padding_h = int((params["kernel_h"] - 1) / 2)
@@ -107,7 +106,7 @@ class InputDenseBlock(nn.Module):
         self.prelu = nn.PReLU()  # Learnable ReLU Parameter
 
     def forward(self, x: Tensor) -> Tensor:
-        """Computational graph
+        """Feedforward through graph.
 
         Parameters
         ----------
@@ -120,7 +119,6 @@ class InputDenseBlock(nn.Module):
             [MISSING]
         
         """
-
         # Input batch normalization
         x0_bn = self.bn0(x)
 
@@ -154,7 +152,7 @@ class InputDenseBlock(nn.Module):
 
 
 class CompetitiveDenseBlock(nn.Module):
-    """Function to define a competitive dense block comprising of 3 convolutional layers, with BN/ReLU
+    """Define a competitive dense block comprising 3 convolutional layers, with BN/ReLU.
 
     Attributes
     ----------
@@ -173,11 +171,11 @@ class CompetitiveDenseBlock(nn.Module):
     Methods
     -------
     forward
-        Computational graph
+        Feedforward through graph
     """
 
     def __init__(self, params: Dict, outblock: bool = False):
-        """Constructor to initialize the Competitive Dense Block
+        """Construct CompetitiveDenseBlock object.
 
         Parameters
         ----------
@@ -187,7 +185,6 @@ class CompetitiveDenseBlock(nn.Module):
             Flag indicating if last block (Default value = False)
 
         """
-
         super(CompetitiveDenseBlock, self).__init__()
 
         # Padding to get output tensor of same dimensions
@@ -248,7 +245,8 @@ class CompetitiveDenseBlock(nn.Module):
         self.outblock = outblock
 
     def forward(self, x: Tensor) -> Tensor:
-        """CompetitiveDenseBlock's computational Graph
+        """Feedforward through CompetitiveDenseBlock.
+
         {in (Conv - BN from prev. block) -> PReLU} -> {Conv -> BN -> Maxout -> PReLU} x 2 -> {Conv -> BN} -> out
         end with batch-normed output to allow maxout across skip-connections
 
@@ -262,9 +260,7 @@ class CompetitiveDenseBlock(nn.Module):
         out
             output tensor (processed feature map)
 
-        
         """
-
         # Activation from pooled input
         x0 = self.prelu(x)
 
@@ -302,7 +298,7 @@ class CompetitiveDenseBlock(nn.Module):
 
 
 class CompetitiveDenseBlockInput(nn.Module):
-    """Class to define a competitive dense block comprising 3 convolutional layers, with BN/ReLU for input
+    """Define a competitive dense block comprising 3 convolutional layers, with BN/ReLU for input.
     
     Attributes
     ----------
@@ -318,12 +314,12 @@ class CompetitiveDenseBlockInput(nn.Module):
                     'input':True}
      Methods
      -------
-    forward
-        Computational graph
+     forward
+        Feedforward through graph
     """
 
     def __init__(self, params: Dict):
-        """Constructor to initialize the Competitive Dense Block
+        """Construct CompetitiveDenseBlockInput object.
 
         Parameters
         ----------
@@ -331,7 +327,6 @@ class CompetitiveDenseBlockInput(nn.Module):
             dictionary with parameters specifying block architecture
 
         """
-
         super(CompetitiveDenseBlockInput, self).__init__()
 
         # Padding to get output tensor of same dimensions
@@ -386,7 +381,8 @@ class CompetitiveDenseBlockInput(nn.Module):
         self.prelu = nn.PReLU()  # Learnable ReLU Parameter
 
     def forward(self, x: Tensor) -> Tensor:
-        """CompetitiveDenseBlockInput's computational Graph
+        """Feed forward trough CompetitiveDenseBlockInput.
+
         in -> BN -> {Conv -> BN -> PReLU} -> {Conv -> BN -> Maxout -> PReLU} -> {Conv -> BN} -> out
 
         Parameters
@@ -399,9 +395,7 @@ class CompetitiveDenseBlockInput(nn.Module):
         out
             output tensor (processed feature map)
 
-        
         """
-
         # Input batch normalization
         x0_bn = self.bn0(x)
 
@@ -434,32 +428,32 @@ class CompetitiveDenseBlockInput(nn.Module):
 
 
 class GaussianNoise(nn.Module):
-    """Class to define a Gaussian Noise Block
+    """Define a Gaussian Noise Block.
     
     Methods
     -------
     forward
-        Computational graph
+        Feedforward through graph
     """
 
     def __init__(self, sigma: float = 0.1, device: str = "cuda"):
-        """Constructor
+        """Construct GaussianNoise object.
 
         Parameters
         ----------
         sigma : float
-             (Default value = 0.1)
+             [MISSING] (Default value = 0.1)
         device : str
-             (Default value = "cuda")
-        """
+             [MISSING] (Default value = "cuda")
 
+        """
         super().__init__()
         self.sigma = sigma
         self.noise = torch.tensor(0).to(device)
         self.register_buffer("noise", torch.tensor(0))
 
     def forward(self, x: Tensor) -> Tensor:
-        """Computational Graph
+        """Feedforward through graph.
 
         Parameters
         ----------
@@ -483,7 +477,7 @@ class GaussianNoise(nn.Module):
 # Encoder/Decoder definitions
 ##
 class CompetitiveEncoderBlock(CompetitiveDenseBlock):
-    """Encoder Block = CompetitiveDenseBlock + Max Pooling
+    """Encoder Block = CompetitiveDenseBlock + Max Pooling.
 
     Attributes
     ----------
@@ -493,18 +487,18 @@ class CompetitiveEncoderBlock(CompetitiveDenseBlock):
     Methods
     -------
     forward
-        Computational graph
+        Feed forward trough graph
     """
 
     def __init__(self, params: Dict):
-        """Encoder Block initialization
+        """Construct CompetitiveEncoderBlock object.
 
         Parameters
         ----------
         params : Dict
             Parameters like number of channels, stride etc.
-        """
 
+        """
         super(CompetitiveEncoderBlock, self).__init__(params)
         self.maxpool = nn.MaxPool2d(
             kernel_size=params["pool"],
@@ -513,9 +507,10 @@ class CompetitiveEncoderBlock(CompetitiveDenseBlock):
         )  # For Unpooling later on with the indices
 
     def forward(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
-        """Computational graph for Encoder Block:
-          * CompetitiveDenseBlock
-          * Max Pooling (+ retain indices)
+        """Feed forward trough Encoder Block.
+
+        * CompetitiveDenseBlock
+        * Max Pooling (+ retain indices)
 
         Parameters
         ----------
@@ -542,12 +537,10 @@ class CompetitiveEncoderBlock(CompetitiveDenseBlock):
 
 
 class CompetitiveEncoderBlockInput(CompetitiveDenseBlockInput):
-    """Encoder Block = CompetitiveDenseBlockInput + Max Pooling"""
+    """Encoder Block = CompetitiveDenseBlockInput + Max Pooling."""
 
     def __init__(self, params: Dict):
-        """Encoder Block initialization
-        
-        Args:
+        """Construct CompetitiveEncoderBlockInput object.
 
         Parameters
         ----------
@@ -565,9 +558,10 @@ class CompetitiveEncoderBlockInput(CompetitiveDenseBlockInput):
         )  # For Unpooling later on with the indices
 
     def forward(self, x: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
-        """Computational graph for Encoder Block:
-          * CompetitiveDenseBlockInput
-          * Max Pooling (+ retain indices)
+        """Feed forward trough Encoder Block.
+
+        * CompetitiveDenseBlockInput
+        * Max Pooling (+ retain indices)
 
         Parameters
         ----------
@@ -589,10 +583,10 @@ class CompetitiveEncoderBlockInput(CompetitiveDenseBlockInput):
 
 
 class CompetitiveDecoderBlock(CompetitiveDenseBlock):
-    """Decoder Block = (Unpooling + Skip Connection) --> Dense Block"""
+    """Decoder Block = (Unpooling + Skip Connection) --> Dense Block."""
 
     def __init__(self, params: Dict, outblock: bool = False):
-        """Decoder Block initialization
+        """Construct CompetitiveDecoderBlock object.
 
         Parameters
         ----------
@@ -601,18 +595,19 @@ class CompetitiveDecoderBlock(CompetitiveDenseBlock):
         outblock : bool
             Flag, indicating if last block of network before classifier
             is created.(Default value = False)
-        """
 
+        """
         super(CompetitiveDecoderBlock, self).__init__(params, outblock=outblock)
         self.unpool = nn.MaxUnpool2d(
             kernel_size=params["pool"], stride=params["stride_pool"]
         )
 
     def forward(self, x: Tensor, out_block: Tensor, indices: Tensor) -> Tensor:
-        """Computational graph Decoder block:
-          * Unpooling of feature maps from lower block
-          * Maxout combination of unpooled map + skip connection
-          * Forwarding toward CompetitiveDenseBlock
+        """Feed forward trough Decoder block.
+
+        * Unpooling of feature maps from lower block
+        * Maxout combination of unpooled map + skip connection
+        * Forwarding toward CompetitiveDenseBlock
 
         Parameters
         ----------
@@ -628,9 +623,7 @@ class CompetitiveDecoderBlock(CompetitiveDenseBlock):
         out_block
             processed feature maps
 
-        
         """
-
         unpool = self.unpool(x, indices)
         concat_max = torch.maximum(unpool, out_block)
         out_block = super(CompetitiveDecoderBlock, self).forward(concat_max)
@@ -639,7 +632,7 @@ class CompetitiveDecoderBlock(CompetitiveDenseBlock):
 
 
 class OutputDenseBlock(nn.Module):
-    """Dense Output Block = (Upinterpolated + Skip Connection) --> Semi Competitive Dense Block
+    """Dense Output Block = (Upinterpolated + Skip Connection) --> Semi Competitive Dense Block.
 
     Attributes
     ----------
@@ -653,18 +646,18 @@ class OutputDenseBlock(nn.Module):
     Methods
     -------
     forward
-        Computational graph
+        Feed forward trough graph.
     """
 
     def __init__(self, params: dict):
-        """Decoder Block initialization
+        """Construct OutputDenseBlock object.
 
         Parameters
         ----------
         params : dict
             parameters like number of channels, stride etc.
-        """
 
+        """
         super(OutputDenseBlock, self).__init__()
 
         # Padding to get output tensor of same dimensions
@@ -718,9 +711,10 @@ class OutputDenseBlock(nn.Module):
         self.prelu = nn.PReLU()  # Learnable ReLU Parameter
 
     def forward(self, x: Tensor, out_block: Tensor) -> Tensor:
-        """Computational graph Output block
-          * Maxout combination of unpooled map from previous block + skip connection
-          * Forwarding toward CompetitiveDenseBlock
+        """Feed forward trough Output block.
+
+        * Maxout combination of unpooled map from previous block + skip connection
+        * Forwarding toward CompetitiveDenseBlock
 
         Parameters
         ----------
@@ -734,9 +728,7 @@ class OutputDenseBlock(nn.Module):
         out
             processed feature maps
 
-        
         """
-
         # Concatenation along channel (different number of channels from decoder and skip connection)
         concat = torch.cat((x, out_block), dim=1)
 
@@ -772,10 +764,10 @@ class OutputDenseBlock(nn.Module):
 
 
 class ClassifierBlock(nn.Module):
-    """Classification Block"""
+    """Classification Block."""
 
     def __init__(self, params: dict):
-        """Classifier Block initialization
+        """Construct ClassifierBlock object.
 
         Parameters
         ----------
@@ -783,7 +775,6 @@ class ClassifierBlock(nn.Module):
             parameters like number of channels, stride etc.
 
         """
-
         super(ClassifierBlock, self).__init__()
         self.conv = nn.Conv2d(
             params["num_channels"],
@@ -793,7 +784,7 @@ class ClassifierBlock(nn.Module):
         )  # To generate logits
 
     def forward(self, x: Tensor) -> Tensor:
-        """Computational graph of classifier
+        """Feed forward trough classifier.
 
         Parameters
         ----------
@@ -805,7 +796,6 @@ class ClassifierBlock(nn.Module):
         logits
             prediction logits
 
-        
         """
         logits = self.conv(x)
 

--- a/FastSurferCNN/quick_qc.py
+++ b/FastSurferCNN/quick_qc.py
@@ -41,7 +41,14 @@ BG_LABEL = 0
 
 
 def options_parse():
-    """Command line option parser"""
+    """Command line option parser.
+
+    Returns
+    -------
+    options
+        object holding options
+
+    """
     parser = optparse.OptionParser(
         version="$Id: quick_qc,v 1.0 2022/09/28 11:34:08 mreuter Exp $", usage=HELPTEXT
     )
@@ -63,6 +70,23 @@ def options_parse():
 
 
 def check_volume(asegdkt_segfile, voxvol, thres=0.70):
+    """Check if total volume is bigger or smaller than threshold.
+
+    Parameters
+    ----------
+    asegdkt_segfile :
+        [MISSING]
+    voxvol :
+        [MISSING]
+    thres :
+        [MISSING]
+
+    Returns
+    -------
+    bool
+        Whether or not total volume is bigger or smaller than threshold
+
+    """
     print("Checking total volume ...")
     mask = asegdkt_segfile > 0
     total_vol = np.sum(mask) * voxvol / 1000000
@@ -77,7 +101,7 @@ def check_volume(asegdkt_segfile, voxvol, thres=0.70):
 def get_region_bg_intersection_mask(
     seg_array, region_labels=VENT_LABELS, bg_label=BG_LABEL
 ):
-    """Returns a mask of the intersection between the voxels of a given region and background voxels.
+    """Return a mask of the intersection between the voxels of a given region and background voxels.
     
     This is obtained by dilating the region by 1 voxel and computing the intersection with the
     background mask.
@@ -98,9 +122,7 @@ def get_region_bg_intersection_mask(
     bg_intersect : numpy.ndarray
         Region and background intersection mask array
 
-    
     """
-
     region_array = seg_array.copy()
     conditions = np.all(
         np.array([(region_array != value) for value in region_labels.values()]), axis=0
@@ -123,7 +145,7 @@ def get_region_bg_intersection_mask(
 
 
 def get_ventricle_bg_intersection_volume(seg_array, voxvol):
-    """Returns a volume estimate for the intersection of ventricle voxels with background voxels.
+    """Return a volume estimate for the intersection of ventricle voxels with background voxels.
 
     Parameters
     ----------
@@ -137,7 +159,6 @@ def get_ventricle_bg_intersection_volume(seg_array, voxvol):
     intersection_volume : float
         Estimated volume of voxels in ventricle and background intersection
 
-    
     """
     bg_intersect_mask = get_region_bg_intersection_mask(seg_array)
     intersection_volume = bg_intersect_mask.sum() * voxvol

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -65,7 +65,14 @@ h_fixwm = "whether to try to flip labels of disconnected WM island to other hemi
 
 
 def options_parse():
-    """Command line option parser for reduce_to_aseg.py"""
+    """Command line option parser.
+
+    Returns
+    -------
+    options
+        object holding options
+
+    """
     parser = optparse.OptionParser(
         version="$Id: reduce_to_aseg.py,v 1.0 2018/06/24 11:34:08 mreuter Exp $",
         usage=HELPTEXT,
@@ -85,15 +92,16 @@ def options_parse():
 
 
 def reduce_to_aseg(data_inseg):
-    """
+    """[MISSING].
 
     Parameters
     ----------
     data_inseg :
-        
+        [MISSING]
 
     Returns
     -------
+        [MISSING]
 
     """
     print("Reducing to aseg ...")
@@ -105,22 +113,22 @@ def reduce_to_aseg(data_inseg):
 
 
 def create_mask(aseg_data, dnum, enum):
-    """
+    """Create dilated mask.
 
     Parameters
     ----------
-    aseg_data :
-        
-    dnum :
-        
-    enum :
-        
+    aseg_data
+        [MISSING]
+    dnum
+        [MISSING]
+    enum
+        [MISSING]
 
     Returns
     -------
+        [MISSING]
 
     """
-
     print("Creating dilated mask ...")
 
     # treat lateral orbital frontal and parsorbitalis special to avoid capturing too much of eye nerve
@@ -159,15 +167,18 @@ def create_mask(aseg_data, dnum, enum):
 
 
 def flip_wm_islands(aseg_data):
-    """
+    """[MISSING].
 
     Parameters
     ----------
-    aseg_data :
+    aseg_data
+        [MISSING]
         
 
     Returns
     -------
+    flip_data
+        [MISSING]
 
     """
     # Sometimes WM is far in the other hemisphere, but with a WM label from the other hemi

--- a/FastSurferCNN/run_model.py
+++ b/FastSurferCNN/run_model.py
@@ -24,7 +24,7 @@ from FastSurferCNN.train import Trainer
 
 
 def setup_options():
-    """Sets up the options parsed from STDIN
+    """Set up the options parsed from STDIN.
     
     Parses arguments from the STDIN, including the flags: --cfg, --aug, --opt, opts,
 
@@ -34,7 +34,6 @@ def setup_options():
         object holding options
     
     """
-
     parser = argparse.ArgumentParser(description="Segmentation")
 
     parser.add_argument(
@@ -61,8 +60,7 @@ def setup_options():
 
 
 def main():
-    """[MISSING] first sets variables and then runs the trainer model"""
-
+    """[MISSING] First set variables and then runs the trainer model."""
     args = setup_options()
     cfg = get_config(args)
 

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -56,7 +56,7 @@ LOGGER = logging.getLogger(__name__)
 # Processing
 ##
 def set_up_cfgs(cfg: str, args: argparse.Namespace) -> yacs.config.CfgNode:
-    """Setup of configuration
+    """Set up configuration.
     
     Sets up configurations with given arguments inside the yaml file
 
@@ -73,7 +73,6 @@ def set_up_cfgs(cfg: str, args: argparse.Namespace) -> yacs.config.CfgNode:
         Node of configurations
 
     """
-
     cfg = load_config(cfg)
     cfg.OUT_LOG_DIR = args.out_dir if args.out_dir is not None else cfg.LOG_DIR
     cfg.OUT_LOG_NAME = "fastsurfer"
@@ -98,7 +97,6 @@ def args2cfg(args: argparse.Namespace) -> Tuple[yacs.config.CfgNode, yacs.config
         configurations for all planes
 
     """
-
     cfg_cor = set_up_cfgs(args.cfg_cor, args) if args.cfg_cor is not None else None
     cfg_sag = set_up_cfgs(args.cfg_sag, args) if args.cfg_sag is not None else None
     cfg_ax = set_up_cfgs(args.cfg_ax, args) if args.cfg_ax is not None else None
@@ -109,7 +107,9 @@ def args2cfg(args: argparse.Namespace) -> Tuple[yacs.config.CfgNode, yacs.config
 
 
 def removesuffix(string: str, suffix: str) -> str:
-    """Similar to string.removesuffix in PY3.9+, removes a suffix from a string.
+    """Remove a suffix from a string.
+
+    Similar to string.removesuffix in PY3.9+,
 
     Parameters
     ----------
@@ -124,7 +124,6 @@ def removesuffix(string: str, suffix: str) -> str:
         Suffix removed string
 
     """
-
     import sys
 
     if sys.version_info.minor >= 9:
@@ -144,13 +143,12 @@ def removesuffix(string: str, suffix: str) -> str:
 
 
 class RunModelOnData:
-    """[MISSING]
-    runs the model prediction on given data
+    """Run the model prediction on given data.
     
     Methods
     -------
     __init__()
-        constructor
+        Construct object.
     set_and_create_outdir()
         sets and creates output directory
     conform_and_save_orig()
@@ -195,8 +193,7 @@ class RunModelOnData:
     conform_to_1mm_threshold: Optional[float]
 
     def __init__(self, args: argparse.Namespace):
-        """
-        constructor
+        """Construct RunModelOnData object.
 
         Parameters
         ----------
@@ -211,8 +208,8 @@ class RunModelOnData:
                 directory of output
             viewagg_device : str
                 device to run viewagg on. Can be auto, cuda or cpu
-        """
 
+        """
         self.pred_name = args.pred_name
         self.conf_name = args.conf_name
         self.orig_name = args.orig_name
@@ -278,6 +275,7 @@ class RunModelOnData:
 
     @property
     def pool(self) -> Executor:
+        """[MISSING]."""
         if not hasattr(self, "_pool"):
             if not self._async_io:
                 self._pool = NoParallelExecutor()
@@ -288,6 +286,7 @@ class RunModelOnData:
         return self._pool
 
     def __del__(self):
+        """[MISSING]."""
         if hasattr(self, "_pool"):
             # only wait on futures, if we specifically ask (see end of the script, so we do not wait if we encounter a
             # fail case)
@@ -297,7 +296,7 @@ class RunModelOnData:
         self,
         subject: SubjectDirectory
     ) -> Tuple[nib.analyze.SpatialImage, np.ndarray]:
-        """Conforms and saves original image [MISSING]
+        """Conform and saves original image.
 
         Parameters
         ----------
@@ -310,7 +309,6 @@ class RunModelOnData:
             Conformed image
 
         """
-
         orig, orig_data = du.load_image(subject.orig_name, "orig image")
         LOGGER.info(f"Successfully loaded image from {subject.orig_name}.")
 
@@ -346,6 +344,7 @@ class RunModelOnData:
         return orig, orig_data
 
     def set_model(self, plane: str):
+        """[MISSING]."""
         self.current_plane = plane
 
     def get_prediction(
@@ -354,7 +353,7 @@ class RunModelOnData:
             orig_data: np.ndarray,
             zoom: Union[np.ndarray, Tuple]
     ) -> np.ndarray:
-        """get prediction
+        """Run and get prediction.
 
         Parameters
         ----------
@@ -371,7 +370,6 @@ class RunModelOnData:
             predicted classes
 
         """
-
         shape = orig_data.shape + (self.get_num_classes(),)
         kwargs = {
             "device": self.viewagg_device,
@@ -398,13 +396,13 @@ class RunModelOnData:
         return pred_classes
 
     def save_img(
-        self,
-        save_as: str,
-        data: Union[np.ndarray, torch.Tensor],
-        orig: nib.analyze.SpatialImage,
-        dtype: Optional[type] = None,
+            self,
+            save_as: str,
+            data: Union[np.ndarray, torch.Tensor],
+            orig: nib.analyze.SpatialImage,
+            dtype: Optional[type] = None,
     ):
-        """Saves image as file
+        """Save image as file.
 
         Parameters
         ----------
@@ -418,7 +416,6 @@ class RunModelOnData:
              (Default value = None)
 
         """
-
         # Create output directory if it does not already exist.
         if not os.path.exists(os.path.dirname(save_as)):
             LOGGER.info(
@@ -439,25 +436,28 @@ class RunModelOnData:
         return r
 
     def async_save_img(
-        self,
-        save_as: str,
-        data: Union[np.ndarray, torch.Tensor],
-        orig: nib.analyze.SpatialImage,
-        dtype: Union[None, type] = None,
+            self,
+            save_as: str,
+            data: Union[np.ndarray, torch.Tensor],
+            orig: nib.analyze.SpatialImage,
+            dtype: Union[None, type] = None,
     ):
-        """Saves the image asynchronously and returns a concurrent.futures.Future to track, when this finished."""
+        """Save the image asynchronously and return a concurrent.futures.Future to track, when this finished."""
         return self.pool.submit(self.save_img, save_as, data, orig, dtype)
 
     def set_up_model_params(self, plane, cfg, ckpt):
+        """Set up the model parameters from the configuration and checkpoint."""
         self.view_ops[plane]["cfg"] = cfg
         self.view_ops[plane]["ckpt"] = ckpt
 
     def get_num_classes(self) -> int:
+        """Return the number of classes."""
         return self.num_classes
 
     def pipeline_conform_and_save_orig(
-        self, subjects: SubjectList
+            self, subjects: SubjectList
     ) -> Iterator[Tuple[SubjectDirectory, Tuple[nib.analyze.SpatialImage, np.ndarray]]]:
+        """[MISSING]."""
         if not self._async_io:
             # do not pipeline, direct iteration and function call
             for subject in subjects:

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -75,6 +75,7 @@ class HelpFormatter(argparse.HelpFormatter):
     """Help formatter that keeps line breaks for texts that start with '/keeplinebreaks/'."""
 
     def _fill_text(self, text, width, indent):
+        """[MISSING]."""
         klb_str = '/keeplinebreaks/'
         if text.startswith(klb_str):
             # the following line is from argparse.RawDescriptionHelpFormatter
@@ -84,6 +85,7 @@ class HelpFormatter(argparse.HelpFormatter):
 
 
 def make_arguments() -> argparse.ArgumentParser:
+    """[MISSING]."""
     parser = argparse.ArgumentParser(usage=USAGE, epilog=HELPTEXT, description=DESCRIPTION,
                                      formatter_class=HelpFormatter)
     parser.add_argument('-norm', '--normfile', type=str, required=True, dest='normfile',
@@ -152,6 +154,16 @@ def make_arguments() -> argparse.ArgumentParser:
 
 def loadfile_full(file: str, name: str) \
         -> Tuple[nib.analyze.SpatialImage, np.ndarray]:
+    """Load full image and data.
+
+    Parameters
+    ----------
+    file : str
+        filename
+    name :
+        Subject name
+
+    """
     try:
         img = nib.load(file)
     except (IOError, FileNotFoundError) as e:
@@ -161,6 +173,18 @@ def loadfile_full(file: str, name: str) \
 
 
 def main(args):
+    """[MISSING].
+
+    Parameters
+    ----------
+    args :
+        [MISSING]
+
+    Returns
+    -------
+    [MISSING]
+
+    """
     import os
     import time
     start = time.perf_counter_ns()
@@ -321,7 +345,6 @@ def write_statsfile(segstatsfile: str, dataframe: pd.DataFrame, vox_vol: float, 
         added. Should not include newline characters (expect at the end of strings). (default: empty sequence)
 
     """
-
     import sys
     import os
     import datetime
@@ -374,7 +397,7 @@ def write_statsfile(segstatsfile: str, dataframe: pd.DataFrame, vox_vol: float, 
                 line = line.replace("\n", " ")
                 from warnings import warn
                 warn_msg_sent or warn(f"extra_header[{i}] includes embedded newline characters. "
-                                      "Replacing all newline characters with <space>.")
+                    "Replacing all newline characters with <space>.")
                 warn_msg_sent = True
             fp.write(f"# {line}\n")
         fp.write(f"#\n")
@@ -389,7 +412,7 @@ def write_statsfile(segstatsfile: str, dataframe: pd.DataFrame, vox_vol: float, 
 
         for i, col in enumerate(dataframe.columns):
             for v, name in zip((col, FIELDS.get(col, "Unknown Column"), UNITS.get(col, "NA")),
-                               ("ColHeader", "FieldName", "Units    ")):
+                ("ColHeader", "FieldName", "Units    ")):
                 fp.write(f"# TableCol {i+1: 2d} {name} {v}\n")
         fp.write(f"# NRows {len(dataframe)}\n"
                  f"# NTableCols {len(dataframe.columns)}\n")
@@ -413,9 +436,9 @@ def write_statsfile(segstatsfile: str, dataframe: pd.DataFrame, vox_vol: float, 
 
 # Label mapping functions (to aparc (eval) and to label (train))
 def read_classes_from_lut(lut_file):
-    """This function is modified from datautils to allow support for FreeSurfer-distributed ColorLUTs
+    """Modify from datautils to allow support for FreeSurfer-distributed ColorLUTs.
     
-    Function to read in **FreeSurfer-like** LUT table
+    Read in **FreeSurfer-like** LUT table
 
     Parameters
     ----------
@@ -455,17 +478,18 @@ def seg_borders(_array: _ArrayType, label: Union[np.integer, bool],
     from scipy.ndimage import laplace
 
     def _laplace(data):
-        """
+        """[MISSING].
 
         Parameters
         ----------
         data :
-            
+            [MISSING]
 
         Returns
         -------
+        bool
+            [MISSING]
 
-        
         """
         return laplace(data.astype(cmp_dtype)) != np.asarray(0., dtype=cmp_dtype)
     # laplace
@@ -478,8 +502,27 @@ def seg_borders(_array: _ArrayType, label: Union[np.integer, bool],
 
 def borders(_array: _ArrayType, labels: Union[Iterable[np.integer], bool], max_label: Optional[np.integer] = None,
             six_connected: bool = True, out: Optional[_ArrayType] = None) -> _ArrayType:
-    """Handle to fast border computation."""
+    """Handle to fast border computation.
 
+    Parameters
+    ----------
+    _array : _ArrayType
+        [MISSING]
+    labels : Union[Iterable[np.integer], bool]
+        [MISSING]
+    max_label : Optional[np.integer], Optional
+        [MISSING]
+    six_connected : bool
+        [MISSING]
+    out : Optional[_ArrayType]
+        [MISSING]
+
+    Returns
+    -------
+    _ArrayType
+        [MISSING]
+
+    """
     dim = _array.ndim
     array_alloc = partial(np.full, dtype=_array.dtype)
     _shape_plus2 = [s + 2 for s in _array.shape]
@@ -526,15 +569,42 @@ def borders(_array: _ArrayType, labels: Union[Iterable[np.integer], bool], max_l
 
 
 def unsqueeze(matrix, axis: Union[int, Sequence[int]] = -1):
-    """Allows insertions of axis into the data/tensor, see numpy.expand_dims. This expands the torch.unsqueeze
-    syntax to allow unsqueezing multiple axis at the same time. """
+    """Unsqueeze the matrix.
+
+    Allows insertions of axis into the data/tensor, see numpy.expand_dims. This expands the torch.unsqueeze
+    syntax to allow unsqueezing multiple axis at the same time.
+
+    Parameters
+    ----------
+    matrix :
+        Matrix to unsqueeze
+    axis : Union[int, Sequence[int]]
+        Axis for unsqueezing
+
+    """
     if isinstance(matrix, np.ndarray):
         return np.expand_dims(matrix, axis=axis)
 
 
 def grow_patch(patch: Sequence[slice], whalf: int, img_size: Union[np.ndarray, Sequence[float]]) -> Tuple[
     Tuple[slice, ...], Tuple[slice, ...]]:
-    """Create two slicing tuples for indexing ndarrays/tensors that 'grow' and re-'ungrow' the patch `patch` by `whalf` (also considering the image shape)."""
+    """Create two slicing tuples for indexing ndarrays/tensors that 'grow' and re-'ungrow' the patch `patch` by `whalf` (also considering the image shape).
+
+    Parameters
+    ----------
+    patch : Sequence[slice]
+        [MISSING]
+    whalf : int
+        [MISSING]
+    img_size : Union[np.ndarray, Sequence[float]]
+        [MISSING]
+
+    Returns
+    -------
+    Tuple[Tuple[slice, ...], Tuple[slice, ...]]
+        [MISSING]
+
+    """
     # patch start/stop
     _patch = np.asarray([(s.start, s.stop) for s in patch])
     start, stop = _patch.T
@@ -551,8 +621,29 @@ def grow_patch(patch: Sequence[slice], whalf: int, img_size: Union[np.ndarray, S
 
 def uniform_filter(arr: _ArrayType, filter_size: int, fillval: float,
                    patch: Optional[Tuple[slice, ...]] = None, out: Optional[_ArrayType] = None) -> _ArrayType:
-    """Apply a uniform filter (with kernel size `filter_size`) to `input`. The uniform filter is normalized
-    (weights add to one)."""
+    """Apply a uniform filter (with kernel size `filter_size`) to `input`.
+
+    The uniform filter is normalized (weights add to one).
+
+    Parameters
+    ----------
+    arr : _ArrayType
+        [MISSING]
+    filter_size : int
+        [MISSING]
+    fillval : float
+        [MISSING]
+    patch : Optional[Tuple[slice, ...]]
+        [MISSING]
+    out : Optional[_ArrayType]
+        [MISSING]
+
+    Returns
+    -------
+    _ArrayType
+        [MISSING]
+
+    """
     _patch = (slice(None),) if patch is None else patch
     arr = arr.astype(float)
     from scipy.ndimage import uniform_filter
@@ -571,6 +662,7 @@ def pv_calc(seg: npt.NDArray[_IntType], norm: np.ndarray, labels: Sequence[_IntT
             vox_vol: float = 1.0, eps: float = 1e-6, robust_percentage: Optional[float] = None,
             merged_labels: Optional[VirtualLabel] = None, threads: int = -1, return_maps: False = False,
             legacy_freesurfer: bool = False) -> List[PVStats]:
+    """[MISSING]."""
     ...
 
 
@@ -580,6 +672,7 @@ def pv_calc(seg: npt.NDArray[_IntType], norm: np.ndarray, labels: Sequence[_IntT
             merged_labels: Optional[VirtualLabel] = None, threads: int = -1, return_maps: True = True,
             legacy_freesurfer: bool = False) \
         -> Tuple[List[PVStats], Dict[str, Dict[int, np.ndarray]]]:
+    """[MISSING]."""
     ...
 
 
@@ -588,7 +681,7 @@ def pv_calc(seg: npt.NDArray[_IntType], norm: np.ndarray, labels: Sequence[_IntT
             merged_labels: Optional[VirtualLabel] = None, threads: int = -1, return_maps: bool = False,
             legacy_freesurfer: bool = False) \
         -> Union[List[PVStats], Tuple[List[PVStats], Dict[str, np.ndarray]]]:
-    """Function to compute volume effects.
+    """Compute volume effects.
 
     Parameters
     ----------
@@ -628,7 +721,6 @@ def pv_calc(seg: npt.NDArray[_IntType], norm: np.ndarray, labels: Sequence[_IntT
         ipv: The partial volume of the alternative (nbr) label at the location
 
     """
-
     if not isinstance(seg, np.ndarray) and np.issubdtype(seg.dtype, np.integer):
         raise TypeError("The seg object is not a numpy.ndarray of int type.")
     if not isinstance(norm, np.ndarray) and np.issubdtype(seg.dtype, np.numeric):
@@ -638,7 +730,7 @@ def pv_calc(seg: npt.NDArray[_IntType], norm: np.ndarray, labels: Sequence[_IntT
 
     if seg.shape != norm.shape:
         raise RuntimeError(f"The shape of the segmentation and the norm must be identical, but shapes are {seg.shape} "
-                           f"and {norm.shape}!")
+            f"and {norm.shape}!")
 
     mins, maxes, voxel_counts, __voxel_counts, sums, sums_2, volumes = [{} for _ in range(7)]
     loc_border = {}
@@ -706,10 +798,10 @@ def pv_calc(seg: npt.NDArray[_IntType], norm: np.ndarray, labels: Sequence[_IntT
         patches = (patch for has_pv_vox, patch in _patches if has_pv_vox)
 
         for vols in pool.map(partial(pv_calc_patch, global_crop=global_crop, loc_border=loc_border, border=border,
-                                     seg=seg, norm=norm, full_nbr_label=full_nbr_label, full_seg_mean=full_seg_mean,
-                                     full_pv=full_pv, full_ipv=full_ipv, full_nbr_mean=full_nbr_mean, eps=eps,
-                                     legacy_freesurfer=legacy_freesurfer),
-                             patches, **map_kwargs):
+                    seg=seg, norm=norm, full_nbr_label=full_nbr_label, full_seg_mean=full_seg_mean,
+                    full_pv=full_pv, full_ipv=full_ipv, full_nbr_mean=full_nbr_mean, eps=eps,
+                    legacy_freesurfer=legacy_freesurfer),
+            patches, **map_kwargs):
             for lab in volumes.keys():
                 volumes[lab] += vols.get(lab, 0.) * vox_vol
 
@@ -751,8 +843,29 @@ def global_stats(lab: _IntType, norm: npt.NDArray[_NumberType], seg: npt.NDArray
                  out: Optional[npt.NDArray[bool]] = None, robust_percentage: Optional[float] = None) \
         -> Union[Tuple[_IntType, int],
                  Tuple[_IntType, int, int, _NumberType, _NumberType, float, float, float, npt.NDArray[bool]]]:
-    """Computes Label, Number of voxels, 'robust' number of voxels, norm minimum, maximum, sum, sum of squares and
-    6-connected border of label lab (out references the border)."""
+    """Compute Label, Number of voxels, 'robust' number of voxels, norm minimum, maximum, sum, sum of squares and 6-connected border of label lab (out references the border).
+
+    Parameters
+    ----------
+    lab : _IntType
+        [MISSING]
+    norm : pt.NDArray[_NumberType]
+        [MISSING]
+    seg : npt.NDArray[_IntType]
+        [MISSING]
+    out : npt.NDArray[bool], Optional
+        [MISSING]
+    robust_percentage : float, Optional
+        [MISSING]
+
+    Returns
+    -------
+    _IntType and int
+        [MISSING]
+    or _IntType, int, int, _NumberType, _NumberType, float, float, float and npt.NDArray[bool]
+        [MISSING]
+
+    """
     bin_array = cast(npt.NDArray[bool], seg == lab)
     data = norm[bin_array].astype(int if np.issubdtype(norm.dtype, np.integer) else float)
     nvoxels: int = data.shape[0]
@@ -786,8 +899,27 @@ def global_stats(lab: _IntType, norm: npt.NDArray[_NumberType], seg: npt.NDArray
 def patch_filter(pos: Tuple[int, int, int], mask: npt.NDArray[bool],
                  global_crop: Tuple[slice, ...], patch_size: int = 32) \
         -> Tuple[bool, Sequence[slice]]:
-    """Returns, whether there are mask-True voxels in the patch starting at pos with size patch_size and the resulting
-    patch shrunk to mask-True regions."""
+    """Return, whether there are mask-True voxels in the patch starting at pos with size patch_size and the resulting patch shrunk to mask-True regions.
+
+    Parameters
+    ----------
+    pos : Tuple[int, int, int]
+        [MISSING]
+    mask : npt.NDArray[bool]
+        [MISSING]
+    global_crop : Tuple[slice, ...]
+        [MISSING]
+    patch_size : int
+        [MISSING]. Defaults to 32
+
+    Returns
+    -------
+    bool
+        [MISSING]
+    Sequence[slice]
+        [MISSING]
+
+    """
     # create slices for current patch context (constrained by the global_crop)
     patch = [slice(p, min(p + patch_size, slice_.stop)) for p, slice_ in zip(pos, global_crop)]
     # crop patch context to the image content
@@ -797,7 +929,9 @@ def patch_filter(pos: Tuple[int, int, int], mask: npt.NDArray[bool],
 def crop_patch_to_mask(mask: npt.NDArray[_NumberType],
                        sub_patch: Optional[Sequence[slice]] = None) \
         -> Tuple[bool, Sequence[slice]]:
-    """Crop the patch to regions of the mask that are non-zero. Assumes mask is always positive. Returns whether there
+    """Crop the patch to regions of the mask that are non-zero.
+
+    Assumes mask is always positive. Returns whether there
     is any mask>0 in the patch and a patch shrunk to mask>0 regions. The optional subpatch constrains this operation to
     the sub-region defined by a sequence of slicing operations.
 
@@ -808,12 +942,18 @@ def crop_patch_to_mask(mask: npt.NDArray[_NumberType],
     sub_patch : Optional[Sequence[slice]]
         subregion of mask to only consider (default: full mask)
 
+    Returns
+    -------
+    bool
+        [MISSING]
+    Sequence[slice]
+        [MISSING]
+
     Note
     ----
     This function requires device synchronization.
 
     """
-
     _patch = []
     patch = tuple([slice(0, s) for s in mask.shape] if sub_patch is None else sub_patch)
     patch_in_patch_coords = tuple([slice(0, slice_.stop - slice_.start) for slice_ in patch])
@@ -852,9 +992,46 @@ def pv_calc_patch(patch: Tuple[slice, ...], global_crop: Tuple[slice, ...],
                   full_nbr_mean: Optional[npt.NDArray[float]] = None, eps: float = 1e-6,
                   legacy_freesurfer: bool = False) \
         -> Dict[_IntType, float]:
-    """Calculates PV for patch. If full* keyword arguments are passed, also fills, per voxel results for the respective
-    voxels in the patch."""
+    """Calculate PV for patch.
 
+    If full* keyword arguments are passed, also fills, per voxel results for the respective
+    voxels in the patch.
+
+    Parameters
+    ----------
+    patch : Tuple[slice, ...]
+        [MISSING]
+    global_crop : Tuple[slice, ...]
+        [MISSING]
+    loc_border : Dict[_IntType, npt.NDArray[bool]]
+        [MISSING]
+    seg : npt.NDArray[_IntType]
+        [MISSING]
+    norm : np.ndarray
+        [MISSING]
+    border : npt.NDArray[bool]
+        [MISSING]
+    full_pv : npt.NDArray[float], Optional
+        [MISSING]
+    full_ipv : npt.NDArray[float], Optional
+        [MISSING]
+    full_nbr_label : npt.NDArray[_IntType], Optional
+        [MISSING]
+    full_seg_mean : npt.NDArray[float], Optional
+        [MISSING]
+    full_nbr_mean : npt.NDArray[float], Optional
+        [MISSING]
+    eps : float
+        [MISSING]. Defaults to 1e-6
+    legacy_freesurfer : bool
+        [MISSING]
+
+    Returns
+    -------
+    Dict[_IntType, float]
+        [MISSING]
+
+    """
     log_eps = -int(np.log10(eps))
 
     patch = tuple(patch)
@@ -948,8 +1125,43 @@ def pv_calc_patch(patch: Tuple[slice, ...], global_crop: Tuple[slice, ...],
 
 
 def patch_neighbors(labels, norm, seg, pat_border, loc_border, patch_grow7, patch_in_gc, patch_shrink6,
-                        ungrow1_patch, ungrow7_patch, ndarray_alloc, eps, legacy_freesurfer = False):
-    """Helper function to calculate the neighbor statistics of labels, etc."""
+                    ungrow1_patch, ungrow7_patch, ndarray_alloc, eps, legacy_freesurfer = False):
+    """Calculate the neighbor statistics of labels, etc..
+
+    Parameters
+    ----------
+    labels :
+        [MISSING]
+    norm :
+        [MISSING]
+    seg :
+        [MISSING]
+    pat_border :
+        [MISSING]
+    loc_border :
+        [MISSING]
+    patch_grow7 :
+        [MISSING]
+    patch_in_gc :
+        [MISSING]
+    patch_shrink6 :
+        [MISSING]
+    ungrow1_patch :
+        [MISSING]
+    ungrow7_patch :
+        [MISSING]
+    ndarray_alloc :
+        [MISSING]
+    eps :
+        [MISSING]
+    legacy_freesurfer : bool
+        [MISSING]. Defaults to False
+
+    Returns
+    -------
+    [MISSING]
+
+    """
     loc_shape = (len(labels),) + pat_border.shape
 
     pat_label_counts, pat_label_sums = ndarray_alloc((2,) + loc_shape, fill_value=0., dtype=float)

--- a/FastSurferCNN/train.py
+++ b/FastSurferCNN/train.py
@@ -41,12 +41,12 @@ logger = logging.getLogger(__name__)
 
 
 class Trainer:
-    """Trainer for the networks
+    """Trainer for the networks.
     
     Methods
     -------
     __init__
-        constructor
+        Construct object.
     train
         trains the network
     eval
@@ -57,7 +57,7 @@ class Trainer:
     """
 
     def __init__(self, cfg: yacs.config.CfgNode):
-        """constructor
+        """Construct Trainer object.
 
         Parameters
         ----------
@@ -65,7 +65,6 @@ class Trainer:
             Node of configs to be used
 
         """
-
         # Set random seed from configs.
         np.random.seed(cfg.RNG_SEED)
         torch.manual_seed(cfg.RNG_SEED)
@@ -99,7 +98,7 @@ class Trainer:
             train_meter: Meter,
             epoch
     ) -> None:
-        """trains the network to the given training data
+        """Train the network to the given training data.
 
         Parameters
         ----------
@@ -115,7 +114,6 @@ class Trainer:
             [MISSING]
         
         """
-
         self.model.train()
         logger.info("Training started ")
         epoch_start = time.time()
@@ -149,8 +147,8 @@ class Trainer:
 
             loss_total.backward()
             if (
-                not self.subepoch
-                or (curr_iter + 1) % (16 / self.cfg.TRAIN.BATCH_SIZE) == 0
+                    not self.subepoch
+                    or (curr_iter + 1) % (16 / self.cfg.TRAIN.BATCH_SIZE) == 0
             ):
                 optimizer.step()  # every second epoch to get batchsize of 16 if using 8
                 if scheduler is not None:
@@ -185,7 +183,7 @@ class Trainer:
             val_meter: Meter,
             epoch: int
     ) -> np.ndarray:
-        """Evaluates model and calculates stats
+        """Evaluate model and calculates stats.
 
         Parameters
         ----------
@@ -201,9 +199,7 @@ class Trainer:
         int, float, ndarray
             median miou [value]
 
-        
         """
-
         logger.info(f"Evaluating model at epoch {epoch}")
         self.model.eval()
 
@@ -311,11 +307,10 @@ class Trainer:
         return np.mean(np.mean(miou))
 
     def run(self):
-        """transfers the model to devices, creates a tensor board summary writer and then performs the training loop"""
-
+        """Transfer the model to devices, create a tensor board summary writer and then perform the training loop."""
         if self.cfg.NUM_GPUS > 1:
             assert (
-                self.cfg.NUM_GPUS <= torch.cuda.device_count()
+                    self.cfg.NUM_GPUS <= torch.cuda.device_count()
             ), "Cannot use more GPU devices than available"
             print("Using ", self.cfg.NUM_GPUS, "GPUs!")
             self.model = torch.nn.DataParallel(self.model)

--- a/FastSurferCNN/utils/arg_types.py
+++ b/FastSurferCNN/utils/arg_types.py
@@ -22,7 +22,7 @@ VoxSizeOption = Union[float, Literal["min"]]
 
 
 def vox_size(a: str) -> VoxSizeOption:
-    """Helper function to convert the vox_size argument to 'min' or a valid voxel size.
+    """Convert the vox_size argument to 'min' or a valid voxel size.
 
     Parameters
     ----------
@@ -32,16 +32,13 @@ def vox_size(a: str) -> VoxSizeOption:
     Returns
     -------
     [MISSING]
-        
 
     Raises
     ------
     argparse.ArgumentTypeError
         An error from creating or using an argument. Additionally, vox_sizes may be 'min'.
 
-    
     """
-
     if a.lower() in ["auto", "min"]:
         return "min"
     try:
@@ -53,7 +50,7 @@ def vox_size(a: str) -> VoxSizeOption:
 
 
 def float_gt_zero_and_le_one(a: str) -> Optional[float]:
-    """Helper function to check whether a parameters is a float between 0 and one.
+    """Check whether a parameters are a float between 0 and one.
 
     Parameters
     ----------
@@ -63,11 +60,8 @@ def float_gt_zero_and_le_one(a: str) -> Optional[float]:
     Returns
     -------
     [MISSING]
-        
 
-    
     """
-
     if a is None or a.lower() in ["none", "infinity"]:
         return None
     a_float = float(a)
@@ -78,7 +72,7 @@ def float_gt_zero_and_le_one(a: str) -> Optional[float]:
 
 
 def target_dtype(a: str) -> str:
-    """Helper function to check for valid dtypes.
+    """Check for valid dtypes.
 
     Parameters
     ----------
@@ -88,16 +82,13 @@ def target_dtype(a: str) -> str:
     Returns
     -------
     [MISSING]
-        
 
     Raises
     ------
     argparse.ArgumentTypeError
         Invalid dtype
 
-    
     """
-
     dtypes = nib.freesurfer.mghformat.data_type_codes.value_set("label")
     dtypes.add("any")
     _a = a.lower()
@@ -116,7 +107,7 @@ def target_dtype(a: str) -> str:
 
 
 def int_gt_zero(value: Union[str, int]) -> int:
-    """Conversion to positive integers.
+    """Convert to positive integers.
 
     Parameters
     ----------
@@ -133,9 +124,7 @@ def int_gt_zero(value: Union[str, int]) -> int:
     argparse
         ArgumentTypeError: Invalid value, must not be negative.
 
-    
     """
-
     val = int(value)
     if val <= 0:
         raise argparse.ArgumentTypeError("Invalid value, must not be negative.")
@@ -143,7 +132,7 @@ def int_gt_zero(value: Union[str, int]) -> int:
 
 
 def int_ge_zero(value) -> int:
-    """Conversion to integers greater 0.
+    """Convert to integers greater 0.
 
     Parameters
     ----------
@@ -161,7 +150,6 @@ def int_ge_zero(value) -> int:
         ArgumentTypeError: Invalid value, must be greater than 0.
 
     """
-
     val = int(value)
     if val < 0:
         raise argparse.ArgumentTypeError("Invalid value, must be greater than 0.")
@@ -169,7 +157,7 @@ def int_ge_zero(value) -> int:
 
 
 def unquote_str(value) -> str:
-    """Unquotes a (single quoted) string.
+    """Unquote a (single quoted) string.
 
     Parameters
     ----------
@@ -181,9 +169,7 @@ def unquote_str(value) -> str:
     val : str
         A string of the value without quoting with '''
 
-    
     """
-
     val = str(value)
     if val.startswith("'") and val.endswith("'"):
         return val[1:-1]

--- a/FastSurferCNN/utils/checkpoint.py
+++ b/FastSurferCNN/utils/checkpoint.py
@@ -35,7 +35,7 @@ VINN_SAG = os.path.join(FASTSURFER_ROOT, "checkpoints/aparc_vinn_sagittal_v2.0.0
 
 
 def create_checkpoint_dir(expr_dir: Union[os.PathLike], expr_num: int):
-    """Create the checkpoint dir if not exists
+    """Create the checkpoint dir if not exists.
 
     Parameters
     ----------
@@ -49,9 +49,7 @@ def create_checkpoint_dir(expr_dir: Union[os.PathLike], expr_num: int):
     checkpoint_dir
         directory of the checkpoint
 
-    
     """
-
     checkpoint_dir = os.path.join(expr_dir, "checkpoints", str(expr_num))
     os.makedirs(checkpoint_dir, exist_ok=True)
     return checkpoint_dir
@@ -72,9 +70,7 @@ def get_checkpoint(ckpt_dir: str, epoch: int) -> str:
     checkpoint_dir
         Standardizes checkpoint name
 
-    
     """
-
     checkpoint_dir = os.path.join(
         ckpt_dir, "Epoch_{:05d}_training_state.pkl".format(epoch)
     )
@@ -97,8 +93,8 @@ def get_checkpoint_path(
     -------
     prior_model_paths : Optional[MutableSequence[str]]
         None, if no models are found, or a list of filenames for checkpoints.
-    """
 
+    """
     if resume_experiment == "Default" or resume_experiment is None:
         return None
     checkpoint_path = os.path.join(log_dir, "checkpoints", str(resume_experiment))
@@ -118,7 +114,7 @@ def load_from_checkpoint(
     fine_tune: bool = False,
     drop_classifier: bool = False,
 ):
-    """Loading the model from the given experiment number
+    """Load the model from the given experiment number.
 
     Parameters
     ----------
@@ -173,7 +169,7 @@ def save_checkpoint(
     scheduler: Optional[Scheduler] = None,
     best: bool = False,
 ) -> None:
-    """Saving the state of training for resume or fine-tune
+    """Save the state of training for resume or fine-tune.
 
     Parameters
     ----------
@@ -197,7 +193,6 @@ def save_checkpoint(
         Whether this was the best checkpoint so far [MISSING] (Default value = False)
 
     """
-
     save_name = f"Epoch_{epoch:05d}_training_state.pkl"
     saving_model = model.module if num_gpus > 1 else model
     checkpoint = {
@@ -219,7 +214,7 @@ def save_checkpoint(
 
 
 def remove_ckpt(ckpt: str):
-    """removes the checkpoint
+    """Remove the checkpoint.
 
     Parameters
     ----------
@@ -227,7 +222,6 @@ def remove_ckpt(ckpt: str):
         Path and filename to the checkpoint
 
     """
-
     try:
         os.remove(ckpt)
     except FileNotFoundError:
@@ -239,8 +233,9 @@ def download_checkpoint(
         checkpoint_name: str,
         checkpoint_path: str
 ) -> None:
-    """Download a checkpoint file. Raises an HTTPError if the file is not found
-        or the server is not reachable.
+    """Download a checkpoint file.
+
+    Raises an HTTPError if the file is not found or the server is not reachable.
 
     Parameters
     ----------
@@ -251,9 +246,7 @@ def download_checkpoint(
     checkpoint_path : str
         path of the file in which the checkpoint will be saved
 
-
     """
-
     try:
         response = requests.get(download_url + "/" + checkpoint_name, verify=True)
         # Raise error if file does not exist:
@@ -278,7 +271,6 @@ def check_and_download_ckpts(checkpoint_path: str, url: str) -> None:
         URL of checkpoint hosting site
 
     """
-
     # Download checkpoint file from url if it does not exist
     if not os.path.exists(checkpoint_path):
         ckptdir, ckptname = os.path.split(checkpoint_path)
@@ -288,7 +280,7 @@ def check_and_download_ckpts(checkpoint_path: str, url: str) -> None:
 
 
 def get_checkpoints(axi: str, cor: str, sag: str, url: str = URL) -> None:
-    """Check and download checkpoint files if not exist
+    """Check and download checkpoint files if not exist.
 
     Parameters
     ----------
@@ -302,7 +294,6 @@ def get_checkpoints(axi: str, cor: str, sag: str, url: str = URL) -> None:
         URL of checkpoint hosting site (Default value = URL)
 
     """
-
     check_and_download_ckpts(axi, url)
     check_and_download_ckpts(cor, url)
     check_and_download_ckpts(sag, url)

--- a/FastSurferCNN/utils/common.py
+++ b/FastSurferCNN/utils/common.py
@@ -55,8 +55,9 @@ def find_device(
     flag_name: str = "device",
     min_memory: int = 0,
 ) -> torch.device:
-    """Create a device object from the device string passed, including detection
-    of devices if device is not definedor "auto".
+    """Create a device object from the device string passed.
+
+    Includes detection of devices if device is not defined or "auto".
 
     Parameters
     ----------
@@ -112,7 +113,7 @@ def find_device(
 
 
 def assert_no_root() -> bool:
-    """Checks whether the user is the root user and raises an error message is so
+    """Check whether the user is the root user and raises an error message is so.
 
     Returns
     -------
@@ -120,7 +121,6 @@ def assert_no_root() -> bool:
         Whether the user is root or not
 
     """
-
     if os.name == "posix" and os.getuid() == 0:
         import sys
         import __main__
@@ -140,7 +140,7 @@ def assert_no_root() -> bool:
 
 
 def handle_cuda_memory_exception(exception: builtins.BaseException) -> bool:
-    """Handles CUDA out of memory exception and prints a help text
+    """Handle CUDA out of memory exception and print a help text.
 
     Parameters
     ----------
@@ -152,9 +152,7 @@ def handle_cuda_memory_exception(exception: builtins.BaseException) -> bool:
     bool
         Whether th exception was a RuntimeError caused by Cuda out memory
 
-
     """
-
     if not isinstance(exception, RuntimeError):
         return False
     message = exception.args[0]
@@ -180,7 +178,8 @@ def pipeline(
     *,
     pipeline_size: int = 1,
 ) -> Iterator[Tuple[_Ti, _T]]:
-    """Function to pipeline a function to be executed in the pool.
+    """Pipeline a function to be executed in the pool.
+
     Analogous to iterate, but run func in a different
     thread for the next element while the current element is returned.
 
@@ -205,7 +204,6 @@ def pipeline(
         [MISSING]
 
     """
-
     # do pipeline loading the next element
     from collections import deque
 
@@ -243,14 +241,16 @@ def iterate(
         elements
     _T
         [MISSING]
-    """
 
+    """
     for element in iterable:
         yield element, func(element)
 
 
 def removesuffix(string: str, suffix: str) -> str:
-    """Similar to string.removesuffix in PY3.9+, removes a suffix from a string.
+    """Remove  a suffix from a string.
+
+    Similar to string.removesuffix in PY3.9+.
 
     Parameters
     ----------
@@ -265,7 +265,6 @@ def removesuffix(string: str, suffix: str) -> str:
         input string with removed suffix
 
     """
-
     import sys
 
     if sys.version_info.minor >= 9:
@@ -280,6 +279,8 @@ def removesuffix(string: str, suffix: str) -> str:
 
 
 class SubjectDirectory:
+    """Represent a subject."""
+
     _orig_name: str
     _copy_orig_name: str
     _conf_name: str
@@ -290,7 +291,7 @@ class SubjectDirectory:
     _id: str
 
     def __init__(self, **kwargs):
-        """Create a subject, supports generic attributes. Some well integrated attributes arguments include:
+        """Create a subject, supports generic attributes.
 
         Parameters
         ----------
@@ -302,13 +303,13 @@ class SubjectDirectory:
             main_segfile: relative or absolute filename of the main segmentation filename
             asegdkt_segfile: relative or absolute filename of the aparc+aseg segmentation filename
             subject_dir: path to the subjects directory (containing subject folders)
-        """
 
+        """
         for k, v in kwargs.items():
             setattr(self, "_" + k, v)
 
     def filename_in_subject_folder(self, filepath: str) -> str:
-        """Returns the full path to the file
+        """Return the full path to the file.
 
         Parameters
         ----------
@@ -321,7 +322,6 @@ class SubjectDirectory:
             Path to the file
 
         """
-
         return (
             filepath
             if os.path.isabs(filepath)
@@ -329,7 +329,7 @@ class SubjectDirectory:
         )
 
     def filename_by_attribute(self, attr_name: str) -> str:
-        """ [MISSING]
+        """[MISSING].
 
         Parameters
         ----------
@@ -361,7 +361,7 @@ class SubjectDirectory:
         return os.path.exists(self.filename_in_subject_folder(filepath))
 
     def fileexists_by_attribute(self, attr_name: str) -> bool:
-        """[MISSING]
+        """[MISSING].
 
         Parameters
         ----------
@@ -378,7 +378,7 @@ class SubjectDirectory:
 
     @property
     def subject_dir(self) -> str:
-        """Gets the subject directory name
+        """Gets the subject directory name.
 
         Returns
         -------
@@ -391,20 +391,19 @@ class SubjectDirectory:
 
     @subject_dir.setter
     def subject_dir(self, _folder: str):
-        """Sets the subject directory name
+        """Set the subject directory name.
 
         Parameters
         ----------
         _folder : str
             The subject directory
 
-
         """
         self._subject_dir = _folder
 
     @property
     def id(self) -> str:
-        """Gets the id
+        """Get the id.
 
         Returns
         -------
@@ -417,7 +416,7 @@ class SubjectDirectory:
 
     @id.setter
     def id(self, _id: str):
-        """Sets the id
+        """Set the id.
 
         Parameters
         ----------
@@ -429,7 +428,9 @@ class SubjectDirectory:
 
     @property
     def orig_name(self) -> str:
-        """This will typically try to return absolute path, if the native_t1_file is a relative path, it will be
+        """Try to return absolute path.
+
+        If the native_t1_file is a relative path, it will be
         interpreted as relative to folder.
 
         Returns
@@ -445,20 +446,21 @@ class SubjectDirectory:
 
     @orig_name.setter
     def orig_name(self, _orig_name: str):
-        """Sets the orig name
+        """Set the orig name.
 
         Parameters
         ----------
         _orig_name : str
             The orig name
 
-
         """
         self._orig_name = _orig_name
 
     @property
     def copy_orig_name(self) -> str:
-        """This will typically try to return absolute path, if the copy_orig_t1_file is a relative path, it will be
+        """Try to return absolute path.
+
+        If the copy_orig_t1_file is a relative path, it will be
         interpreted as relative to folder.
 
         Returns
@@ -475,7 +477,7 @@ class SubjectDirectory:
 
     @copy_orig_name.setter
     def copy_orig_name(self, _copy_orig_name: str):
-        """Sets the copy of orig name
+        """Set the copy of orig name.
 
         Parameters
         ----------
@@ -492,7 +494,9 @@ class SubjectDirectory:
 
     @property
     def conf_name(self) -> str:
-        """This will typically try to return absolute path, if the conformed_t1_file is a relative path, it will be
+        """Try to return absolute path.
+
+        If the conformed_t1_file is a relative path, it will be
         interpreted as relative to folder.
 
         Returns
@@ -508,7 +512,7 @@ class SubjectDirectory:
 
     @conf_name.setter
     def conf_name(self, _conf_name: str):
-        """[MISSING]
+        """[MISSING].
 
         Parameters
         ----------
@@ -525,15 +529,14 @@ class SubjectDirectory:
 
     @property
     def segfile(self) -> str:
-        """This will typically try to return absolute path, if the segfile is a relative path, it will be
-        interpreted as relative to folder.
+        """Try to return absolute path.
 
-        Parameters
-        ----------
+        If the segfile is a relative path, it will be interpreted as relative to folder.
 
         Returns
         -------
-
+        str
+            Path to the segfile
 
         """
         assert hasattr(self, "_segfile") or "The _segfile attribute has not been set!"
@@ -541,32 +544,27 @@ class SubjectDirectory:
 
     @segfile.setter
     def segfile(self, _segfile: str):
-        """
+        """Set segfile.
 
         Parameters
         ----------
         _segfile : str
-
-
-        Returns
-        -------
-
+            [MISSING]
 
         """
         self._segfile = _segfile
 
     @property
     def asegdkt_segfile(self) -> str:
-        """This will typically try to return absolute path, if the asegdkt_segfile is a relative path, it will be
-        interpreted as relative to folder.
+        """Try to return absolute path.
 
-        Parameters
-        ----------
+        If the asegdkt_segfile is a relative path, it will be
+        interpreted as relative to folder.
 
         Returns
         -------
-
-
+        str
+            Path to segmentation file
         """
         assert (
             hasattr(self, "_segfile")
@@ -576,31 +574,27 @@ class SubjectDirectory:
 
     @asegdkt_segfile.setter
     def asegdkt_segfile(self, _asegdkt_segfile: str):
-        """
+        """Set path to segmentation file.
 
         Parameters
         ----------
         _asegdkt_segfile : str
-
-
-        Returns
-        -------
-
+            Path to segmentation file
 
         """
         self._asegdkt_segfile = _asegdkt_segfile
 
     @property
     def main_segfile(self) -> str:
-        """This will typically try to return absolute path, if the main_segfile is a relative path, it will be
-        interpreted as relative to folder.
+        """Try to return absolute path.
 
-        Parameters
-        ----------
+        If the main_segfile is a relative path, it will be
+        interpreted as relative to folder.
 
         Returns
         -------
-
+        str
+            Path to the main segfile.
 
         """
         assert (
@@ -611,57 +605,55 @@ class SubjectDirectory:
 
     @main_segfile.setter
     def main_segfile(self, _main_segfile: str):
-        """
+        """Set the main segfile.
 
         Parameters
         ----------
         _main_segfile : str
-
-
-        Returns
-        -------
-
+            Path to the main_segfile
 
         """
         self._main_segfile = _main_segfile
 
     def can_resolve_filename(self, filename: str) -> bool:
-        """Whether we can resolve the file name.
+        """Check whether we can resolve the file name.
 
         Parameters
         ----------
         filename : str
-
+            Name of the filename to check
 
         Returns
         -------
-
+        bool
+            Whether we can resolve the file name
 
         """
         return os.path.isabs(filename) or self._subject_dir is not None
 
     def can_resolve_attribute(self, attr_name: str) -> bool:
-        """
+        """Check whether we can resolve the attribute.
 
         Parameters
         ----------
         attr_name : str
-
+            Name of the attribute to check
 
         Returns
         -------
-
+        bool
+            Whether we can resolve the attribute
 
         """
         return self.can_resolve_filename(self.get_attribute(attr_name))
 
     def has_attribute(self, attr_name: str) -> bool:
-        """Checks of the attribute is set
+        """Check if the attribute is set.
 
         Parameters
         ----------
         attr_name : str
-
+            Name of the attribute to check
 
         Returns
         -------
@@ -672,16 +664,16 @@ class SubjectDirectory:
         return getattr(self, "_" + attr_name, None) is not None
 
     def get_attribute(self, attr_name: str):
-        """
+        """Give the requested attribute.
 
         Parameters
         ----------
         attr_name : str
-
+            Name of the attribute to return
 
         Returns
         -------
-
+            Value of the attribute
 
         """
         if not self.has_attribute(attr_name):
@@ -690,7 +682,8 @@ class SubjectDirectory:
 
 
 class SubjectList:
-    """ """
+    """Represent a list of subjects."""
+
     _subjects: List[str]
     _orig_name_: str
     _conf_name_: str
@@ -745,7 +738,6 @@ class SubjectList:
             When using {sid[flag]} with multiple subjects.
 
         """
-
         # populate _flags with DEFAULT_FLAGS
         self._flags = flags.copy() if flags is not None else {}
         for flag, default in self.DEFAULT_FLAGS.items():
@@ -946,12 +938,29 @@ class SubjectList:
 
     @property
     def flags(self) -> Dict[str, Dict]:
+        """Give the flags.
+
+        Returns
+        -------
+        dict[str, dict]
+            Flags
+
+        """
         return self._flags
 
     def __len__(self) -> int:
+        """Give length of subject list.
+
+        Returns
+        -------
+        int
+            Number of subjects
+
+        """
         return self._num_subjects
 
     def make_subjects_dir(self):
+        """Try to create the subject directory."""
         if self._out_dir is None:
             LOGGER.info(
                 "No Subjects directory found, absolute paths for filenames are required."
@@ -965,8 +974,7 @@ class SubjectList:
             os.makedirs(self._out_dir)
 
     def __getitem__(self, item: Union[int, str]) -> SubjectDirectory:
-        """Returns a SubjectDirectory object for the i-th subject (if item is an int) or for the subject with
-        name/folder (if item is a str).
+        """Return a SubjectDirectory object for the i-th subject (if item is an int) or for the subject with name/folder (if item is a str).
 
         Parameters
         ----------
@@ -979,7 +987,6 @@ class SubjectList:
             [MISSING]
 
         """
-
         if isinstance(item, int):
             if item < 0 or item >= self._num_subjects:
                 raise IndexError(
@@ -1016,15 +1023,14 @@ class SubjectList:
         )
 
     def get_common_suffix(self) -> str:
-        """Finds, if all entries in the subject list share a common suffix
+        """Find common suffix, if all entries in the subject list share a common suffix.
 
         Returns
         -------
         str
-            [MISSING]
+            The suffix the entries share
 
         """
-
         suffix = self._subjects[0]
         for subj in self._subjects[1:]:
             if subj.endswith(suffix):
@@ -1038,7 +1044,10 @@ class SubjectList:
         return suffix
 
     def are_all_subject_files(self):
-        """Checks if all entries in subjects are actually files. This is performed asynchronously internally."""
+        """Check if all entries in subjects are actually files.
+
+        This is performed asynchronously internally
+        """
         from asyncio import run, gather
 
         async def is_file(path):
@@ -1051,6 +1060,8 @@ class SubjectList:
 
 
 class NoParallelExecutor(Executor):
+    """Represent a serial executor."""
+
     def map(
         self,
         fn: Callable[..., _T],
@@ -1058,7 +1069,7 @@ class NoParallelExecutor(Executor):
         timeout: Optional[float] = None,
         chunksize: int = -1,
     ) -> Iterator[_T]:
-        """
+        """[MISSING].
 
         Parameters
         ----------
@@ -1080,7 +1091,7 @@ class NoParallelExecutor(Executor):
         return map(fn, *iterables)
 
     def submit(self, __fn: Callable[..., _T], *args, **kwargs) -> "Future[_T]":
-        """
+        """[MISSING].
 
         Parameters
         ----------
@@ -1097,7 +1108,6 @@ class NoParallelExecutor(Executor):
             [MISSING]
 
         """
-
         f = Future()
         try:
             f.set_result(__fn(*args, **kwargs))

--- a/FastSurferCNN/utils/load_config.py
+++ b/FastSurferCNN/utils/load_config.py
@@ -33,7 +33,6 @@ def get_config(args: argparse.Namespace) -> yacs.config.CfgNode:
         Configuration node
     
     """
-
     # Setup cfg.
     cfg = get_cfg_defaults()
     # Load config from cfg.
@@ -55,7 +54,7 @@ def get_config(args: argparse.Namespace) -> yacs.config.CfgNode:
 
 
 def load_config(cfg_file: str) -> yacs.config.CfgNode:
-    """Load a yaml config file
+    """Load a yaml config file.
 
     Parameters
     ----------
@@ -68,7 +67,6 @@ def load_config(cfg_file: str) -> yacs.config.CfgNode:
         configuration node
     
     """
-
     # setup base
     cfg = get_cfg_defaults()
     cfg.EXPR_NUM = "Default"

--- a/FastSurferCNN/utils/logging.py
+++ b/FastSurferCNN/utils/logging.py
@@ -28,7 +28,7 @@ from sys import stdout as _stdout
 
 
 def setup_logging(log_file_path: str):
-    """Sets up the logging
+    """Set up the logging.
 
     Parameters
     ----------
@@ -36,7 +36,6 @@ def setup_logging(log_file_path: str):
         Path to the logfile
 
     """
-
     # Set up logging format.
     _FORMAT = "[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s"
     handlers = [StreamHandler(_stdout)]

--- a/FastSurferCNN/utils/lr_scheduler.py
+++ b/FastSurferCNN/utils/lr_scheduler.py
@@ -23,7 +23,7 @@ def get_lr_scheduler(
         optimzer: torch.optim.Optimizer,
         cfg: yacs.config.CfgNode
 ) -> Union[None, scheduler.StepLR, scheduler.CosineAnnealingWarmRestarts]:
-    """
+    """Give a schedular for left-right scheduling.
 
     Parameters
     ----------
@@ -34,15 +34,14 @@ def get_lr_scheduler(
 
     Returns
     -------
+    [MISSING]
 
     Raises
     ------
     ValueError
         lr scheduler is not supported
 
-    
     """
-
     scheduler_type = cfg.OPTIMIZER.LR_SCHEDULER
     if scheduler_type == "step_lr":
         return scheduler.StepLR(

--- a/FastSurferCNN/utils/mapper.py
+++ b/FastSurferCNN/utils/mapper.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 """
-Original Author: David Kuegler
+Original Author: David Kuegler.
+
 Date: Aug-19-2022
 """
 
@@ -79,20 +80,19 @@ LabelImageType = TypeVar("LabelImageType", torch.Tensor, npt.NDArray[int])
 
 
 def is_int(a_object) -> bool:
-    """Checks whether the array_or_tensor is an integer.
+    """Check whether the array_or_tensor is an integer.
 
     Parameters
     ----------
     a_object :
-        An object
+        The object to check its type
 
     Returns
     -------
     bool
-        [MISSING]
+        Whether the data type of the object is int or not
     
     """
-
     from collections.abc import Collection
 
     if isinstance(a_object, np.ndarray):
@@ -108,7 +108,7 @@ def is_int(a_object) -> bool:
 
 
 def to_same_type(data, type_hint: AT) -> AT:
-    """Converts data to the same type as type_hint.
+    """Convert data to the same type as type_hint.
 
     Parameters
     ----------
@@ -123,7 +123,6 @@ def to_same_type(data, type_hint: AT) -> AT:
         [MISSING]
     
     """
-
     if torch.is_tensor(type_hint) and not torch.is_tensor(data):
         return torch.as_tensor(data, dtype=type_hint.dtype, device=type_hint.device)
     elif isinstance(type_hint, np.ndarray) and not isinstance(data, np.ndarray):
@@ -135,7 +134,7 @@ def to_same_type(data, type_hint: AT) -> AT:
 
 
 class Mapper(Generic[KT, VT]):
-    """Class to map from one label space to a generic 'label'-space."""
+    """Map from one label space to a generic 'label'-space."""
 
     _map_dict: Dict[KT, npt.NDArray[VT]]
     _label_shape: Tuple[int, ...]
@@ -147,7 +146,7 @@ class Mapper(Generic[KT, VT]):
     def __init__(
         self, mappings: Mapping[KT, Union[VT, npt.NDArray[VT]]], name: str = "undefined"
     ):
-        """Creates a :class:`Mapper` object from a mappings dictionary.
+        """Construct `Mapper` object from a mappings dictionary.
 
         Parameters
         ----------
@@ -157,7 +156,6 @@ class Mapper(Generic[KT, VT]):
             name for messages (default: "undefined").
 
         """
-
         if len(mappings) == 0:
             raise RuntimeError("The mappings object is empty.")
 
@@ -184,27 +182,27 @@ class Mapper(Generic[KT, VT]):
 
     @property
     def name(self) -> str:
-        """Returns the name of the mapper."""
+        """Return the name of the mapper."""
         return self._name
 
     @name.setter
     def name(self, name: str):
-        """Set the name"""
+        """Set the name."""
         self._name = name
 
     @property
     def source_space(self) -> Set[KT]:
-        """Returns a set of labels the mapper accepts."""
+        """Return a set of labels the mapper accepts."""
         return set(self._map_dict.keys())
 
     @property
     def target_space(self) -> Collection[VT]:
-        """Returns the set of labels the mapper converts to as a set of python-natives (if possible), arrays
-        expanded to tuples."""
+        """Return the set of labels the mapper converts to as a set of python-natives (if possible), arrays expanded to tuples."""
         return self._map_dict.values()
 
     @property
     def max_label(self) -> int:
+        """Return the max label."""
         if self._max_label is None:
             raise RuntimeError("max_label is only valid for integer keys.")
         return self._max_label
@@ -212,7 +210,7 @@ class Mapper(Generic[KT, VT]):
     def update(
         self, other: "Mapper[KT, VT]", overwrite: bool = True
     ) -> "Mapper[KT, VT]":
-        """Merges another map into this mapper.
+        """Merge another map into this mapper.
 
         Parameters
         ----------
@@ -227,7 +225,6 @@ class Mapper(Generic[KT, VT]):
             [MISSING]
         
         """
-
         for key, value in iter(other):
             if overwrite or key not in self._map_dict:
                 self._map_dict[key] = value
@@ -258,7 +255,6 @@ class Mapper(Generic[KT, VT]):
             [MISSING]
         
         """
-
         # torch sparse tensors can't index with images
         # self._map = _b.torch.sparse_coo_tensor(src_labels, labels, (self._max_label,) + self._label_shape)
 
@@ -346,7 +342,6 @@ class Mapper(Generic[KT, VT]):
             [MISSING]
         
         """
-
         out_type = image if out is None else out
         if out is None:
 
@@ -374,7 +369,7 @@ class Mapper(Generic[KT, VT]):
     def __call__(
         self, image: AT, label_image: Union[npt.NDArray[KT], torch.Tensor]
     ) -> Tuple[AT, Union[npt.NDArray, torch.Tensor]]:
-        """Transforms a dataset from prediction to internal space for sets of image and segmentation.
+        """Transform a dataset from prediction to internal space for sets of image and segmentation.
 
         Parameters
         ----------
@@ -390,12 +385,12 @@ class Mapper(Generic[KT, VT]):
             image
         Union[npt.NDArray, torch.Tensor]
             mapped values
-        """
 
+        """
         return image, self.map(label_image)
 
     def reversed_dict(self) -> Mapping[VT, KT]:
-        """A dictionary mapping from the target space to the source space."""
+        """Map dictionary from the target space to the source space."""
         rev_mappings = {}
         for src in sorted(self.source_space):
             a = self._map_dict[src]
@@ -407,26 +402,31 @@ class Mapper(Generic[KT, VT]):
         return rev_mappings
 
     def __reversed__(self) -> "Mapper[VT, KT]":
-        """A mapper that reverts the original transformation (with non-bijective mappings mapping to the lower key)."""
+        """Reverse map the original transformation (with non-bijective mappings mapping to the lower key)."""
         return Mapper(self.reversed_dict(), name="reverse-" + self.name)
 
     def is_bijective(self) -> bool:
-        """Returns, whether the Mapper is bijective."""
+        """Return, whether the Mapper is bijective."""
         return len(self.source_space) == len(self.target_space)
 
     def __getitem__(self, item: KT) -> VT:
+        """Return the value of the item."""
         return self._map_dict[item]
 
     def __iter__(self) -> Iterator[Tuple[KT, VT]]:
+        """[MISSING]."""
         return iter(self._map_dict.items())
 
     def __contains__(self, item: KT) -> bool:
+        """Check whether the mapping contains the item."""
         return self._map_dict.__contains__(item)
 
     def chain(
         self, other_mapper: "Mapper[VT, T_OtherValue]"
     ) -> "Mapper[KT, T_OtherValue]":
-        """Chains the current mapper with the `other_mapper`.  This effectively is an optimization to first applying this
+        """Chain the current mapper with the `other_mapper`.
+
+        This effectively is an optimization to first applying this
         mapper and then applying the `other_mapper`.
 
         Parameters
@@ -438,6 +438,7 @@ class Mapper(Generic[KT, VT]):
         -------
         Mapper : "Mapper[KT, T_OtherValue]"
             A mapper mapping from the input space of this mapper to the target-space of the `other_mapper`.
+
         """
         target_space = list(self.target_space)
         is_target_set = [not isinstance(t, Hashable) for t in target_space]
@@ -471,7 +472,8 @@ class Mapper(Generic[KT, VT]):
         compress_out_space: bool = False,
         name: str = "undefined",
     ) -> "Mapper[int, int]":
-        """Mapper to map from one label space (int) to another (also int) using a mappings function.
+        """Map from one label space (int) to another (also int) using a mappings function.
+
         Can also be used as a transform.
         
         Creates a :class:`Mapper` object from a mappings dictionary and a
@@ -498,8 +500,8 @@ class Mapper(Generic[KT, VT]):
         ------
         ValueError
             If keep_labels contains an entry > 65535.
-        """
 
+        """
         if any(v not in keep_labels for v in mappings.values()):
             mappings.update(dict((k, k) for k in keep_labels))
 
@@ -524,7 +526,6 @@ class Mapper(Generic[KT, VT]):
         mode: Literal["logit", "prob"] = "logit",
     ) -> AT:
         """Map logits or probabilities with the Mapper."""
-
         if not is_int(self.source_space) or not is_int(self.target_space):
             raise ValueError("map_logits/map_probs requires a mapping from int to int.")
 
@@ -614,7 +615,7 @@ class ColorLookupTable(Generic[KT]):
         colormap: Union[str, Colormap, ColormapGenerator] = "gist_ncar",
         name: Optional[str] = None,
     ):
-        """Create a LookupTable.
+        """Construct a LookupTable object.
 
         Parameters
         ----------
@@ -631,7 +632,6 @@ class ColorLookupTable(Generic[KT]):
             name for messages (default: "unnamed lookup table").
 
         """
-
         self._name = "unnamed lookup table" if name is None else name
 
         if (
@@ -648,26 +648,17 @@ class ColorLookupTable(Generic[KT]):
 
     @property
     def name(self) -> str:
-        """Returns the name of the mapper."""
+        """Return the name of the mapper."""
         return self._name
 
     @name.setter
     def name(self, name: str):
-        """Set the name"""
+        """Set the name."""
         self._name = name
 
     @property
     def classes(self) -> Optional[List[KT]]:
-        """
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-
-        
-        """
+        """Return the classes."""
         return self._classes
 
     @classes.setter
@@ -693,6 +684,7 @@ class ColorLookupTable(Generic[KT]):
 
     @property
     def color_palette(self) -> Optional[npt.NDArray[float]]:
+        """Return the color palette if it exists."""
         return self._color_palette
 
     @color_palette.setter
@@ -721,7 +713,7 @@ class ColorLookupTable(Generic[KT]):
             self._color_palette = color_palette
 
     def __getitem__(self, key: KT) -> Tuple[int, KT, Tuple[int, int, int, int], Any]:
-        """Returns index, key, colors and additional values for the key.
+        """Return index, key, colors and additional values for the key.
 
         Parameters
         ----------
@@ -734,19 +726,18 @@ class ColorLookupTable(Generic[KT]):
             If key is not in _classes
 
         """
-
         index = self._classes.index(key)
         return self.getitem_by_index(index)
 
     def getitem_by_index(
         self, index: int
     ) -> Tuple[int, KT, Tuple[int, int, int, int], Any]:
-        """Returns index, key, colors and additional values for the key."""
+        """Return index, key, colors and additional values for the key."""
         color = self.get_color_by_index(index, 255)
         return index, self._classes[index], color, None
 
     def get_color_by_index(self, index: int, base: NT = 1.0) -> Tuple[NT, NT, NT, NT]:
-        """Returns the color (r, g, b, a) tuple associated with the index in the passed base."""
+        """Return the color (r, g, b, a) tuple associated with the index in the passed base."""
         if self._color_palette is None:
             raise RuntimeError("No color_palette set")
         base_type = type(base)
@@ -764,6 +755,7 @@ class ColorLookupTable(Generic[KT]):
         return color
 
     def colormap(self) -> Mapper[KT, ColorTuple]:
+        """[MISSING]."""
         if self._color_palette is None:
             raise RuntimeError("No color_palette set")
         return Mapper(
@@ -771,15 +763,17 @@ class ColorLookupTable(Generic[KT]):
         )
 
     def labelname2index(self) -> Mapper[KT, int]:
-        """Returns a mapping between the key and the (consecutive) index it is associated with. This is the inverse of
-        ColorLookupTable.classes."""
+        """Return a mapping between the key and the (consecutive) index it is associated with.
+
+        This is the inverse of ColorLookupTable.classes.
+        """
         return Mapper(
             dict(zip(self._classes, range(len(self._classes)))),
             name="index-" + self.name,
         )
 
     def labelname2id(self) -> Mapper[KT, Any]:
-        """Returns a mapping between the key and the value it is associated with.
+        """Return a mapping between the key and the value it is associated with.
 
         Raises
         ------
@@ -787,11 +781,11 @@ class ColorLookupTable(Generic[KT]):
             If no value is associated.
 
         """
-
         raise RuntimeError("The base class keeps no ids (only indexes).")
 
 
 class JsonColorLookupTable(ColorLookupTable[KT]):
+    """[MISSING]."""
 
     _data: Any
 
@@ -802,7 +796,7 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
         colormap: Union[str, Colormap, ColormapGenerator] = "gist_ncar",
         name: Optional[str] = None,
     ) -> None:
-        """Creates a JsonLookupTable object from `file_or_buffer` passed.
+        """Construct a JsonLookupTable object from `file_or_buffer` passed.
 
         Parameters
         ----------
@@ -819,7 +813,6 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
             name for messages (default: fallback to file_or_buffer, if possible).
 
         """
-
         if isinstance(file_or_buffer, str) and file_or_buffer.lstrip().startswith("{"):
             self._data = json.loads(file_or_buffer)
             if name is None:
@@ -860,6 +853,7 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
         )
 
     def _get_labels(self) -> Union[Dict[KT, Any], Iterable[KT]]:
+        """Return labels."""
         return (
             self._data["labels"]
             if isinstance(self._data, dict) and "labels" in self._data
@@ -867,11 +861,12 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
         )
 
     def dataframe(self) -> pandas.DataFrame:
+        """[MISSING]."""
         if isinstance(self._data, dict) and "labels" in self._data:
             return pandas.DataFrame.from_dict(self._data["labels"])
 
     def __getitem__(self, key: KT) -> Tuple[int, KT, Tuple[int, int, int, int], Any]:
-        """Int will index by the index position, unless either key or value are int."""
+        """Index by the index position, unless either key or value are int."""
         labels = self._get_labels()
         index, key, color, _other = super(JsonColorLookupTable, self).__getitem__(key)
         if isinstance(labels, dict):
@@ -879,7 +874,7 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
         return index, key, color, _other
 
     def labelname2id(self) -> Mapper[KT, Any]:
-        """Returns a mapping between the key and the value it is associated with.
+        """Return a mapping between the key and the value it is associated with.
 
         Returns
         -------
@@ -890,8 +885,8 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
         ------
         RuntimeError
             If no value is associated.
-        """
 
+        """
         labels = self._get_labels()
         if not isinstance(labels, dict):
             raise RuntimeError("The json file contained no values.")
@@ -901,6 +896,7 @@ class JsonColorLookupTable(ColorLookupTable[KT]):
 
 
 class TSVLookupTable(ColorLookupTable[str]):
+    """[MISSING]."""
 
     _data: pandas.DataFrame
 
@@ -911,7 +907,7 @@ class TSVLookupTable(ColorLookupTable[str]):
         header: bool = False,
         add_background: bool = True,
     ) -> None:
-        """Creates a CSVLookupTable object from `file_or_buffer` passed.
+        """Create a CSVLookupTable object from `file_or_buffer` passed.
 
         Parameters
         ----------
@@ -926,7 +922,6 @@ class TSVLookupTable(ColorLookupTable[str]):
             whether to add a label for background (default: True)
 
         """
-
         if name is None:
             if isinstance(file_or_buffer, str):
                 if not os.path.exists(file_or_buffer):
@@ -992,16 +987,15 @@ class TSVLookupTable(ColorLookupTable[str]):
             [MISSING]
         
         """
-
         index, key, color, _ = super(TSVLookupTable, self).getitem_by_index(index)
         return index, key, color, self._data.iloc[index].name
 
     def dataframe(self) -> pandas.DataFrame:
-        """Returns the raw panda data object."""
+        """Return the raw panda data object."""
         return self._data
 
     def labelname2id(self) -> Mapper[KT, Any]:
-        """Returns a Mapper between the key and the value it is associated with.
+        """Return a Mapper between the key and the value it is associated with.
 
         Returns
         -------
@@ -1011,6 +1005,7 @@ class TSVLookupTable(ColorLookupTable[str]):
         ------
         RuntimeError
             If no value is associated.
+
         """
         return Mapper(
             dict(zip(self._classes, self._data.index)), name="value-" + self.name

--- a/FastSurferCNN/utils/meters.py
+++ b/FastSurferCNN/utils/meters.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 class Meter:
+    """[MISSING]."""
+
     def __init__(
         self,
         cfg: yacs.config.CfgNode,
@@ -39,6 +41,28 @@ class Meter:
         device: Optional[Any] = None,
         writer:  Optional[Any] = None,
     ):
+        """Construct a Meter object.
+
+        Parameters
+        ----------
+        cfg
+            [MISSING]
+        mode
+            [MISSING]
+        global_step
+            [MISSING]
+        total_iter
+            [MISSING]
+        total_epoch
+            [MISSING]
+        class_names
+            [MISSING]
+        device
+            [MISSING]
+        writer
+            [MISSING]
+
+        """
         self._cfg = cfg
         self.mode = mode.capitalize()
         self.confusion_mat = False
@@ -54,23 +78,25 @@ class Meter:
         self.total_epochs = total_epoch
 
     def reset(self):
-        """reset bach losses and dice scores"""
+        """Reset bach losses and dice scores."""
         self.batch_losses = []
         self.dice_score.reset()
 
     def enable_confusion_mat(self):
+        """[MISSING]."""
         self.confusion_mat = True
 
     def disable_confusion_mat(self):
+        """[MISSING]."""
         self.confusion_mat = False
 
     def update_stats(self, pred, labels, batch_loss):
+        """[MISSING]."""
         self.dice_score.update((pred, labels), self.confusion_mat)
         self.batch_losses.append(batch_loss.item())
 
     def write_summary(self, loss_total, lr=None, loss_ce=None, loss_dice=None):
-        """write a summary of the losses and scores
-
+        """Write a summary of the losses and scores.
 
         Parameters
         ----------
@@ -84,7 +110,6 @@ class Meter:
             [MISSING] (Default value = None)
 
         """
-
         self.writer.add_scalar(
             f"{self.mode}/total_loss", loss_total.item(), self.global_iter
         )
@@ -102,7 +127,7 @@ class Meter:
         self.global_iter += 1
 
     def log_iter(self, cur_iter: int, cur_epoch: int):
-        """logs the current iteration
+        """Log the current iteration.
 
         Parameters
         ----------
@@ -112,7 +137,6 @@ class Meter:
             current epoch
 
         """
-
         if (cur_iter + 1) % self._cfg.TRAIN.LOG_INTERVAL == 0:
             logger.info(
                 "{} Epoch [{}/{}] Iter [{}/{}] with loss {:.4f}".format(
@@ -126,7 +150,7 @@ class Meter:
             )
 
     def log_epoch(self, cur_epoch: int):
-        """logs the current epoch
+        """Log the current epoch.
 
         Parameters
         ----------
@@ -134,7 +158,6 @@ class Meter:
             current epoch
         
         """
-
         dice_score = self.dice_score.compute_dsc()
         self.writer.add_scalar(f"{self.mode}/mean_dice_score", dice_score, cur_epoch)
         if self.confusion_mat:

--- a/FastSurferCNN/utils/metrics.py
+++ b/FastSurferCNN/utils/metrics.py
@@ -23,8 +23,9 @@ logger = logging.getLogger(__name__)
 
 
 def iou_score(pred_cls: torch.Tensor, true_cls: torch.Tensor, nclass: int =79) -> Tuple[np.ndarray, np.ndarray]:
-    """compute the intersection-over-union score
-    both inputs should be categorical (as opposed to one-hot)
+    """Compute the intersection-over-union score.
+
+    Both inputs should be categorical (as opposed to one-hot)
 
     Parameters
     ----------
@@ -41,8 +42,8 @@ def iou_score(pred_cls: torch.Tensor, true_cls: torch.Tensor, nclass: int =79) -
         [MISSING]
     np.ndarray
         [MISSING]
-    """
 
+    """
     intersect_ = []
     union_ = []
 
@@ -62,7 +63,7 @@ def precision_recall(
         true_cls: torch.Tensor,
         nclass: int = 79
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Function to calculate recall (TP/(TP + FN) and precision (TP/(TP+FP) per class
+    """Calculate recall (TP/(TP + FN) and precision (TP/(TP+FP) per class.
 
     Parameters
     ----------
@@ -79,8 +80,8 @@ def precision_recall(
         [MISSING]
     np.ndarray
         [MISSING]
-    """
 
+    """
     tpos_fneg = []
     tpos_fpos = []
     tpos = []
@@ -97,7 +98,7 @@ def precision_recall(
 
 
 class DiceScore:
-    """Accumulating the component of the dice coefficient i.e. the union and intersection
+    """Accumulate the component of the dice coefficient i.e. the union and intersection.
 
     Attributes
     ----------
@@ -122,6 +123,7 @@ class DiceScore:
         device: Optional[str] =None,
         output_transform=lambda y_pred, y: (y_pred.data.max(1)[1], y),
     ):
+        """Construct DiceScore object."""
         self._device = device
         self.out_transform = output_transform
         self.n_classes = num_classes
@@ -129,12 +131,14 @@ class DiceScore:
         self.intersection = torch.zeros(self.n_classes, self.n_classes, device=device)
 
     def reset(self):
+        """[MISSING]."""
         self.union = torch.zeros(self.n_classes, self.n_classes, device=self._device)
         self.intersection = torch.zeros(
             self.n_classes, self.n_classes, device=self._device
         )
 
     def _check_output_type(self, output):
+        """Check the output type."""
         if not (isinstance(output, tuple)):
             raise TypeError(
                 "Output should a tuple consist of of torch.Tensors, but given {}".format(
@@ -143,7 +147,7 @@ class DiceScore:
             )
 
     def _update_union_intersection_matrix(self, batch_output: torch.Tensor, labels_batch: torch.Tensor):
-        """Update the union intersection matrix
+        """Update the union intersection matrix.
 
         Parameters
         ----------
@@ -153,7 +157,6 @@ class DiceScore:
             label batch
         
         """
-
         for i in range(self.n_classes):
             gt = (labels_batch == i).float()
             for j in range(self.n_classes):
@@ -162,7 +165,7 @@ class DiceScore:
                 self.union[i, j] += torch.sum(gt) + torch.sum(pred)
 
     def _update_union_intersection(self, batch_output: torch.Tensor, labels_batch: torch.Tensor):
-        """Update the union intersection
+        """Update the union intersection.
 
         Parameters
         ----------
@@ -171,7 +174,6 @@ class DiceScore:
         labels_batch : torch.Tensor
 
         """
-
         for i in range(self.n_classes):
             gt = (labels_batch == i).float()
             pred = (batch_output == i).float()
@@ -179,7 +181,7 @@ class DiceScore:
             self.union[i, i] += torch.sum(gt) + torch.sum(pred)
 
     def update(self, output: Tuple[Any, Any], cnf_mat: bool):
-        """update the intersection
+        """Update the intersection.
 
         Parameters
         ----------
@@ -189,7 +191,6 @@ class DiceScore:
             Confusion matrix
 
         """
-
         self._check_output_type(output)
 
         if self._device is not None:
@@ -204,7 +205,7 @@ class DiceScore:
             self._update_union_intersection(y_pred, y)
 
     def compute_dsc(self) -> float:
-        """computes the dice score
+        """Compute the dice score.
 
         Returns
         -------
@@ -212,22 +213,24 @@ class DiceScore:
             dice score
         
         """
-
         dsc_per_class = self._dice_calculation()
         dsc = dsc_per_class.mean()
         return dsc
 
     def comput_dice_cnf(self):
+        """Compute the dice cnf."""
         dice_cm_mat = self._dice_confusion_matrix()
         return dice_cm_mat
 
     def _dice_calculation(self):
+        """[MISSING]."""
         intersection = self.intersection.diagonal()
         union = self.union.diagonal()
         dsc = 2 * torch.div(intersection, union)
         return dsc
 
     def _dice_confusion_matrix(self):
+        """[MISSING]."""
         dice_intersection = self.intersection.cpu().numpy()
         dice_union = self.union.cpu().numpy()
         if not (dice_union > 0).all():
@@ -237,4 +240,5 @@ class DiceScore:
 
 
 def dice_score(cm):
+    """[MISSING]."""
     pass

--- a/FastSurferCNN/utils/misc.py
+++ b/FastSurferCNN/utils/misc.py
@@ -36,7 +36,7 @@ def plot_predictions(
         plt_title: str,
         file_save_name: str
 ) -> None:
-    """Function to plot predictions from validation set.
+    """Plot predictions from validation set.
 
     Parameters
     ----------
@@ -52,7 +52,6 @@ def plot_predictions(
         name the plot should be saved tp
 
     """
-
     f = plt.figure(figsize=(20, 10))
     n, c, h, w = images_batch.shape
     mid_slice = c // 2
@@ -88,7 +87,7 @@ def plot_confusion_matrix(
         cmap: plt.cm.ColormapRegistry = plt.cm.Blues,
         file_save_name: str = "temp.pdf"
 ) -> matplotlib.figure.Figure:
-    """
+    """Plot the confusion matrix.
 
     Parameters
     ----------
@@ -107,8 +106,8 @@ def plot_confusion_matrix(
     -------
     fig : matplotlib.figure.Figure
         [MISSING]
-    """
 
+    """
     n_classes = len(classes)
 
     fig, ax = plt.subplots()
@@ -150,7 +149,7 @@ def plot_confusion_matrix(
 
 
 def find_latest_experiment(path: str) -> int:
-    """Find an load latest experiment
+    """Find and load latest experiment.
 
     Parameters
     ----------
@@ -163,7 +162,6 @@ def find_latest_experiment(path: str) -> int:
         latest experiments
     
     """
-
     list_of_experiments = os.listdir(path)
     list_of_int_experiments = []
     for exp in list_of_experiments:
@@ -180,10 +178,21 @@ def find_latest_experiment(path: str) -> int:
 
 
 def check_path(path: str):
+    """Create path."""
     os.makedirs(path, exist_ok=True)
     return path
 
 
 def update_num_steps(dataloader: FastSurferCNN.data_loader.loader.DataLoader,
                      cfg: yacs.config.CfgNode):
+    """Update the number of steps.
+
+    Parameters
+    ----------
+    dataloader : FastSurferCNN.data_loader.loader.DataLoader
+        [MISSING]
+    cfg : yacs.config.CfgNode
+        [MISSING]
+
+    """
     cfg.TRAIN.NUM_STEPS = len(dataloader)

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Contains the ALL_FLAGS dictionary, which can be used as follows to add default flags:
+Contains the ALL_FLAGS dictionary, which can be used as follows to add default flags.
 
 >>> parser = argparse.ArgumentParser()
 >>> ALL_FLAGS["allow_root"](parser, dest="root")
@@ -47,12 +47,16 @@ VoxSize = Union[Literal["min"], float]
 
 
 class CanAddArguments(Protocol):
+    """[MISSING]."""
+
     def add_argument(self, *args, **kwargs):
+        """[MISSING]."""
         ...
 
 
 def __arg(*default_flags, **default_kwargs):
-    """Function to create stub function, which sets default settings for argparse arguments.
+    """Create stub function, which sets default settings for argparse arguments.
+
     The positional and keyword arguments function as if they were directly passed to parser.add_arguments().
     
     The result will be a stub function, which has as first argument a parser (or other object with an
@@ -62,7 +66,6 @@ def __arg(*default_flags, **default_kwargs):
     
     This function is private for this module.
     """
-
     def _stub(parser: Union[CanAddArguments, Type[Dict]], *flags, **kwargs):
         # prefer the value passed to the "new" call
         for kw, arg in kwargs.items():
@@ -289,8 +292,8 @@ def add_arguments(parser: T_AddArgs, flags: Iterable[str]) -> T_AddArgs:
     -------
     T_AddArgs
         The parser object
-    """
 
+    """
     for flag in flags:
         if flag.startswith("--"):
             flag = flag[2:]
@@ -309,7 +312,9 @@ def add_plane_flags(
     type: Literal["checkpoint", "config"],
     files: Mapping[str, str],
 ) -> argparse.ArgumentParser:
-    """Helper function to add plane arguments. Arguments will be added for each entry in files, where the key is the "plane"
+    """Add plane arguments.
+
+    Arguments will be added for each entry in files, where the key is the "plane"
     and the values is the file name (relative for path relative to FASTSURFER_HOME.
 
     Parameters
@@ -329,7 +334,6 @@ def add_plane_flags(
         The parser object.
     
     """
-
     if type not in PLANE_SHORT:
         raise ValueError("type must be either config or checkpoint.")
 

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -82,7 +82,7 @@ h_threads = "<int> number of threads, default: 1"
 
 
 def options_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
@@ -90,7 +90,6 @@ def options_parse():
         object holding options
 
     """
-
     parser = optparse.OptionParser(
         version="$Id: N4_bias_correct.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $",
         usage=HELPTEXT,
@@ -154,9 +153,7 @@ def N4correctITK(
     itkcorrected
         Bias field corrected image
 
-    
     """
-
     # if no mask is passed, create a simple mask from the image
     if not itkmask:
         itkmask = itkimage > 0
@@ -215,7 +212,7 @@ def normalizeWM(
         centroid: Optional[Any] = None,
         targetWM: int = 110
 ) -> sitk.Image:
-    """Normalize WM image [MISSING]
+    """Normalize WM image [MISSING].
 
     Parameters
     ----------
@@ -234,10 +231,8 @@ def normalizeWM(
     -------
     normed
         Normalized WM image
-
     
     """
-
     # print("\nnormalizeWM:")
 
     mask_passed = True
@@ -310,7 +305,7 @@ def normalizeWM(
 
 
 def readTalairachXFM(fname: str) -> np.ndarray:
-    """Read TalairachXFM image
+    """Read TalairachXFM image.
 
     Parameters
     ----------
@@ -322,9 +317,7 @@ def readTalairachXFM(fname: str) -> np.ndarray:
     tal
         TalairachXFM image
 
-    
     """
-
     with open(fname) as f:
         lines = f.readlines()
     f.close()
@@ -344,7 +337,7 @@ def readTalairachXFM(fname: str) -> np.ndarray:
 
 
 def getTalOriginVox(tal: npt.ArrayLike, image: sitk.Image):
-    """Get the original Talairach Voxel
+    """Get the original Talairach Voxel.
 
     Parameters
     ----------
@@ -358,9 +351,7 @@ def getTalOriginVox(tal: npt.ArrayLike, image: sitk.Image):
     vox_origin
         Original Talairach Voxel
 
-    
     """
-
     talinv = np.linalg.inv(tal)
     tal_origin = np.array(talinv[0:3, 3]).ravel()
     # print("Tal Physical Origin: {}".format(tal_origin))
@@ -370,7 +361,6 @@ def getTalOriginVox(tal: npt.ArrayLike, image: sitk.Image):
 
 
 if __name__ == "__main__":
-
     # Command Line options are error checking done here
     options = options_parse()
 

--- a/recon_surf/align_points.py
+++ b/recon_surf/align_points.py
@@ -28,8 +28,7 @@ from typing import Tuple
 
 
 def rmat2angles(R: npt.NDArray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Extracts rotation angles (alpha,beta,gamma) in FreeSurfer format (mris_register)
-    from a rotation matrix
+    """Extract rotation angles (alpha,beta,gamma) in FreeSurfer format (mris_register) from a rotation matrix.
 
     Parameters
     ----------
@@ -42,7 +41,6 @@ def rmat2angles(R: npt.NDArray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         Rotation degree
 
     """
-
     alpha = np.degrees(-np.arctan2(R[1, 0], R[0, 0]))
     beta = np.degrees(np.arcsin(R[2, 0]))
     gamma = np.degrees(np.arctan2(R[2, 1], R[2, 2]))
@@ -50,7 +48,7 @@ def rmat2angles(R: npt.NDArray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
 
 
 def angles2rmat(alpha: float, beta: float, gamma: float) -> np.array:
-    """Converts FreeSurfer angles (alpha,beta,gamma) in degrees to a rotation matrix
+    """Convert FreeSurfer angles (alpha,beta,gamma) in degrees to a rotation matrix.
 
     Parameters
     ----------
@@ -67,7 +65,6 @@ def angles2rmat(alpha: float, beta: float, gamma: float) -> np.array:
         rotation angles
 
     """
-
     sa = np.sin(np.radians(alpha))
     sb = np.sin(np.radians(beta))
     sg = np.sin(np.radians(gamma))
@@ -85,7 +82,7 @@ def angles2rmat(alpha: float, beta: float, gamma: float) -> np.array:
 
 
 def find_rotation(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
-    """find the rotation matrix
+    """Find the rotation matrix.
 
     Parameters
     ----------
@@ -104,9 +101,7 @@ def find_rotation(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
     ValueError
         Shape of points should be identical
 
-
     """
-
     if p_mov.shape != p_dst.shape:
         raise ValueError(
             "Shape of points should be identical, but mov = {}, dst = {} expecting Nx3".format(
@@ -136,7 +131,7 @@ def find_rotation(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
 
 
 def find_rigid(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
-    """[MISSING]
+    """[MISSING].
 
     Parameters
     ----------
@@ -150,9 +145,7 @@ def find_rigid(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
     T
         Homogeneous transformation matrix
 
-
     """
-
     if p_mov.shape != p_dst.shape:
         raise ValueError(
             "Shape of points should be identical, but mov = {}, dst = {} expecting Nx3".format(
@@ -182,8 +175,9 @@ def find_rigid(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
     return T
 
 def find_affine(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
-    """find affine by least squares solution of overdetermined system
-    (assuming we have more than 4 point pairs)
+    """Find affine by least squares solution of overdetermined system.
+
+    Assuming we have more than 4 point pairs
 
     Parameters
     ----------
@@ -202,9 +196,7 @@ def find_affine(p_mov: npt.NDArray, p_dst: npt.NDArray) -> np.ndarray:
     ValueError
         Shape of points should be identical
 
-
     """
-
     from scipy.linalg import pinv
 
     if p_mov.shape != p_dst.shape:

--- a/recon_surf/align_seg.py
+++ b/recon_surf/align_seg.py
@@ -64,10 +64,7 @@ h_flipped = "register to left-right flipped as target aparc+aseg (cortical neede
 
 
 def options_parse():
-    """Command line option parser
-
-    Parameters
-    ----------
+    """Command line option parser.
 
     Returns
     -------
@@ -101,7 +98,7 @@ def options_parse():
 
 
 def get_seg_centroids(seg_mov: sitk.Image, seg_dst: sitk.Image, label_ids: Optional[npt.NDArray[int]] = []) -> Tuple[npt.NDArray, npt.NDArray]:
-    """extracts the centroids of the segmentation labels for mov and dst in RAS coords
+    """Extract the centroids of the segmentation labels for mov and dst in RAS coords.
 
     Parameters
     ----------
@@ -120,7 +117,6 @@ def get_seg_centroids(seg_mov: sitk.Image, seg_dst: sitk.Image, label_ids: Optio
         List of centroids of target segmentation
 
     """
-
     if not label_ids:
         # use all joint labels except -1 and 0:
         nda1 = sitk.GetArrayFromImage(seg_mov)
@@ -161,8 +157,7 @@ def align_seg_centroids(
         label_ids: Optional[npt.NDArray[int]] = [],
         affine: bool = False
 ) -> npt.NDArray:
-    """Aligns the segmentations based on label centroids (rigid is default)
-    returns RAS2RAS transform
+    """Align the segmentations based on label centroids (rigid is default).
 
     Parameters
     ----------
@@ -179,10 +174,9 @@ def align_seg_centroids(
     Returns
     -------
     T
-        aligned centroids
+        aligned centroids RAS2RAS transform
 
     """
-
     # get centroids of each label in image
     centroids_mov, centroids_dst = get_seg_centroids(seg_mov, seg_dst, label_ids)
     # register
@@ -195,8 +189,9 @@ def align_seg_centroids(
 
 
 def align_flipped(seg: sitk.Image) -> npt.NDArray:
-    """left - right registration (make upright)
-    we are registering cortial lables
+    """Registrate Left - right (make upright).
+
+    Register cortial lables
 
     Parameters
     ----------
@@ -209,7 +204,6 @@ def align_flipped(seg: sitk.Image) -> npt.NDArray:
         Linear transformation matrix for registration
 
     """
-
     lhids = np.array(
         [
             1002,

--- a/recon_surf/create_annotation.py
+++ b/recon_surf/create_annotation.py
@@ -90,7 +90,7 @@ h_trgsid = "optional, when storing mapped labels: target subject id, also writte
 
 
 def options_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
@@ -98,7 +98,6 @@ def options_parse():
         object holding options
 
     """
-
     parser = optparse.OptionParser(
         version="$Id:create_annotation.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $",
         usage=HELPTEXT,
@@ -157,9 +156,10 @@ def map_multiple_labels(
         out_dir: Optional[str] = None,
         stop_missing: bool = True
 ) -> Tuple[npt.ArrayLike, npt.ArrayLike]:
-    """function to map a list of labels (just names without hemisphere or path, which are
-    passed via hemi, src_dir, out_dir) from one surface (e.g. fsavaerage sphere.reg)
-    to another.
+    """Map a list of labels from one surface (e.g. fsavaerage sphere.reg) to another.
+
+    Labels are just names without hemisphere or path,
+    which are passed via hemi, src_dir, out_dir)
 
     Parameters
     ----------
@@ -195,9 +195,7 @@ def map_multiple_labels(
     ValueError
         Label file missing
 
-
     """
-
     # get reverse mapping (trg->src) for sampling
     rev_mapping, _, _ = getSurfCorrespondence(trg_sphere_name, src_sphere_name)
     all_labels = []
@@ -238,7 +236,7 @@ def read_multiple_labels(
         input_dir: str,
         label_names: npt.ArrayLike
 ) -> Tuple[ List[npt.NDArray],  List[npt.NDArray]]:
-    """read multiple label files from input_dir
+    """Read multiple label files from input_dir.
 
     Parameters
     ----------
@@ -256,9 +254,7 @@ def read_multiple_labels(
     all_values
         values of read labels
 
-
     """
-
     all_labels = []
     all_values = []
     for l_name in label_names:
@@ -279,9 +275,11 @@ def build_annot(all_labels: npt.ArrayLike, all_values: npt.ArrayLike,
                 col_ids: npt.ArrayLike, trg_white: Union[str, npt.NDArray],
                 cortex_label_name: Optional[str] = None
                 ) -> Tuple[npt.NDArray, npt.NDArray]:
-    """function to create an annotation from multiple labels. Here we also consider the
-    label values and overwrite existing labels if values of current are larger (or equal,
-    so the order of the labels matters). No output is written.
+    """Create an annotation from multiple labels.
+
+    Here we also consider the label values and overwrite existing labels
+    if values of current are larger (or equal, so the order of the labels matters).
+    No output is written.
 
     Parameters
     ----------
@@ -303,9 +301,7 @@ def build_annot(all_labels: npt.ArrayLike, all_values: npt.ArrayLike,
     annot_vals
         Values of build Annotations
 
-
     """
-
     # create annot from a bunch of labels (and values)
     if isinstance(trg_white, str):
         trg_white = fs.read_geometry(trg_white, read_metadata=False)[0]
@@ -343,7 +339,7 @@ def build_annot(all_labels: npt.ArrayLike, all_values: npt.ArrayLike,
 
 
 def read_colortable(colortab_name: str) -> Tuple[npt.ArrayLike, List[str], npt.ArrayLike]:
-    """reads the colortable of given name
+    """Read the colortable of given name.
 
     Parameters
     ----------
@@ -359,9 +355,7 @@ def read_colortable(colortab_name: str) -> Tuple[npt.ArrayLike, List[str], npt.A
     colors
         List of colors corresponding to ids and names
 
-
     """
-
     colortab = np.genfromtxt(colortab_name, dtype="i8", usecols=(0, 2, 3, 4, 5))
     ids = colortab[:, 0]
     colors = colortab[:, 1:]
@@ -377,8 +371,9 @@ def write_annot(
         out_annot: str,
         append: Union[None, str] = ""
 ) -> None:
-    """This function combines the colortable with the annotations ids to
-    write an annotation file (which contains colortable information)
+    """Combine the colortable with the annotations ids to write an annotation file.
+
+    The annotation file contains colortable information
     Care needs to be taken that the colortable file has the same number
     and order of labels as specified in the label_names list
 
@@ -396,7 +391,6 @@ def write_annot(
         String to append to colour name. Defaults to ""
 
     """
-
     # colortab_name="colortable_BA.txt"
     col_ids, col_names, col_colors = read_colortable(colortab_name)
     offset = 0
@@ -419,7 +413,9 @@ def write_annot(
 
 
 def create_annotation(options, verbose: bool = True) -> None:
-    """main function to map (if required), build  and write annotation
+    """Map (if required), build  and write annotation.
+
+    (Main function)
 
     Parameters
     ----------
@@ -438,7 +434,6 @@ def create_annotation(options, verbose: bool = True) -> None:
         True if options should be printed. Defaults to True
 
     """
-
     print()
     print("Map BA Labels Parameters:")
     print()
@@ -508,7 +503,6 @@ def create_annotation(options, verbose: bool = True) -> None:
 
 
 if __name__ == "__main__":
-
     # Command line options and error checking done here
     options = options_parse()
 

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -74,19 +74,14 @@ h_fsaverage = (
 
 
 def options_parse():
-    """Command line option parser
-
-    Parameters
-    ----------
+    """Command line option parser.
 
     Returns
     -------
     options
         object holding options
 
-
     """
-
     parser = optparse.OptionParser(
         version="$Id:fs_balabels.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $",
         usage=HELPTEXT,
@@ -115,8 +110,7 @@ def read_colortables(
         colappend: List[str],
         drop_unknown: bool = True
 ) -> Tuple[List, List, List]:
-    """reads multiple colortables and appends extensions,
-    drops unknown by default
+    """Read multiple colortables and appends extensions, drops unknown by default.
 
     Parameters
     ----------
@@ -137,9 +131,7 @@ def read_colortables(
     all_cols
         List of all colors
 
-
     """
-
     pos = 0
     all_names = []
     all_ids = []

--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -29,7 +29,7 @@ def mgh_from_sitk(
         sitk_img: sitk.Image,
         orig_mgh_header: Optional[nib.freesurfer.mghformat.MGHHeader] = None
 ) -> nib.MGHImage:
-    """converts sitk image to mgh image
+    """Convert sitk image to mgh image.
 
     Parameters
     ----------
@@ -44,7 +44,6 @@ def mgh_from_sitk(
         mgh image
 
     """
-
     if orig_mgh_header:
         h1 = MGHHeader.from_header(orig_mgh_header)
     else:
@@ -76,7 +75,7 @@ def mgh_from_sitk(
     
     
 def sitk_from_mgh(img: nib.MGHImage) -> sitk.Image:
-    """converts mgh image to sitk image
+    """Convert mgh image to sitk image.
 
     Parameters
     ----------
@@ -89,7 +88,6 @@ def sitk_from_mgh(img: nib.MGHImage) -> sitk.Image:
         sitk image
 
     """
-
     # reorder data as structure differs between nibabel and sITK:
     data = np.swapaxes(np.asanyarray(img.dataobj), 0, 2)
     # sitk can only create image with system native endianness
@@ -113,7 +111,7 @@ def readITKimage(
         vox_type: Optional[Any] = None,
         with_header: bool = False
 ) -> Union[sitk.Image, Tuple[sitk.Image, Any]]:
-    """reads the itk image
+    """Read the itk image.
 
     Parameters
     ----------
@@ -131,9 +129,7 @@ def readITKimage(
     header
         Image header (if with_header = True)
 
-
     """
-
     # If image is nifti image
     header = None
     if filename[-7:] == ".nii.gz" or filename[-4:] == ".nii":
@@ -167,7 +163,7 @@ def writeITKimage(
         filename: str,
         header: Optional[nib.freesurfer.mghformat.MGHHeader] = None
 ) -> None:
-    """[MISSING]
+    """[MISSING].
 
     Parameters
     ----------
@@ -179,7 +175,6 @@ def writeITKimage(
         mgh image header (Default value = None)
 
     """
-
     # If image is nifti image
     if filename[-7:] == ".nii.gz" or filename[-4:] == ".nii":
         print("write Nifti image via sITK...")

--- a/recon_surf/lta.py
+++ b/recon_surf/lta.py
@@ -28,7 +28,7 @@ def writeLTA(
         dst_fname: str,
         dst_header: Dict
 ) -> None:
-    """Writes linear transform array info to a .lta file
+    """Write linear transform array info to a .lta file.
 
     Parameters
     ----------
@@ -45,15 +45,12 @@ def writeLTA(
     dst_header : Dict
         Destination header
 
-
     Raises
     ------
     ValueError
         Header format missing field (Source or Destination)
-
     
     """
-
     from datetime import datetime
     import getpass
 

--- a/recon_surf/map_surf_label.py
+++ b/recon_surf/map_surf_label.py
@@ -59,7 +59,7 @@ h_outlabel = "output label file"
 
 
 def options_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
@@ -67,7 +67,6 @@ def options_parse():
         object holding options
 
     """
-
     parser = optparse.OptionParser(
         version="$Id:map_surf_label.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $",
         usage=HELPTEXT,
@@ -100,8 +99,9 @@ def writeSurfLabel(
         values: npt.NDArray,
         surf: npt.NDArray
 ) -> None:
-    """Writes a FS surface label file to filename (e.g. lh.labelname.label)
-    stores sid string in the header, then number of vertices
+    """Write a FS surface label file to filename (e.g. lh.labelname.label).
+
+    Stores sid string in the header, then number of vertices
     and table of vertex index, RAS wm-surface coords (taken from surf)
     and values (which can be zero)
 
@@ -123,9 +123,7 @@ def writeSurfLabel(
     ValueError
         Label and values should have same sizes
 
-
     """
-
     if values is None:
         values = np.zeros(label.shape)
     if values.size != label.size:
@@ -153,8 +151,9 @@ def getSurfCorrespondence(
         trg_sphere: Union[str, Tuple, np.ndarray],
         tree: Optional[KDTree] = None
 ) -> Tuple[np.ndarray, np.ndarray, KDTree]:
-    """For each vertex in src_sphere finds the closest vertex in trg_sphere
-    spheres are Nx3 arrays of coordinates on the sphere (usually R=100 FS format)
+    """For each vertex in src_sphere find the closest vertex in trg_sphere.
+
+    Spheres are Nx3 arrays of coordinates on the sphere (usually R=100 FS format)
     *_sphere can also be a file name of the sphere.reg files, then we load it.
     The KDtree can be passed in cases where src moves around and trg stays fixed
 
@@ -178,9 +177,7 @@ def getSurfCorrespondence(
     tree : KDTree
         KDTree of the trg surface
 
-
     """
-
     # We can also work with file names instead of surface vertices
     if isinstance(src_sphere, str):
         src_sphere = fs.read_geometry(src_sphere, read_metadata=False)[0]
@@ -207,7 +204,8 @@ def mapSurfLabel(
         trg_sid: str,
         rev_mapping: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """maps a label from src surface according to the correspondence
+    """Map a label from src surface according to the correspondence.
+
     trg_surf is passed so that the label file will list the
     correct coordinates (usually the white surface), can be vetrices or filename
 
@@ -236,9 +234,7 @@ def mapSurfLabel(
     ValueError
         Label and trg vertices should have same sizes
 
-
     """
-
     print("Mapping label: {} ...".format(src_label_name))
     src_label, src_values = fs.read_label(src_label_name, read_scalars=True)
     smax = max(np.max(src_label), np.max(rev_mapping)) + 1
@@ -267,7 +263,6 @@ def mapSurfLabel(
 
 
 if __name__ == "__main__":
-
     # Command line options and error checking done here
     options = options_parse()
 

--- a/recon_surf/paint_cc_into_pred.py
+++ b/recon_surf/paint_cc_into_pred.py
@@ -42,16 +42,14 @@ Date: Jul-10-2020
 
 
 def argument_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
     options
         object holding options
 
-    
     """
-
     parser = argparse.ArgumentParser(usage=HELPTEXT)
     parser.add_argument(
         "--input_cc",
@@ -81,8 +79,9 @@ def argument_parse():
 
 
 def paint_in_cc(pred: npt.ArrayLike, aseg_cc: npt.ArrayLike) -> npt.ArrayLike:
-    """Function to paint corpus callosum segmentation into prediction. Note, that this function
-    modifies the original array and does not create a copy.
+    """Paint corpus callosum segmentation into prediction.
+
+    Note, that this function modifies the original array and does not create a copy.
 
     Parameters
     ----------
@@ -97,7 +96,6 @@ def paint_in_cc(pred: npt.ArrayLike, aseg_cc: npt.ArrayLike) -> npt.ArrayLike:
         Prediction with added CC
 
     """
-
     cc_mask = (aseg_cc >= 251) & (aseg_cc <= 255)
     pred[cc_mask] = aseg_cc[cc_mask]
     return pred

--- a/recon_surf/rewrite_mc_surface.py
+++ b/recon_surf/rewrite_mc_surface.py
@@ -22,14 +22,14 @@ from lapy._read_geometry import read_geometry
 
 
 def options_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
     options
         object holding options
 
-    
+
     """
     parser = optparse.OptionParser(
         version="$Id: rewrite_mc_surface,v 1.1 2020/06/23 15:42:08 henschell $",
@@ -55,7 +55,8 @@ def options_parse():
 
 
 def resafe_surface(insurf: str, outsurf: str, pretess: str) -> None:
-    """takes path to insurf and rewrites it to outsurf thereby fixing vertex locs flag error
+    """Take path to insurf and rewrite it to outsurf thereby fixing vertex locs flag error.
+
     (scannerRAS instead of surfaceRAS after marching cube)
 
     Parameters
@@ -68,7 +69,6 @@ def resafe_surface(insurf: str, outsurf: str, pretess: str) -> None:
         Path and name of file the input surface was created on (e.g. filled-pretess127.mgz)
     
     """
-
     surf = read_geometry(insurf, read_metadata=True)
 
     if not surf[2]["filename"]:

--- a/recon_surf/rotate_sphere.py
+++ b/recon_surf/rotate_sphere.py
@@ -66,7 +66,7 @@ h_out = "path to output txt files for angles"
 
 
 def options_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
@@ -74,7 +74,6 @@ def options_parse():
         object holding options
 
     """
-
     parser = optparse.OptionParser(
         version="$Id: rotate_sphere.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $",
         usage=HELPTEXT,
@@ -107,7 +106,7 @@ def align_aparc_centroids(
         labels_dst: npt.ArrayLike,
         label_ids: npt.ArrayLike = []
 ) -> np.ndarray:
-    """Aligns centroid of aparc parcels on the sphere (Attention mapping back to sphere!)
+    """Align centroid of aparc parcels on the sphere (Attention mapping back to sphere!).
 
     Parameters
     ----------
@@ -128,7 +127,6 @@ def align_aparc_centroids(
         Rotation Matrix
 
     """
-
     #nferiorparietal, inferiortemporal, lateraloccipital, postcentral, posteriorsingulate
     #  precentral, precuneus, superiorfrontal, supramarginal
     # lids=np.array([8,9,11,22,23,24,25,28,31])
@@ -162,7 +160,6 @@ def align_aparc_centroids(
 
 
 if __name__ == "__main__":
-
     # Command Line options are error checking done here
     options = options_parse()
 

--- a/recon_surf/spherically_project.py
+++ b/recon_surf/spherically_project.py
@@ -72,7 +72,7 @@ h_output = "path to output surface, spherically projected"
 
 
 def options_parse():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
@@ -80,7 +80,6 @@ def options_parse():
         object holding options
 
     """
-
     parser = optparse.OptionParser(
         version="$Id: spherically_project,v 1.1 2017/01/30 20:42:08 ltirrell Exp $",
         usage=HELPTEXT,
@@ -101,13 +100,15 @@ def tria_spherical_project(
         debug: bool = False,
         use_cholmod: bool = True
 ) -> TriaMesh:
-    """Computes the first three non-constant eigenfunctions
-        and then projects the spectral embedding onto a sphere. This works
-        when the first functions have a single closed zero level set,
-        splitting the mesh into two domains each. Depending on the original
-        shape triangles could get inverted. We also flip the functions
-        according to the axes that they are aligned with for the special
-        case of brain surfaces in FreeSurfer coordinates.
+    """Compute the first three sphere-projected non-constant eigenfunctions.
+
+    Compute the first three non-constant eigenfunctions
+    and then projects the spectral embedding onto a sphere. This works
+    when the first functions have a single closed zero level set,
+    splitting the mesh into two domains each. Depending on the original
+    shape triangles could get inverted. We also flip the functions
+    according to the axes that they are aligned with for the special
+    case of brain surfaces in FreeSurfer coordinates.
 
     Parameters
     ----------
@@ -125,9 +126,7 @@ def tria_spherical_project(
     trianew
         Triangle Mesh spherically projected
 
-    
     """
-
     if not tria.is_closed():
         raise ValueError("Error: Can only project closed meshes!")
 
@@ -309,7 +308,7 @@ def spherically_project_surface(
         outsurf: str,
         use_cholmod: bool = True
 ) -> None:
-    """takes path to insurf, spherically projects it, outputs it to outsurf
+    """Take path to insurf, spherically projects it, outputs it to outsurf.
 
     Parameters
     ----------
@@ -321,7 +320,6 @@ def spherically_project_surface(
         Try to use the Cholesky decomposition from the cholmod. Defaults to True
 
     """
-
     surf = read_geometry(insurf, read_metadata=True)
     projected = tria_spherical_project(
         TriaMesh(surf[0], surf[1]), flow_iter=3, use_cholmod=use_cholmod

--- a/recon_surf/spherically_project_wrapper.py
+++ b/recon_surf/spherically_project_wrapper.py
@@ -21,7 +21,7 @@ from typing import Any
 
 
 def setup_options():
-    """Command line option parser
+    """Command line option parser.
 
     Returns
     -------
@@ -46,8 +46,9 @@ def setup_options():
 
 
 def call(command: str, **kwargs: Any) -> int:
-    """Run command with arguments. Wait for command to complete. Sends
-    output to logging module.
+    """Run command with arguments.
+
+    Wait for command to complete. Sends output to logging module.
 
     Parameters
     ----------
@@ -61,9 +62,7 @@ def call(command: str, **kwargs: Any) -> int:
     int
        Returncode of called command
 
-    
     """
-
     kwargs["stdout"] = PIPE
     kwargs["stderr"] = PIPE
     command_split = shlex.split(command)
@@ -79,7 +78,7 @@ def call(command: str, **kwargs: Any) -> int:
 
 
 def spherical_wrapper(command1: str, command2: str, **kwargs: Any) -> int:
-    """Runs the first command. If it fails the fallback command is run as well.
+    """Run the first command. If it fails the fallback command is run as well.
 
     Parameters
     ----------
@@ -94,10 +93,8 @@ def spherical_wrapper(command1: str, command2: str, **kwargs: Any) -> int:
     -------
     code_1
         Return code of command1. If command1 failed return code of command2
-
     
     """
-
     # First try to run standard spherical project
     print("Running command: {}".format(command1))
     code_1 = call(command1, **kwargs)


### PR DESCRIPTION
This PR conforms the docstrings to Numpy style guide using pydocstyle as a reference for violations. This should lead to compatibility for Sphinx (With the numpydoc extensions).

##### TODO: 
- Fill "[MISSING]" blocks
- CerebNet documentations
- Fix pydocstyle error D100 (Missing docstring in public module). This was ignored so far as no module hast documentation. 