### PR TITLE
Modify the batch and slurm scripts to support additonal per-subject parameters

### DIFF
--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -121,7 +121,7 @@ case $key in
         echo "ERROR: Could not find the subject list $2!"
         exit 1
       fi
-      subjects="$subjects$newline$(cat $2)"
+      subjects="$subjects$newline$(cat "$2")"
       subjects_stdin="false"
     shift # past argument
     shift # past value
@@ -129,7 +129,7 @@ case $key in
     --subjects)
       subjects_stdin="false"
       shift # argument
-      while [[ "$(expr match \"$1\" '--.')" == 0 ]]
+      while [[ "$1" =~ ^-- ]]
       do
         if [[ -n "$subjects" ]]; then subjects="$subjects$newline"; fi
         subjects="$subjects$1"
@@ -144,7 +144,7 @@ case $key in
     ;;
     --parallel_subjects)
       shift
-      if [[ "$(expr match \"$1\" '--.')" == 0 ]]
+      if [[ "$1" =~ ^-- ]]
       then
         lower_value="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
         # has parameter

--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -55,7 +55,7 @@ Documentation of Options:
 Generally, brun_fastsurfer works similar to run_fastsurfer, but loops over multiple subjects from
 i. a list passed through stdin of the format (one subject per line)
 ---
-<subject_id>=<path to t1 image>
+<subject_id>=<path to t1 image>[,<subject-specific parameters>[,...]]
 ...
 ---
 ii. a subject_list file using the same format (use Ctrl-D to end the input), or
@@ -384,13 +384,19 @@ do
       fi
     fi
 
-    image_path=$(echo "$subject" | cut -d= -f2)
+    subject_parameters=$(echo "$subject" | cut -d= -f2)
+    image_path=$(echo "$subject_parameters" | cut -d, -f1)
+    subject_flags=$(echo "$subject_parameters" | cut -d, --output-delimiter=" " -f2-1000)
     args=(--sid "$subject_id")
+    if [[ -n "${subject_flags// /}" ]]
+    then
+      args=("${args[@]}" $subject_flags)
+    fi
     if [[ "$parallel_surf" == "true" ]]
     then
       if [[ "$debug" == "true" ]]
       then
-        echo "DEBUG: $run_fastsurfer --seg_only --t1 "$image_path"" "${args[@]}" "${POSITIONAL_FASTSURFER[@]}"
+        echo "DEBUG: $run_fastsurfer --seg_only --t1" "$image_path" "${args[@]}" "${POSITIONAL_FASTSURFER[@]}"
       fi
       $run_fastsurfer "--seg_only"  --t1 "$image_path" "${args[@]}" "${POSITIONAL_FASTSURFER[@]}"
       if [[ -n "$statusfile" ]]

--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -115,7 +115,7 @@ do
 key=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
 case $key in
-    --subject_list)
+    --subject_list|--subjects_list)
       if [[ ! -f "$2" ]]
       then
         echo "ERROR: Could not find the subject list $2!"

--- a/doc/scripts/slurm.rst
+++ b/doc/scripts/slurm.rst
@@ -1,0 +1,37 @@
+
+
+Debugging SLURM runs
+------
+
+1. Did the run succeed?
+
+i) Check whether all jobs are done (specifically the copy job).
+```bash
+$ squeue -u $USER --Format JobArrayID,Name,State,Dependency
+1750814_3           FastSurfer-Seg-kueglRUNNING             (null)
+1750815_3           FastSurfer-Surf-kuegPENDING             aftercorr:1750814_*(
+1750816             FastSurfer-Cleanup-kPENDING             afterany:1750815_*(u
+1750815_1           FastSurfer-Surf-kuegRUNNING             (null)
+1750815_2           FastSurfer-Surf-kuegRUNNING             (null)
+```
+Here, jobs are not finished yet. The FastSurfer-Cleanup-$USER Job moves data to the subject directory (--sd).
+
+ii) Check whether there are subject folders and log files in the subject directory, <subject directory>/slurm/logs for the latter.
+
+iii) Check the subject_success file in <subject directory>/slurm/scripts. It should have a line for each subject for both parts of the FastSurfer pipeline, e.g. `<subject id>: Finished --seg_only successfully` or `<subject id>: Finished --surf_only successfully`! If one of these is missing, the job was likely killed by slurm (e.g. because of the time or the memory limit).
+
+iv) For subjects that were unsuccessful (the subject_success will say so), check `<subject directory>/<subject id>/scripts/deep-seg.log` and `<subject directory>/<subject id>/scripts/recon-surf.log` to see what failed.
+Can be found by looking for "<subject id>: Failed <--seg_only/--surf_only> with exit code <return code>" in `<subject directory>/slurm/scripts/subject_success`.
+
+iv) For subjects that were terminated (missing in subject_success), find which job is associated with subject id `grep "<subject id>" slurm/logs/surf_*.log`, then look at the end of the job and the job step logs (surf_XXX_YY.log and surf_XXX_YY_ZZ.log). If slurm terminated the job, it will say so there. You can increase the time and memory budget in `srun_fastsurfer.sh` with `--time` and `--mem` flags.
+The following bash code snippet can help identify failed runs.
+```
+cd <subject directory>
+for sub in *
+do
+  if [[ -z "$(grep "$sub: Finished --surf" slurm/scripts/subject_success)" ]]
+  then
+    echo "$sub was terminated externally"
+  fi
+done
+```

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -279,11 +279,12 @@ key=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
 case $key in
     --fs_license)
