### PR TITLE
FIX and DOC: is_conform and vox sizes in 4D single-frame images

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -323,7 +323,7 @@ class RunModelOnData:
             orig,
             conform_vox_size=self.vox_size,
             check_dtype=True,
-            verbose=False,
+            verbose=True,
             conform_to_1mm_threshold=self.conform_to_1mm_threshold,
         ):
             LOGGER.info("Conforming image")


### PR DESCRIPTION
Better verbosity and error handling for conforming images
Fix a bug arising from 4D single-frame images as input. #431 

conform.py
- add functionality to process frames to map_image
- formatting cleanup
- make is_conform messages more verbose 
run_prediction.py
- by default: output verbose messages of is_conform