### PR TITLE
Add documentation and small fixes to slurm script

### DIFF
--- a/stools.sh
+++ b/stools.sh
@@ -12,12 +12,17 @@ function read_cases ()
   # but may be transformed to the optional mount_dir
   prev_pwd="$(pwd)"
   { pushd "$1" > /dev/null || (echo "Could not go to $1" && exit 1)} >&2
+    # pattern without fixed postfixes, e.g. */mri/orig.mgz -> *
+    no_fixed_postfix="${2/%\/[^*{[]*}"
     for file_match in ./$2; do
       if [[ -e "$file_match" ]]
       then
         file_match="${file_match/#.\/}"
-        subject_file="${file_match//\//_}"
-        subject="${subject_file/%.nii.gz/}"
+        # remove postfix from file_match
+        subject="${file_match/%${2:${#no_fixed_postfix}}}"
+        subject="${subject//\//_}" # / -> _
+        # remove common file extensions
+        subject="${subject/%.nii.gz/}"
         subject="${subject/%.nii/}"
         subject="${subject/%.mgz/}"
         if [[ $(($#)) -gt 2 ]]

--- a/stools.sh
+++ b/stools.sh
@@ -5,23 +5,27 @@
 function read_cases ()
 {
   # param1 data_dir
-  # param2 search_patttern
+  # param2 search_pattern
   # param3 (optional, alternate mount_dir to print paths relative to)
   # outputs one line per subject, format: "subject_id=input_path"
   # cases are read based on globbing the search_pattern in data_dir,
   # but may be transformed to the optional mount_dir
   prev_pwd="$(pwd)"
   { pushd "$1" > /dev/null || (echo "Could not go to $1" && exit 1)} >&2
-    for file_match in $2; do
-      subject_file="${file_match//\//_}"
-      subject="${subject_file/%.nii.gz/}"
-      subject="${subject/%.nii/}"
-      subject="${subject/%.mgz/}"
-      if [[ $(($#)) -gt 2 ]]
+    for file_match in ./$2; do
+      if [[ -e "$file_match" ]]
       then
-        echo "$subject=$3/$file_match"
-      else
-        echo "$subject=$1/$file_match"
+        file_match="${file_match/#.\/}"
+        subject_file="${file_match//\//_}"
+        subject="${subject_file/%.nii.gz/}"
+        subject="${subject/%.nii/}"
+        subject="${subject/%.mgz/}"
+        if [[ $(($#)) -gt 2 ]]
+        then
+          echo "$subject=$3/$file_match"
+        else
+          echo "$subject=$1/$file_match"
+        fi
       fi
     done
   { popd > /dev/null || (echo "Could not return to $prev_pwd" && exit 1)} >&2


### PR DESCRIPTION
Fix documentation of messages in the slurm script
Fix the images-only default pattern "*.{mgz,nii,nii.gz}" Increase the default time limit for the surface reconstruction Fix some doc typos
Add --cpu_only and --skip_cleanup flags to srun_fastsurfer.sh with doc