-    if [[ -f "$2" ]]; then
-        export FS_LICENSE="$2"
+    if [[ -f "$2" ]]
+    then
+      export FS_LICENSE="$2"
     else
-        echo "Provided FreeSurfer license file $2 could not be found. Make sure to provide the full path and name. Exiting..."
-        exit 1;
+      echo "Provided FreeSurfer license file $2 could not be found. Make sure to provide the full path and name. Exiting..."
+      exit 1;
     fi
     shift # past argument
     shift # past value
@@ -309,10 +310,12 @@ case $key in
     shift # past value
     ;;
     --seg | --asegdkt_segfile | --aparc_aseg_segfile)
-    if [[ "$key" == "--seg" ]]; then
+    if [[ "$key" == "--seg" ]]
+    then
       echo "WARNING: --seg <filename> is deprecated and will be removed, use --asegdkt_segfile <filename>."
     fi
-    if [[ "$key" == "--aparc_aseg_segfile" ]]; then
+    if [[ "$key" == "--aparc_aseg_segfile" ]]
+    then
       echo "WARNING: --aparc_aseg_segfile <filename> is deprecated and will be removed, use --asegdkt_segfile <filename>"
     fi
     asegdkt_segfile="$2"
@@ -474,32 +477,38 @@ case $key in
     exit
     ;;
     --version)
-      if [[ "$#" -lt 2 ]]; then
-          version_and_quit="1"
-      else
-        case $2 in
-          all)
-            version_and_quit="+checkpoints+git+pip"
-            shift
-            ;;
-          +*)
-            version_and_quit="$2"
-            shift
-            ;;
-          --*)
-            version_and_quit="1"
-            ;;
-          *)
-            echo "Invalid option for --version"
-            exit 1
-            ;;
-        esac
-      fi
+    if [[ "$#" -lt 2 ]]; then
+      version_and_quit="1"
+    else
+      case $2 in
+        all)
+        version_and_quit="+checkpoints+git+pip"
+        shift
+        ;;
+        +*)
+        version_and_quit="$2"
+        shift
+        ;;
+        --*)
+        version_and_quit="1"
+        ;;
+        *)
+        echo "Invalid option for --version: '$2', must be 'all' or [+checkpoints][+git][+pip]"
+        exit 1
+        ;;
+      esac
+    fi
     shift
     ;;
     *)    # unknown option
-    echo ERROR: Flag $1 unrecognized.
-    exit 1
+    if [[ "$1" == "" ]]
+    then
+      # skip empty arguments
+      shift
+    else
+      echo "ERROR: Flag '$1' unrecognized."
+      exit 1
+    fi
     ;;
 esac
 done
@@ -514,10 +523,10 @@ else
 fi
 
 ########################################## VERSION AND QUIT HERE ########################################
-version_args=""
+version_args=()
 if [[ -f "$FASTSURFER_HOME/BUILD.info" ]]
   then
-    version_args="--build_cache $FASTSURFER_HOME/BUILD.info --prefer_cache"
+    version_args=(--build_cache "$FASTSURFER_HOME/BUILD.info" --prefer_cache)
 fi
 
 if [[ -n "$version_and_quit" ]]
