### PR TITLE
Adding FreeSurfer commands (for validation tests)

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -175,7 +175,7 @@ COPY /Docker/python-s /venv/bin/
 
 # Copy fastsurfer over from the build context and add PYTHONPATH
 COPY . /fastsurfer/
-ENV PYTHONPATH=/fastsurfer:$PYTHONPATH \
+ENV PYTHONPATH=/fastsurfer:/opt/freesurfer/python/package:$PYTHONPATH \
     FASTSURFER_HOME=/fastsurfer
 
 # Download all remote network checkpoints already, compile all FastSurfer scripts into bytecode and update

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -114,7 +114,9 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 # install freesurfer and point to new python location
 RUN /install/install_fs_pruned.sh /opt --upx && \
-    rm -R /install
+rm /opt/freesurfer/bin/fspython &&  \
+rm -R /install && \
+ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
 
 
 # =======================================================

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -114,9 +114,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 # install freesurfer and point to new python location
 RUN /install/install_fs_pruned.sh /opt --upx && \
-    rm /opt/freesurfer/bin/fspython &&  \
-    rm -R /install && \
-    ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
+    rm -R /install
 
 
 # =======================================================


### PR DESCRIPTION
## Description

This PR includes a few additional commands and binaries in the pruned Freesurfer install that are used in the FastSurfer validation pipeline.

The validation pipeline is being modified to run FastSurfer processing and Freesurfer commands through the FastSurfer Docker image. Therefore, the following Freesurfer binaries/scripts and their required files have been included:
* `asegstats2table`
* `aparcstats2table`
* `mris_preproc`
* `mri_glmfit`

This increases the FastSurfer Docker image size by ~60MB.

**Note:** 
* The stats Python scripts necessitate the inclusion of Freesurfer's packaged Python interpreter and some libs to work. These account for nearly all of the size increase (> 57MB).
* The Dockerfile was changed to not delete/overwrite Freesurfer's Python.

## Secondary Dependencies

This section lists the binaries, scripts, and files that are needed by the aforementioned Freesurfer binaries/scripts.

### `asegstats2table` and `aparcstats2table`

Python packages:
* `fsbindings`

### `mris_preproc`

Binaries:
* `fname2stem`
* `fspython`
* `mri_surf2surf`

Scripts (without the following, the script still runs through but with silent failures that lead to incorrect results):
* `isanalyze`
* `isnifti`

### `mri_glmfit`

None.