### PR TITLE
Fix the link in Docker\README.md

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -55,7 +55,7 @@ To run only the surface pipeline or only the segmentation pipeline, the entrypoi
 
 Note, for many HPC users with limited GPUs or with very large datasets, it may be most efficient to run the full pipeline on the CPU, trading a longer run-time for the segmentation with massive parallelization on the subject level. 
 
-Also note, in order to run our Docker containers on a Mac, users need to increase docker memory to 10 GB by overwriting the settings under Docker Desktop --> Preferences --> Resources --> Advanced (slide the bar under Memory to 10 GB; see: [docker for mac](https://docs.docker.com/docker-for-mac/) for details). For the new Apple silicon chips (M1,etc), we noticed that a native install runs much faster than docker, because the Apple Accelerator (use the experimental MPS device via `--device mps`) can be used. There is no support for MPS-based acceleration through docker at the moment. 
+Also note, in order to run our Docker containers on a Mac, users need to increase docker memory to 10 GB by overwriting the settings under Docker Desktop --> Preferences --> Resources --> Advanced (slide the bar under Memory to 10 GB; see: [Change Docker Desktop settings on Mac](https://docs.docker.com/desktop/settings/mac/) for details). For the new Apple silicon chips (M1,etc), we noticed that a native install runs much faster than docker, because the Apple Accelerator (use the experimental MPS device via `--device mps`) can be used. There is no support for MPS-based acceleration through docker at the moment. 
 
 ### General build settings
 The build script `build.py` supports additional args, targets and options, see `python Docker/build.py --help`.


### PR DESCRIPTION
- `docker for mac` was deleted.
- Page of [Change Docker Desktop settings on Mac](https://docs.docker.com/desktop/settings/mac/) describe the memory change settings.