@@ -525,9 +534,9 @@ if [[ -n "$version_and_quit" ]]
     # if version_and_quit is 1, it should only print the version number+git branch
     if [[ "$version_and_quit" != "1" ]]
       then
-        version_args="$version_args --sections $version_and_quit"
+        version_args=("${version_args[@]}" --sections "$version_and_quit")
     fi
-    $python $FASTSURFER_HOME/FastSurferCNN/version.py $version_args
+    $python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}"
     exit
 fi
 
@@ -703,7 +712,7 @@ else
     append_flag=(-a "$seg_log")
 fi
 
-VERSION=$($python $FASTSURFER_HOME/FastSurferCNN/version.py $version_args)
+VERSION=$($python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}")
 echo "Version: $VERSION" |& tee "${append_flag[@]}"
 
 ### IF THE SCRIPT GETS TERMINATED, ADD A MESSAGE
@@ -711,7 +720,7 @@ trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" >> \"$s
 
 # create the build log, file with all version info in parallel
 printf "%s %s\n%s\n" "$THIS_SCRIPT" "${inputargs[*]}" "$(date -R)" >> "$build_log"
-$python "$FASTSURFER_HOME/FastSurferCNN/version.py" $version_args >> "$build_log" &
+$python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}" >> "$build_log" &
 
 if [[ ! -f "$seg_log" ]] || [[ "$run_seg_pipeline" != "1" ]]
   then

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -705,15 +705,12 @@ fi
 ########################################## START ########################################################
 mkdir -p "$(dirname "$seg_log")"
 
-if [[ -f "$seg_log" ]] && [[ "$run_seg_pipeline" == "1" ]]
-  then
-    append_flag=("$seg_log")
-else
-    append_flag=(-a "$seg_log")
+if [[ -f "$seg_log" ]]; then log_existed="true"
+else log_existed="false"
 fi
 
 VERSION=$($python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}")
-echo "Version: $VERSION" |& tee "${append_flag[@]}"
+echo "Version: $VERSION" |& tee -a "$seg_log"
 
 ### IF THE SCRIPT GETS TERMINATED, ADD A MESSAGE
 trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" >> \"$seg_log\" }" SIGINT SIGTERM
@@ -722,9 +719,9 @@ trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" >> \"$s
 printf "%s %s\n%s\n" "$THIS_SCRIPT" "${inputargs[*]}" "$(date -R)" >> "$build_log"
 $python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}" >> "$build_log" &
 
-if [[ ! -f "$seg_log" ]] || [[ "$run_seg_pipeline" != "1" ]]
+if [[ "$run_seg_pipeline" != "1" ]]
   then
-    echo "Running run_fastsurfer.sh on a "
+    echo "Running run_fastsurfer.sh without segmentation ; expecting previous --seg_only run in ${sd}/${subject}" | tee -a "$seg_log"
 fi
 
 

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -502,6 +502,12 @@ then
   # the test for files (check_subject_images) requires paths to be wrt
   cases=$(translate_cases "$in_dir" "$subject_list" "$in_dir" "${subject_list_delim}" "${subject_list_awk_code_sid}" "${subject_list_awk_code_args}")
   check_subject_images "$cases"
+  if [[ "$debug" == "true" ]]
+  then
+    echo "Debug output of the parsed subject_list:"
+    echo "$cases"
+    echo ""
+  fi
 
   cases=$(translate_cases "$in_dir" "$subject_list" "/source" "${subject_list_delim}" "${subject_list_awk_code_sid}" "${subject_list_awk_code_args}" | $tofile)
 else

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -176,7 +176,7 @@ EOF
 }
 
 # the memory required for the surface and the segmentation pipeline depends on the
-# voxel size of the image, here we use values proven to work for 0.7mm (and also 0.8 and 1m)
+# voxel size of the image, here we use values proven to work for 0.7mm (and also 0.8 and 1mm)
 mem_seg_cpu=10 # in GB, seg on cpu, actually required: 9G
 mem_seg_gpu=7 # in GB, seg on gpu, actually required: 6G
 mem_surf_parallel=6 # in GB, hemi in parallel
@@ -365,6 +365,24 @@ case $key in
     usage
     exit
     ;;
