### PR TITLE
Fix the identification of the number of cpus

### DIFF
--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -14,7 +14,7 @@
 
 # IMPORTS
 import time
-from os import makedirs, cpu_count
+from os import makedirs
 from os.path import join, dirname, isfile
 from typing import Dict, List, Tuple, Optional, Literal
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from FastSurferCNN.utils import logging
+from FastSurferCNN.utils.threads import get_num_threads
 from FastSurferCNN.utils.mapper import JsonColorLookupTable, TSVLookupTable
 from FastSurferCNN.utils.common import (
     find_device,
@@ -64,7 +65,7 @@ class Inference:
         self.pool = None
         self._threads = None
         self.threads = threads
-        torch.set_num_threads(cpu_count() if self._threads is None else self._threads)
+        torch.set_num_threads(get_num_threads() if self._threads is None else self._threads)
         self.pool = (
             ThreadPoolExecutor(self._threads) if async_io else NoParallelExecutor()
         )

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -162,7 +162,7 @@ ENV OS=Linux \
 # create matplotlib config dir; make sure we use bash and activate conda env
 #  (in case someone starts this interactively)
 RUN mkdir -m 777 $MPLCONFIGDIR && \
-    echo "source /venv/bin/activate" >> ~/.bashrc
+    echo "source /venv/bin/activate" >> /etc/bash.bashrc
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Copy fastsurfer venv and pruned freesurfer from build images

--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -158,6 +158,7 @@ copy_files="
   bin/fs-check-version
   bin/fsr-getxopts
   bin/gauss_4dfp
+  bin/ifh2hdr
   bin/imgreg_4dfp
   bin/isanalyze
   bin/isnifti

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -27,10 +27,10 @@ Values can also be extracted by
 """
 
 import argparse
-import multiprocessing
 from os import path
 from typing import Iterable, Mapping, Union, Literal, Dict, Protocol, TypeVar, Type
 
+from FastSurferCNN.utils.threads import get_num_threads
 from FastSurferCNN.utils.arg_types import (
     vox_size as __vox_size,
     float_gt_zero_and_le_one as __conform_to_one_mm,
@@ -262,9 +262,9 @@ ALL_FLAGS = {
     "threads": __arg(
         "--threads",
         dest="threads",
-        default=multiprocessing.cpu_count(),
+        default=get_num_threads(),
         type=int,
-        help=f"Number of threads to use (defaults to number of hardware threads: {multiprocessing.cpu_count()})",
+        help=f"Number of threads to use (defaults to number of hardware threads: {get_num_threads()})",
     ),
     "async_io": __arg(
         "--async_io",

--- a/FastSurferCNN/utils/threads.py
+++ b/FastSurferCNN/utils/threads.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [
-    "checkpoint",
-    "common",
-    "load_config",
-    "logging",
-    "lr_scheduler",
-    "mapper",
-    "meters",
-    "metrics",
-    "misc",
-    "parser_defaults",
-    "threads",
-]
+def get_num_threads():
+    try:
+        from os import sched_getaffinity as __getaffinity
+        return len(__getaffinity(0))
+    except ImportError:
+        from os import cpu_count
+        return cpu_count()

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-
-
-# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+# Copyright 2023 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +15,18 @@
 
 
 # IMPORTS
-import optparse
+import argparse
 import sys
-from typing import Any, Optional
+from pathlib import Path
+from typing import Optional, cast
+import logging
+
 import SimpleITK as sitk
 import numpy as np
 from numpy import typing as npt
 
 import image_io as iio
+
 
 HELPTEXT = """
 
@@ -67,11 +69,16 @@ There are different options how the center is found:
 
 Original Author: Martin Reuter
 Date: Mar-18-2022
+
+Modified: David Kügler
+Date: Oct-25-2023
 """
 
+h_verbosity = "Logging verbosity: 0 (none), 1 (normal), 2 (debug)"
 h_invol = "path to input.nii.gz"
 h_outvol = "path to corrected.nii.gz"
 h_mask = "optional: path to mask.nii.gz"
+h_aseg = "optional: path to aseg or aseg+dkt image to find the white matter mask"
 h_shrink = "<int> shrink factor, default: 4"
 h_levels = "<int> number of fitting levels, default: 4"
 h_numiter = "<int> max number of iterations per level, default: 50"
@@ -90,52 +97,53 @@ def options_parse():
         object holding options
 
     """
-    parser = optparse.OptionParser(
-        version="$Id: N4_bias_correct.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $",
-        usage=HELPTEXT,
+    parser = argparse.ArgumentParser(
+        description=HELPTEXT,
     )
-    parser.add_option("--in", dest="invol", help=h_invol)
-    parser.add_option("--out", dest="outvol", help=h_outvol)
-    parser.add_option("--mask", dest="mask", help=h_mask, default=None)
-    parser.add_option("--shrink", dest="shrink", help=h_shrink, default=4, type="int")
-    parser.add_option("--levels", dest="levels", help=h_levels, default=4, type="int")
-    parser.add_option(
-        "--numiter", dest="numiter", help=h_numiter, default=50, type="int"
+    parser.add_argument(
+        "-v", "--verbosity",
+        dest="verbosity", choices=(0, 1, 2), default=-1, help=h_verbosity, type=int
     )
-    parser.add_option("--thres", dest="thres", help=h_thres, default=0.0, type="float")
-    parser.add_option(
+    parser.add_argument("--in", dest="invol", help=h_invol, required=True)
+    parser.add_argument("--out", dest="outvol", help=h_outvol, required=True)
+    parser.add_argument("--mask", dest="mask", help=h_mask, default=None)
+    parser.add_argument("--aseg", dest="aseg", help=h_aseg, default=None)
+    parser.add_argument("--shrink", dest="shrink", help=h_shrink, default=4, type=int)
+    parser.add_argument("--levels", dest="levels", help=h_levels, default=4, type=int)
+    parser.add_argument(
+        "--numiter", dest="numiter", help=h_numiter, default=50, type=int
+    )
+    parser.add_argument("--thres", dest="thres", help=h_thres, default=0.0, type=float)
+    parser.add_argument(
         "--skipwm", dest="skipwm", help=h_skipwm, default=False, action="store_true"
     )
-    parser.add_option("--tal", dest="tal", help=h_tal, default=None)
-    parser.add_option(
-        "--threads", dest="threads", help=h_threads, default=1, type="int"
+    parser.add_argument("--tal", dest="tal", help=h_tal, default=None)
+    parser.add_argument(
+        "--threads", dest="threads", help=h_threads, default=1, type=int
     )
-    (options, args) = parser.parse_args()
-
-    if options.invol is None or options.outvol is None:
-        sys.exit(
-            "\nERROR: Please specify --in input.nii --out output.nii as nifti\n   or use --help to see all options.\n"
-        )
-
-    return options
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="$Id: N4_bias_correct.py,v 2.0 2023/10/25 20:02:08 mreuter,dkuegler Exp $"
+    )
+    return parser.parse_args()
 
 
-def N4correctITK(
-        itkimage: sitk.Image,
-        itkmask: Optional[sitk.Image] = None,
+def itk_n4_bfcorrection(
+        itk_image: sitk.Image,
+        itk_mask: Optional[sitk.Image] = None,
         shrink: int = 4,
         levels: int = 4,
         numiter: int = 50,
         thres: float = 0.0,
-        rescale: bool = True
 ) -> sitk.Image:
     """Perform the bias field correction.
 
     Parameters
     ----------
-    itkimage : sitk.Image
+    itk_image : sitk.Image
         n-dimensional image
-    itkmask : Optional[sitk.Image]
+    itk_mask : Optional[sitk.Image]
         Image mask. Defaults to None. Optional
     shrink : int
         Shrink factors. Defaults to 4
@@ -145,30 +153,29 @@ def N4correctITK(
         Maximum number if iterations. Defaults 50
     thres : float
         Convergence threshold. Defaults to 0.0
-    rescale : bool
-        Whether image should be rescaled. Defaults to True
 
     Returns
     -------
-    itkcorrected
+    itk_bfcorr_image
         Bias field corrected image
 
     """
+    _logger = logging.getLogger(__name__ + ".itk_n4_bfcorrection")
     # if no mask is passed, create a simple mask from the image
-    if not itkmask:
-        itkmask = itkimage > 0
-        itkmask.CopyInformation(itkimage)
-        print("- mask: default (>0)")
-    else:
+    if itk_mask:
         # binarize mask
-        itkmask = itkmask > 0
+        itk_mask = itk_mask > 0
+    else:
+        itk_mask = itk_image > 0
+        itk_mask.CopyInformation(itk_image)
+        _logger.info("- mask: default (>0)")
 
-    itkorig = itkimage
+    itk_orig = itk_image
 
     # subsample image
     if shrink > 1:
-        itkimage = sitk.Shrink(itkimage, [shrink] * itkimage.GetDimension())
-        itkmask = sitk.Shrink(itkmask, [shrink] * itkimage.GetDimension())
+        itk_image = sitk.Shrink(itk_image, [shrink] * itk_image.GetDimension())
+        itk_mask = sitk.Shrink(itk_mask, [shrink] * itk_image.GetDimension())
 
     # init corrector
     corrector = sitk.N4BiasFieldCorrectionImageFilter()
@@ -177,134 +184,162 @@ def N4correctITK(
 
     # bias correct image
     sitk.ProcessObject.SetGlobalDefaultCoordinateTolerance(1e-04)
-    corrector.Execute(itkimage, itkmask)
+    corrector.Execute(itk_image, itk_mask)
 
     # we need to apply bias field to original input
-    log_bias_field = corrector.GetLogBiasFieldAsImage(itkorig)
-    itkcorrected = itkorig / sitk.Exp(log_bias_field)
-
-    # normalize to average input intensity
-    if rescale:
-        stats = sitk.StatisticsImageFilter()
-        stats.Execute(itkcorrected)
-        m1 = stats.GetMean()
-        stats.Execute(itkorig)
-        m0 = stats.GetMean()
-        print("- rescale")
-        print(
-            "   mean input: {:.4f} , mean corrected {:.4f} , image rescale: {:.4f}".format(
-                m0, m1, m0 / m1
-            )
-        )
-        itkcorrected = itkcorrected * (m0 / m1)
+    log_bias_field = corrector.GetLogBiasFieldAsImage(itk_orig)
+    itk_bfcorr_image = itk_orig / sitk.Exp(log_bias_field)
 
     # should already be Float 32
-    # itkcorrected = sitk.Cast(itkcorrected, sitk.sitkFloat32)
-    if itkimage.GetPixelIDTypeAsString() != "32-bit float":
-        print(f"The data type is: {itkimage.GetPixelIDTypeAsString()}")
-    return itkcorrected
+    # itk_bfcorr_image = sitk.Cast(itk_bfcorr_image, sitk.sitkFloat32)
+    if itk_image.GetPixelIDTypeAsString() != "32-bit float":
+        _logger.info(f"The data type is: {itk_image.GetPixelIDTypeAsString()}")
+    return itk_bfcorr_image
 
 
-def normalizeWM(
-        itkimage: sitk.Image,
-        itkmask: Optional[sitk.Image] = None,
-        radius: int = 50,
-        centroid: Optional[Any] = None,
-        targetWM: int = 110
+def normalize_wm_mask_ball(
+        itk_image: sitk.Image,
+        itk_mask: sitk.Image,
+        radius: float = 50.,
+        centroid: Optional[np.ndarray] = None,
+        target_wm: float = 110.
+) -> sitk.Image:
+    """Normalize WM image by Mask and optionally ball around talairach center.
+
+    Parameters
+    ----------
+    itk_image : sitk.Image
+        n-dimensional itk image
+    itk_mask : sitk.Image
+        Image mask.
+    radius : float | int
+        Defaults to 50 [MISSING]
+    centroid : np.ndarray
+        brain centroid.
+    target_wm : float | int
+        Target white matter intensity. Defaults to 110.
+
+    Returns
+    -------
+    normalized_image : sitk.Image
+        Normalized WM image
+
+    """
+    _logger = logging.getLogger(__name__ + ".normalize_wm_mask_ball")
+    _logger.info(f"- centroid: {centroid}")
+    _logger.info(f"- size: {itk_image.GetSize()}")
+    _logger.info(f"- spacing: {' '.join(f'{f:.2f}' for f in itk_image.GetSpacing())}")
+
+    # distance image to centroid
+    isize = itk_image.GetSize()
+    ispace = itk_image.GetSpacing()
+
+    def get_distance(axis):
+        ii = np.arange(isize[2 - axis])
+        for i in range(3):
+            if i != axis:
+                ii = np.expand_dims(ii, 0 if i < axis else -1)
+        xx = ispace[axis] * (ii - centroid[axis])
+        return xx * xx
+
+    zz, yy, xx = map(get_distance, range(3))
+    distance = xx + yy + zz
+    ball = distance < radius * radius
+
+    # get mask as intersection of ball and passed mask
+    ball_mask = np.logical_and(ball, sitk.GetArrayFromImage(itk_mask))
+
+    # get ndarray from sitk image
+    image = sitk.GetArrayFromImage(itk_image)
+    # get 90th percentiles of intensities in ball (to identify WM intensity)
+    source_wm_intensity = np.percentile(image[ball_mask], 90)
+
+    _logger.info(
+        f"- source white matter intensity: {source_wm_intensity:.2f}"
+    )
+
+    return normalize_img(itk_image, itk_mask, source_wm_intensity, target_wm)
+
+
+def normalize_wm_aseg(
+        itk_image: sitk.Image,
+        itk_mask: sitk.Image,
+        itk_aseg: sitk.Image,
+        target_wm: float = 110.
 ) -> sitk.Image:
     """Normalize WM image [MISSING].
 
     Parameters
     ----------
-    itkimage : sitk.Image
+    itk_image : sitk.Image
         n-dimensional itk image
-    itkmask : Optional[sitk.Image]
-        Image mask. Defaults to None. Optional
-    radius : int
+    itk_mask : sitk.Image
+        Image mask.
+    itk_aseg : sitk.Image
+        aseg-like segmentation image to find WM.
+    radius : float | int
         Defaults to 50 [MISSING]
-    centroid : Optional[Any]
+    centroid : Optional[np.ndarray]
         Image centroid. Defaults to None
-    targetWM : int
+    target_wm : float | int
         Defaults to 110 [MISSING]
 
     Returns
     -------
-    normed
+    normed : sitk.Image
         Normalized WM image
-    
+
     """
-    # print("\nnormalizeWM:")
-
-    mask_passed = True
-    if not itkmask:
-        itkmask = sitk.OtsuThreshold(itkimage, 0, 1, 200)
-        print("- mask: default (otsu)")
-        # itkmask = itkimage>0
-        # print("- mask: default (>0)")
-        itkmask.CopyInformation(itkimage)
-        mask_passed = False
-    else:
-        # binarize mask
-        itkmask = itkmask > 0
-
-    if not centroid:
-        # extract centroid from mask
-        label_stats = sitk.LabelShapeStatisticsImageFilter()
-        label_stats.Execute(itkmask)
-        # centroid_world = label_stats.GetCenterGravity(1)
-        centroid_world = label_stats.GetCentroid(1)
-        # print("centroid physical: {}".format(centroid_world))
-        # centroidf = itkmask.TransformPhysicalPointToContinuousIndex(centroid_world)
-        # print("centroid voxel: {}".format(centroidf))
-        centroid = itkmask.TransformPhysicalPointToIndex(centroid_world)
-
-    print("- centroid: {}".format(centroid))
-    print("- size: {}".format(itkimage.GetSize()))
-    print("- spacing: " + " ".join(format(f, ".2f") for f in itkimage.GetSpacing()))
-
-    # distance image
-    isize = itkimage.GetSize()
-    ispace = itkimage.GetSpacing()
-    zz, yy, xx = np.meshgrid(
-        range(isize[2]), range(isize[1]), range(isize[0]), indexing="ij"
-    )
-    xx = ispace[0] * (xx - centroid[0])
-    yy = ispace[1] * (yy - centroid[1])
-    zz = ispace[2] * (zz - centroid[2])
-    distance = xx * xx + yy * yy + zz * zz
-    ball = distance < radius * radius
-
-    # make sure to crop non-brain regions (if masked was passed)
-    #  warning do not use otsu mask as it is cropping low-intensity values
-    if mask_passed:
-        ball = ball * sitk.GetArrayFromImage(itkmask)
-    # for debugging the ball location and size:
-    # balli = sitk.GetImageFromArray(1.0 * ball)
-    # balli.CopyInformation(itkimage)
-    # sitk.WriteImage(balli, "ball.nii.gz")
+    _logger = logging.getLogger(__name__ + ".normalize_wm_aseg")
 
     # get 1 and 90 percentiles of intensities in ball
-    mask = np.extract(ball, sitk.GetArrayFromImage(itkimage))
-    percentiles = np.percentile(mask, [1, 90])
-    percentile01, percentile90 = percentiles.tolist()
-    print(
-        "-  1st percentile: {:.2f}\n- 90th percentile: {:.2f}".format(
-            percentile01, percentile90
-        )
+    img = sitk.GetArrayFromImage(itk_image)
+    aseg = sitk.GetArrayFromImage(itk_aseg)
+    # Left and Right White Matter
+    mask = (aseg == 2) | (aseg == 41)
+    source_wm_intensity = np.mean(img[mask])
+
+    _logger.info(
+        f"- source white matter intensity: {source_wm_intensity:.2f}"
     )
 
+    return normalize_img(itk_image, itk_mask, source_wm_intensity, target_wm)
+
+
+def normalize_img(
+        itk_image: sitk.Image,
+        itk_mask: sitk.Image,
+        source_intensity: float,
+        target_intensity: float
+) -> sitk.Image:
+    """
+    Normalize image by source and target intensity values (retains zero-point).
+
+    Parameters
+    ----------
+    itk_image : sitk.Image
+    itk_mask : sitk.Image
+    source_intensity : float
+    target_intensity : float
+
+    Returns
+    -------
+    Rescaled image
+    """
+    _logger = logging.getLogger(__name__ + ".normalize_wm")
     # compute intensity transformation
-    m = (targetWM - 2.55) / (percentile90 - percentile01)
-    b = targetWM - m * percentile90
-    print("- m: {:.4f}  b: {:.4f}".format(m, b))
+    m = target_intensity / source_intensity
+    _logger.info(f"- m: {m:.4f}")
 
-    # itkImage already is Float32 and output should be also Float32, we clamp outside as well
-    normed = itkimage * m + b
+    # itk_image already is Float32 and output should be also Float32, we clamp outside
+    normalized = itk_image * m
 
-    return normed
+    # ensure normalized image is > 0, where mask is true
+    correction_mask = cast(sitk.Image, (normalized < 1) & itk_mask)
+    return normalized + sitk.Cast(correction_mask, normalized.GetPixelID())
 
 
-def readTalairachXFM(fname: str) -> np.ndarray:
+def read_talairach_xfm(fname: Path | str) -> np.ndarray:
     """Read TalairachXFM image.
 
     Parameters
@@ -315,28 +350,35 @@ def readTalairachXFM(fname: str) -> np.ndarray:
     Returns
     -------
     tal
-        TalairachXFM image
+        Talairach transform matrix
+
+    Raises
+    ------
+    ValueError
+        if the file is of an invalid format.
 
     """
+    _logger = logging.getLogger(__name__ + ".read_talairach_xfm")
+    _logger.info(f"reading talairach transform from {fname}")
     with open(fname) as f:
         lines = f.readlines()
-    f.close()
-    counter = 0
-    tal = []
-    for line in lines:
-        counter += 1
-        firstword = line.split(sep="_", maxsplit=1)[0].lower()
-        if firstword == "linear":
-            taltxt = np.char.replace(lines[counter : counter + 3], ";", " ")
-            tal = np.genfromtxt(taltxt)
-            tal = np.vstack([tal, [0, 0, 0, 1]])
-            # tal = np.loadtxt(fname,skiprows=counter,delimiter=)
 
-    print(" tal: {}".format(tal))
-    return tal
+    try:
+        transf_start = [l.lower().startswith("linear_") for l in lines].index(True) + 1
+        tal_str = [l.replace(";", " ") for l in lines[transf_start:transf_start + 3]]
+        tal = np.genfromtxt(tal_str)
+        tal = np.vstack([tal, [0, 0, 0, 1]])
+
+        _logger.info(f"- tal: {tal}")
+
+        return tal
+    except Exception as e:
+        err = ValueError(f"Could not find taiairach transform in {fname}.")
+        _logger.exception(err)
+        raise err from e
 
 
-def getTalOriginVox(tal: npt.ArrayLike, image: sitk.Image):
+def get_tal_origin_voxel(tal: npt.ArrayLike, image: sitk.Image) -> np.ndarray:
     """Get the original Talairach Voxel.
 
     Parameters
@@ -348,86 +390,182 @@ def getTalOriginVox(tal: npt.ArrayLike, image: sitk.Image):
 
     Returns
     -------
-    vox_origin
+    vox_origin : np.ndarray
         Original Talairach Voxel
 
     """
-    talinv = np.linalg.inv(tal)
-    tal_origin = np.array(talinv[0:3, 3]).ravel()
-    # print("Tal Physical Origin: {}".format(tal_origin))
+    tal_inv = np.linalg.inv(tal)
+    tal_origin = np.array(tal_inv[0:3, 3]).ravel()
+    _logger = logging.getLogger(__name__ + ".get_talairach_origin_voxel")
+    _logger.debug(f"Talairach Physical Origin: {tal_origin}")
+
     vox_origin = image.TransformPhysicalPointToIndex(tal_origin)
-    print("Tal Voxel Origin: {}".format(vox_origin))
+    _logger.info(f"Talairach Voxel Origin: {vox_origin}")
     return vox_origin
 
 
+def print_options(options: dict):
+    msg = ("",
+           "N4 Bias Correction Parameters:",
+           "",
+           "- verbosity: {verbosity}",
+           "- input volume: {invol}",
+           "- output volume: {outvol}",
+           "- mask: {mask}" if options.get("mask") else "- mask: default (>0)",
+           "- aseg: {aseg}" if options.get("aseg") else "- aseg: not defined",
+           "- shrink factor: {shrink}",
+           "- number fitting levels: {levels}",
+           "- number iterations: {numiter}",
+           "- convergence threshold: {thres}",
+           "- skipwm: {skipwm}",
+           "- talairach: {tal}" if options.get("tal") else None,
+           "- threads: {threads}")
+
+    _logger = logging.getLogger(__name__ + ".print_options")
+    for m in msg:
+        if m is not None:
+            _logger.info(m.format(**options))
+
+
+def get_image_mean(image: sitk.Image) -> float:
+    """
+    Get the mean of a sitk Image.
+
+    Parameters
+    ----------
+    image : sitk.Image
+        image to get mean of
+
+    Returns
+    -------
+    mean : float
+    """
+    stats = sitk.StatisticsImageFilter()
+    stats.Execute(image)
+    return stats.GetMean()
+
+
+def get_brain_centroid(itk_mask: sitk.Image) -> np.ndarray:
+    """
+    Get the brain centroid from the itk_mask
+
+    Parameters
+    ----------
+    itk_mask : sitk.Image
+
+    Returns
+    -------
+    brain centroid
+
+    """
+    _logger = logging.getLogger(__name__ + ".get_brain_centroid")
+    _logger.debug("No talairach center passed, estimating center from mask.")
+    # extract centroid from mask
+    label_stats = sitk.LabelShapeStatisticsImageFilter()
+    label_stats.Execute(itk_mask)
+    centroid_world = label_stats.GetCentroid(1)
+    _logger.debug(f"centroid physical: {centroid_world}")
+    centroid_index = itk_mask.TransformPhysicalPointToContinuousIndex(centroid_world)
+    _logger.debug(f"centroid voxel: {centroid_index}")
+    return itk_mask.TransformPhysicalPointToIndex(centroid_world)
+
+
 if __name__ == "__main__":
+
     # Command Line options are error checking done here
     options = options_parse()
-
-    print()
-    print("N4 Bias Correction Parameters:")
-    print()
-    print("- input volume: {}".format(options.invol))
-    print("- output volume: {}".format(options.outvol))
-    if options.mask:
-        print("- mask: {}".format(options.mask))
-    else:
-        print("- mask: default (>0)")
-    print("- shrink factor: {}".format(options.shrink))
-    print("- number fitting levels: {}".format(options.levels))
-    print("- number iterations: {}".format(options.numiter))
-    print("- convergence threshold: {}".format(options.thres))
-    print("- skipwm: {}".format(bool(options.skipwm)))
-    if options.tal:
-        print("- talairach: {}".format(options.tal))
-    print("- threads: {}".format(options.threads))
+    LOGLEVEL = (logging.WARNING, logging.INFO, logging.DEBUG)
+    FORMAT = "" if options.verbosity < 0 else "%(levelname)s (%(module)s:%(lineno)s): "
+    FORMAT += "%(message)s"
+    logging.basicConfig(stream=sys.stdout, format=FORMAT)
+    logging.getLogger().setLevel(LOGLEVEL[abs(options.verbosity)])
+    logger = logging.getLogger(__name__)
+    print_options(vars(options))
 
     # set number of threads
     sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(options.threads)
 
     # read image (only nii supported) and convert to float32
-    print("\nreading {}".format(options.invol))
-    # itkimage = sitk.ReadImage(options.invol, sitk.sitkFloat32)
-    itkimage, header = iio.readITKimage(
+    logger.debug(f"reading input volume {options.invol}")
+    # itk_image = sitk.ReadImage(options.invol, sitk.sitkFloat32)
+    itk_image, image_header = iio.readITKimage(
         options.invol, sitk.sitkFloat32, with_header=True
     )
 
-    # if talaraich is passed
-    talorig = None
-    if options.tal:
-        taltrans = readTalairachXFM(options.tal)
-        talorig = getTalOriginVox(taltrans, itkimage)
-
     # read mask (as uchar)
-    if options.mask:
-        itkmask = iio.readITKimage(options.mask, sitk.sitkUInt8)
+    has_mask = bool(options.mask)
+    if has_mask:
+        logger.debug(f"reading mask {options.mask}")
+        itk_mask: sitk.Image = iio.readITKimage(
+            options.mask,
+            sitk.sitkUInt8,
+            with_header=False
+        )
+        # binarize mask
+        itk_mask = cast(sitk.Image, itk_mask > 0)
     else:
-        itkmask = None
+        logger.debug("generate mask with otsu (0, 1, 200)")
+        itk_mask = sitk.OtsuThreshold(itk_image, 0, 1, 200)
+        logger.info("- mask: default (otsu)")
+        itk_mask.CopyInformation(itk_image)
 
     # call N4 correct
-    print("\nexecuting N4 correction ...")
-    itkcorrected = N4correctITK(
-        itkimage,
-        itkmask,
+    logger.info("executing N4 correction ...")
+    itk_bfcorr_image = itk_n4_bfcorrection(
+        itk_image,
+        itk_mask,
         options.shrink,
         options.levels,
         options.numiter,
         options.thres,
-        rescale=options.skipwm,
     )
 
-    if not options.skipwm:
-        print("\nnormalize WM to 110")
-        itkcorrected = normalizeWM(itkcorrected, itkmask, centroid=talorig)
+    target_wm = 110.
 
-    print("\nconverting to UCHAR")
-    itkcorrected = sitk.Cast(
-        sitk.Clamp(itkcorrected, lowerBound=0, upperBound=255), sitk.sitkUInt8
+    if options.skipwm:
+        logger.info("Skipping WM normalization, ignoring talairach and aseg inputs")
+        # normalize to average input intensity
+        m_bf_img = get_image_mean(itk_bfcorr_image)
+        m_image = get_image_mean(itk_image)
+        logger.info("- rescale")
+        logger.info(f"   mean input: {m_image:.4f}, mean corrected {m_bf_img:.4f})")
+        itk_bfcorr_image = normalize_img(itk_image, itk_mask, m_bf_img, m_image)
+
+    elif options.aseg:
+        logger.info(f"normalize WM to {target_wm:.1f} (find WM from aseg)")
+        # only grab the white matter
+        itk_aseg = iio.readITKimage(options.aseg, with_header=False)
+
+        itk_bfcorr_image = normalize_wm_aseg(
+            itk_bfcorr_image,
+            itk_mask,
+            itk_aseg,
+            target_wm=target_wm
+        )
+    else:
+        logger.info(f"normalize WM to {target_wm:.1f} (find WM from mask & otsu)")
+        if not has_mask:
+            logger.debug("generate white matter segmentation with otsu (0, 1, 200)")
+            itk_mask = sitk.OtsuThreshold(itk_image, 0, 1, 200)
+        if options.tal:
+            talairach_center = read_talairach_xfm(options.tal)
+            brain_centroid = get_tal_origin_voxel(talairach_center, itk_image)
+        else:
+            brain_centroid = get_brain_centroid(itk_mask)
+
+        itk_bfcorr_image = normalize_wm_mask_ball(
+            itk_bfcorr_image,
+            itk_mask,
+            centroid=brain_centroid
+        )
+
+    logger.info("converting to UCHAR")
+    itk_bfcorr_image = sitk.Cast(
+        sitk.Clamp(itk_bfcorr_image, lowerBound=0, upperBound=255), sitk.sitkUInt8
     )
 
     # write image
-    print("writing: {}".format(options.outvol))
-    # sitk.WriteImage(itkcorrected, options.outvol)
-    iio.writeITKimage(itkcorrected, options.outvol, header)
+    logger.info(f"writing: {options.outvol}")
+    iio.writeITKimage(itk_bfcorr_image, options.outvol, image_header)
 
     sys.exit(0)

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -340,12 +340,12 @@ def normalize_img(
 
 
 def read_talairach_xfm(fname: Path | str) -> np.ndarray:
-    """Read TalairachXFM image.
+    """Read Talairach transform.
 
     Parameters
     ----------
     fname : str
-        Filename to TalairachXFM
+        Filename to Talairach transform
 
     Returns
     -------
@@ -379,19 +379,19 @@ def read_talairach_xfm(fname: Path | str) -> np.ndarray:
 
 
 def get_tal_origin_voxel(tal: npt.ArrayLike, image: sitk.Image) -> np.ndarray:
-    """Get the original Talairach Voxel.
+    """Get the origin of Talairach space in voxel coordinates.
 
     Parameters
     ----------
     tal : npt.ArrayLike
-        [MISSING]
+        Talairach transform matrix.
     image : sitk.Image
-        Original image
+        Image.
 
     Returns
     -------
     vox_origin : np.ndarray
-        Original Talairach Voxel
+        Voxel coordinate of Talairach origin
 
     """
     tal_inv = np.linalg.inv(tal)

--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -22,7 +22,7 @@ import sys
 import SimpleITK as sitk
 import nibabel as nib
 from nibabel.freesurfer.mghformat import MGHHeader
-from typing import Union, Any, Optional, Tuple
+from typing import Union, Any, Optional, Tuple, overload
 
 
 def mgh_from_sitk(
@@ -104,6 +104,24 @@ def sitk_from_mgh(img: nib.MGHImage) -> sitk.Image:
     origin = img.affine[:3, 3:] * [[-1], [-1], [1]]
     img_sitk.SetOrigin(origin.ravel())
     return img_sitk
+
+
+@overload
+def readITKimage(
+        filename: str,
+        vox_type: Optional[Any] = None,
+        with_header: False = False
+) -> sitk.Image:
+    ...
+
+
+@overload
+def readITKimage(
+        filename: str,
+        vox_type: Optional[Any] = None,
+        with_header: True = True
+) -> Tuple[sitk.Image, Any]:
+    ...
 
 
 def readITKimage(

--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -142,7 +142,7 @@ def readITKimage(
 
     Returns
     -------
-    itkimage
+    itk_image
         itk image
     header
         Image header (if with_header = True)

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -62,8 +62,12 @@ run_asegdkt_module="1"
 run_cereb_module="1"
 threads="1"
 # python3.10 -s excludes user-directory package inclusion, but passing "python3.10 -s" is not possible
-# python-s is a miniscript to add this flag
-python="python-s"
+# python-s is a miniscript to add this flag, but this only works if python-s is defined
+if [ -n "$(which python-s)" ]; then
+  python="python-s"
+else
+  python="python3.10"
+fi
 allow_root=""
 version_and_quit=""
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -734,7 +734,7 @@ if [ "$run_seg_pipeline" == "1" ]
       then
         # this will always run, since norm_name is set to subject_dir/mri/orig_nu.mgz, if it is not passed/empty
         echo "INFO: Running N4 bias-field correction" | tee -a "$seg_log"
-        cmd="$python ${reconsurfdir}/N4_bias_correct.py --in $conformed_name --out $norm_name --mask $mask_name --threads $threads"
+        cmd="$python ${reconsurfdir}/N4_bias_correct.py --in $conformed_name --out $norm_name --mask $asegdkt_segfile --threads $threads"
         echo "$cmd" |& tee -a "$seg_log"
         $cmd
         if [ "${PIPESTATUS[0]}" -ne 0 ]

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -734,7 +734,7 @@ if [ "$run_seg_pipeline" == "1" ]
       then
         # this will always run, since norm_name is set to subject_dir/mri/orig_nu.mgz, if it is not passed/empty
         echo "INFO: Running N4 bias-field correction" | tee -a "$seg_log"
-        cmd="$python ${reconsurfdir}/N4_bias_correct.py --in $conformed_name --out $norm_name --mask $asegdkt_segfile --threads $threads"
+        cmd="$python ${reconsurfdir}/N4_bias_correct.py --in $conformed_name --out $norm_name --mask $mask_name --aseg $asegdkt_segfile --threads $threads"
         echo "$cmd" |& tee -a "$seg_log"
         $cmd
         if [ "${PIPESTATUS[0]}" -ne 0 ]


### PR DESCRIPTION
Python uses os.cpu_count to find the total number of cpus, not the assigned/available number of cores.
For that, we are now using os.sched_getaffinity

(already based on talairach PR)