### PR TITLE
Fix: fspython environment variable

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -175,7 +175,7 @@ COPY /Docker/python-s /venv/bin/
 
 # Copy fastsurfer over from the build context and add PYTHONPATH
 COPY . /fastsurfer/
-ENV PYTHONPATH=/fastsurfer:/opt/freesurfer/python/package:$PYTHONPATH \
+ENV PYTHONPATH=/fastsurfer:/opt/freesurfer/python/packages:$PYTHONPATH \
     FASTSURFER_HOME=/fastsurfer
 
 # Download all remote network checkpoints already, compile all FastSurfer scripts into bytecode and update


### PR DESCRIPTION
## Description 

This PR fixes a minor error in the path of the Freesurfer Python packages path that was recently added to the `PYTHONPATH` environment variable to enable running minimally-packaged Freesurfer Python commands.