+  --mem)
+    # make key lowercase
+    lower_value=$(echo "$2" | tr '[:upper:]' '[:lower:]')
+    if [[ "$lower_value" =~ ^seg=[0-9]+$ ]]
+    then
+      mem_seg_cpu=${2:4}
+      mem_seg_gpu=${2:4}
+    elif [[ "$lower_value" =~ ^surf=[0-9]+$ ]]
+    then
+      mem_surf_parallel=${2:5}
+      mem_surf_noparallel=${2:5}
+    else
+      echo "Invalid parameter to --mem: $2, must be seg|surf=<integer (GigaBytes)>"
+      exit 1
+    fi
+    shift
+    shift
+    ;;
   *)    # unknown option
     POSITIONAL_FASTSURFER[$i]=$1
     i=$(($i + 1))
@@ -382,7 +400,7 @@ function log() { echo "$@" | tee -a "$LF" ; }
 function logf() { printf "$@" | tee -a "$LF" ; }
 
 log "Log of FastSurfer SLURM script"
-log $(date -R)
+log "$(date -R)"
 log "$THIS_SCRIPT ${inputargs[*]}"
 log ""
 
@@ -789,6 +807,6 @@ if [[ "$submit_jobs" == "true" ]]
 then
   log_dir="$out_dir/slurm/logs"
   mkdir -p "$log_dir"
-  cp $tmpLF "$log_dir/$log_name.log"
+  cp "$tmpLF" "$log_dir/$log_name.log"
 fi
-rm $tmpLF
+rm "$tmpLF"

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -44,7 +44,8 @@ subject_list_awk_code_args="\$2"
 subject_list_delim="="
 jobarray=""
 timelimit_seg=5
-timelimit_surf=180
+# 1mm can take 1h per hemi plus 1h extra on a single core (depending on cpu speed)
+timelimit_surf=$((4 * 60))
 
 function usage()
 {

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -226,12 +226,12 @@ case $key in
     shift # past argument
     shift # past value
     ;;
-  --subject_list)
+  --subject_list|--subjects_list)
     subject_list="$2"
     shift
     shift
     ;;
-  --subject_list_delim)
+  --subject_list_delim|--subjects_list_delim)
     subject_list_delim="$2"
     shift
     shift
@@ -240,12 +240,12 @@ case $key in
     echo "--subject_list_awk_code is outdated, use subject_list_awk_code_sid and subject_list_awk_code_args!"
     exit 1
     ;;
-  --subject_list_awk_code_sid)
+  --subject_list_awk_code_sid|--subjects_list_awk_code_sid)
     subject_list_awk_code_sid="$2"
     shift
     shift
     ;;
-  --subject_list_awk_code_args)
+  --subject_list_awk_code_args|--subjects_list_awk_code_args)
     subject_list_awk_code_args="$2"
     shift
     shift

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -39,7 +39,7 @@ extra_singularity_options_seg=""
 email=""
 pattern="*.{nii.gz,nii,mgz}"
 subject_list=""
-subject_list_awk_code="\$1:\$2"
+subject_list_awk_code="\$1=\$2"
 subject_list_delim="="
 jobarray=""
 timelimit_seg=5
@@ -92,12 +92,20 @@ Data- and subject-related options:
   subject_id1=/path/to/t1.mgz
   ...
   This option invalidates the --pattern option.
+  May also add additional parameters like:
+  subject_id1=/path/to/t1.mgz,--vox_size,1.0
 --subject_list_delim: alternative delimiter in the file (default: "="). For example, if you
   pass --subject_list_delim "," the subject_list file is parsed as a comma-delimited csv file.
---subject_list_awk_code <subject_id code>:<subject_path code>: alternative way to construct
-  subject_id and subject_path from the row in the subject_list (default: '\$1:\$2'), other
-  examples: '\$1:\$2/\$1/mri/orig.mgz', where the first field is the subject_id and the second
+--subject_list_awk_code <subject_id code>=<subject_path code>: alternative way to construct
+  subject_id and subject_path from the row in the subject_list (default: '\$1=\$2'), other
+  examples: '\$1=\$2/\$1/mri/orig.mgz', where the first field is the subject_id and the second
   field is the containing folder, e.g. the study.
