### PR TITLE
Fix memory limitation and subject/case globbing on slurm script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ Tutorial
 Docker/Dockerfile*
 *.txt
 venv
+/srun_fastsurfer.sh

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -142,9 +142,9 @@ EOF
 # voxel size of the image, here we use values proven to work for 0.7mm (and also 0.8 and 1m)
 mem_seg_cpu=10 # in GB, seg on cpu, actually required: 9G
 mem_seg_gpu=7 # in GB, seg on gpu, actually required: 6G
-mem_surf_parallel=16 # in GB, hemi in parallel
-mem_surf_noparallel=14 # in GB, hemi in series
-num_cpus_surf=2 # base number of cpus to use for surfaces (doubled if --parallel)
+mem_surf_parallel=20 # in GB, hemi in parallel
+mem_surf_noparallel=18 # in GB, hemi in series
+num_cpus_surf=1 # base number of cpus to use for surfaces (doubled if --parallel)
 
 do_parallel="false"
 
@@ -376,8 +376,8 @@ then
   if [[ "$do_parallel" == "true" ]]; then echo "--parallel"; fi
   for p in "${POSITIONAL_FASTSURFER[@]}"
   do
-    if [[ "$p" = --* ]]; then printf "\n%s" "$p";
-    else printf " %s" '$p';
+    if [[ "$p" == --* ]]; then printf "\n%s" "$p";
+    else printf " %s" "$p";
     fi
   done
   echo ""
@@ -449,6 +449,24 @@ else
   cases=$(read_cases "$in_dir" "$pattern" "/source" | $tofile)
 fi
 num_cases=$(echo "$cases" | wc -l)
+
+if [[ "$num_cases" -lt 1 ]] || [[ -z "$cases" ]]
+then
+  wait
+  echo "WARNING: No cases found using the parameters provided. Aborting job submission!"
+  if [[ "$submit_jobs" == "true" ]] && [[ "$do_cleanup" == "true" ]]
+  then
+    echo "Cleaning temporary work directory!"
+    rm -R "$hpc_work/images"
+    rm -R "$hpc_work/scripts"
+    if [[ "$delete_hpc_work" == "false" ]]
+    then
+      rm -R "$hpc_work"
+    fi
+  fi
+  exit 0
+fi
+
 
 if [[ "$submit_jobs" != "true" ]]
 then

--- a/stools.sh
+++ b/stools.sh
@@ -14,7 +14,7 @@ function read_cases ()
   { pushd "$1" > /dev/null || (echo "Could not go to $1" && exit 1)} >&2
     # pattern without fixed postfixes, e.g. */mri/orig.mgz -> *
     no_fixed_postfix="${2/%\/[^*{[]*}"
-    for file_match in ./$2; do
+    for file_match in $(eval echo "./$2"); do
       if [[ -e "$file_match" ]]
       then
         file_match="${file_match/#.\/}"


### PR DESCRIPTION
Adjust memory limits to fail less often
fix globbing, so globbing does happen if subjects/cases are read

confirmation for known bad OASIS cases is running

This specifically is caused by very inconsistent memory usage of mris_sample_parc, which runs into memory limitations for 14GB of memory.