+  Example for additional parameters:
+  --subject_list_delim "," --subject_list_awk_code '\$1=\$2,--vox_size,\$4'
+  to implement from the subject_list line
+  subject-101,raw/T1w-101A.nii.gz,study-1,0.9
+  to
+  --sid subject-101 --t1 <data-path>/raw/T1w-101A.nii.gz --vox_size 0.9
 
 FastSurfer options:
 --fs_license: path to the freesurfer license (either absolute path or relative to pwd)

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -467,7 +467,8 @@ wait # for directories to be made
 all_cases_file="/$hpc_work/scripts/subject_list"
 
 echo "cp \"$singularity_image\" \"$hpc_work/images/fastsurfer.sif\""
-echo "cp \"$(dirname $THIS_SCRIPT)/brun_fastsurfer.sh\" \"$hpc_work/scripts\""
+script_dir="$(dirname "$THIS_SCRIPT")"
+echo "cp \"$script_dir/brun_fastsurfer.sh\" \"$script_dir/stools.sh\" \"$hpc_work/scripts\""
 echo "cp \"$fs_license\" \"$hpc_work/scripts/.fs_license\""
 echo "Create Status/Success file at $hpc_work/scripts/subject_success"
 
@@ -475,7 +476,7 @@ tofile="cat"
 if [[ "$submit_jobs" == "true" ]]
 then
   cp "$singularity_image" "$hpc_work/images/fastsurfer.sif" &
-  cp "$(dirname $THIS_SCRIPT)/brun_fastsurfer.sh" "$hpc_work/scripts" &
+  cp "$script_dir/brun_fastsurfer.sh" "$script_dir/stools.sh" "$hpc_work/scripts" &
   cp "$fs_license" "$hpc_work/scripts/.fs_license" &
   echo "#Status/Success file of srun_fastsurfer-run $(date)" > "$hpc_work/scripts/subject_success" &
 

--- a/stools.sh
+++ b/stools.sh
@@ -68,13 +68,15 @@ function translate_cases ()
     regex2=\",(\" source_dir \"|\" target_dir \")/*\";
   }
   length(\$NF) > 1 {
-    subid=${subid_awk@Q};
-    subpath=${subpath_awk@Q};
+    subid=${subid_awk};
+    subpath=${subpath_awk};
     gsub(regex, \"\", subpath);
     gsub(regex2, \",\" target_dir \"/\", subpath);
     print subid \"=\" target_dir \"/\" subpath;
   }"
   #>&2 echo "awk -F \"$delimiter\" -v target_dir=\"$3\" -v source_dir=\"$1\" \"$script\" \"$2\""
+  #>&2 cat "$2"
+  #>&2 awk -F "$delimiter" -v target_dir="$3" -v source_dir="$1" "$script" "$2"
   awk -F "$delimiter" -v target_dir="$3" -v source_dir="$1" "$script" "$2"
 }
 
@@ -141,12 +143,13 @@ function check_subject_images ()
   do
     subject_id=$(echo "$subject" | cut -d= -f1)
     image_parameters=$(echo "$subject" | cut -d= -f2)
+    i=0
     OLD_IFS=$IFS
     IFS=","
     for arg in $image_parameters
     do
       if [[ "$i" == 0 ]]; then image_path="$arg"; fi
-      i=$(( i + 1))
+      i=$((i + 1))
     done
     IFS=$OLD_IFS
     #TODO: also check here, if any of the folders up to the mounted dir leading to the file are symlinks


### PR DESCRIPTION
A current limitation of both srun_fastsurfer and brun_fastsurfer is that it is not possible to define additional subject-specific parameters to run_fastsurfer.sh.
This PR adds the feature to add such options to both srun_fastsurfer and brun_fastsurfer.

In particular, brun_fastsurfer.sh <subjects> can have additional parameters (format <subject id>=<path to t1>,<additional subject-specific parameters>). This also passed through to srun_fastsurfer, for example:
Example 1:
`--subject_list_delim "," --subject_list_awk_code_args '\$2 ",--vox_size," \$4'`
to implement from the subject_list line
`subject-101,raw/T1w-101A.nii.gz,study-1,0.9`
to
`--sid subject-101 --t1 <data-path>/raw/T1w-101A.nii.gz --vox_size 0.9`
Example 2:
`--subject_list_delim "," --subject_list_awk_code '\$2' --subject_list_awk_code_args '\$4,--asegdkt_segfile,\$3'`
to implement from the subject_list line
`4,sub_A1,mri/asegdkt.mgz,412463-t1.nii.gz`
to
`--sid sub_A1 --t1 <data-path>/412463-t1.nii.gz --asegdkt_segfile mri/asegdkt.mgz`