### PR TITLE
plane defaults

### DIFF
--- a/CerebNet/config/checkpoint_paths.yaml
+++ b/CerebNet/config/checkpoint_paths.yaml
@@ -1,0 +1,8 @@
+URL:
+- "https://b2share.fz-juelich.de/api/files/c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5"
+- "https://zenodo.org/records/10390742/files"
+
+CKPT:
+  AXIAL:  "CerebNet/checkpoints/CerebNet_axial_v1.0.0.pkl"
+  CORONAL: "CerebNet/checkpoints/CerebNet_coronal_v1.0.0.pkl"
+  SAGITTAL: "CerebNet/checkpoints/CerebNet_sagittal_v1.0.0.pkl"

--- a/CerebNet/utils/checkpoint.py
+++ b/CerebNet/utils/checkpoint.py
@@ -30,11 +30,6 @@ from FastSurferCNN.utils.checkpoint import (
 
 logger = logging.get_logger(__name__)
 
-# Defaults
-URL = "https://b2share.fz-juelich.de/api/files/c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5"
-CEREBNET_AXI = FASTSURFER_ROOT / "checkpoints/CerebNet_axial_v1.0.0.pkl"
-CEREBNET_COR = FASTSURFER_ROOT / "checkpoints/CerebNet_coronal_v1.0.0.pkl"
-CEREBNET_SAG = FASTSURFER_ROOT / "checkpoints/CerebNet_sagittal_v1.0.0.pkl"
 
 
 def is_checkpoint_epoch(cfg: "yacs.config.CfgNode", cur_epoch: int) -> bool:

--- a/FastSurferCNN/README.md
+++ b/FastSurferCNN/README.md
@@ -20,14 +20,14 @@ The *FastSurferCNN* directory contains all the source code and modules needed to
 * `--strip`: strip suffix from path definition of input file to yield correct subject name. (Optional, if full path is defined for `--t1`)
 * `--lut`: FreeSurfer-style Color Lookup Table with labels to use in final prediction. Default: ./config/FastSurfer_ColorLUT.tsv
 * `--seg`: Name of intermediate DL-based segmentation file (similar to aparc+aseg).
-* `--cfg_cor`: Path to the coronal config file
-* `--cfg_sag`: Path to the axial config file
-* `--cfg_ax`: Path to the sagittal config file
 
-#### Checkpoints
+#### Checkpoints and configs
 * `--ckpt_sag`: path to sagittal network checkpoint
 * `--ckpt_cor`: path to coronal network checkpoint
 * `--ckpt_ax`: path to axial network checkpoint
+* `--cfg_cor`: Path to the coronal config file
+* `--cfg_sag`: Path to the axial config file
+* `--cfg_ax`: Path to the sagittal config file
 
 #### Optional commands
 * `--clean`: clean up segmentation after running it (optional)

--- a/FastSurferCNN/config/checkpoint_paths.yaml
+++ b/FastSurferCNN/config/checkpoint_paths.yaml
@@ -1,0 +1,13 @@
+URL:
+- https://b2share.fz-juelich.de/api/files/a423a576-220d-47b0-9e0c-b5b32d45fc59
+- https://zenodo.org/records/10390573/files
+
+CKPT:
+  AXIAL: FastSurferCNN/checkpoints/aparc_vinn_axial_v2.0.0.pkl
+  CORONAL: FastSurferCNN/checkpoints/aparc_vinn_coronal_v2.0.0.pkl
+  SAGITTAL: FastSurferCNN/checkpoints/aparc_vinn_sagittal_v2.0.0.pkl
+
+CFG:
+  AXIAL: FastSurferCNN/config/FastSurferVINN_axial.yaml
+  CORONAL: FastSurferCNN/config/FastSurferVINN_coronal.yaml
+  SAGITTAL: FastSurferCNN/config/FastSurferVINN_sagittal.yaml

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -18,12 +18,11 @@ import copy
 import sys
 from concurrent.futures import Executor, ThreadPoolExecutor, Future
 from pathlib import Path
-from typing import Dict, Any, Iterator, Literal, Optional, Sequence
+from typing import Any, Iterator, Literal, Optional, Sequence
 
 import nibabel as nib
 import numpy as np
 import torch
-import nibabel as nib
 import yacs.config
 
 import FastSurferCNN.reduce_to_aseg as rta

--- a/FastSurferCNN/utils/checkpoint.py
+++ b/FastSurferCNN/utils/checkpoint.py
@@ -41,9 +41,9 @@ def get_plane_dict(filename : Path = YAML_DEFAULT) -> dict[str, Union[str, list[
     ----------
     filename : Path
         path to the yaml file. Either absolute or relative to the FastSurfer root directory.
+
     Returns
     -------
-
     dict[str, Union[str, list[str]]]
         dictionary of the yaml file
 
@@ -55,22 +55,22 @@ def get_plane_dict(filename : Path = YAML_DEFAULT) -> dict[str, Union[str, list[
         dictionary = yaml.load(file, Loader=yaml.FullLoader)
     return dictionary
 
-def get_plane_default(type : str, plane : Optional[str] = None, filename : str | Path = YAML_DEFAULT) -> Union[str, list[str]]:
+def get_plane_default(type : Literal["URL", "CKPT", "CFG"], plane : Optional[str] = None, filename : str | Path = YAML_DEFAULT) -> str | list[str]:
     """
     Get the default value for a specific plane.
 
     Parameters
     ----------
-    type : str
-        Type of value. Can be URL, CKPT, CFG
+    type : "URL", "CKPT", "CFG"
+        Type of value.
     plane : str
         Plane to get the default value for. Can be "axial", "coronal" or "sagittal".
     filename : str | Path
-        path to the yaml file. Either absolute or relative to the FastSurfer root directory.
+        The path to the yaml file. Either absolute or relative to the FastSurfer root directory.
 
     Returns
     -------
-    Union[str, list[str]]
+    str, list[str]
         Default value for the plane.
 
     """

--- a/FastSurferCNN/utils/checkpoint.py
+++ b/FastSurferCNN/utils/checkpoint.py
@@ -15,7 +15,7 @@
 # IMPORTS
 import os
 from pathlib import Path
-from typing import MutableSequence, Optional, Union, Any
+from typing import MutableSequence, Optional, Union, Literal
 
 import requests
 import torch

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -30,12 +30,14 @@ import argparse
 from pathlib import Path
 from typing import Dict, Iterable, Literal, Mapping, Protocol, Type, TypeVar, Union
 
+FASTSURFER_ROOT = Path(__file__).parents[2]
+
 from FastSurferCNN.utils.arg_types import float_gt_zero_and_le_one as __conform_to_one
 from FastSurferCNN.utils.arg_types import unquote_str
 from FastSurferCNN.utils.arg_types import vox_size as __vox_size
 from FastSurferCNN.utils.threads import get_num_threads
+from FastSurferCNN.utils.checkpoint import get_plane_default
 
-FASTSURFER_ROOT = Path(__file__).parents[2]
 PLANE_SHORT = {"checkpoint": "ckpt", "config": "cfg"}
 PLANE_HELP = {
     "checkpoint": "{} checkpoint to load",
@@ -339,6 +341,7 @@ def add_plane_flags(
     parser: argparse.ArgumentParser,
     type: Literal["checkpoint", "config"],
     files: Mapping[str, Path],
+    default_path: str,
 ) -> argparse.ArgumentParser:
     """
     Add plane arguments.
@@ -370,8 +373,10 @@ def add_plane_flags(
 
     for key, filepath in files.items():
         path = Path(filepath)
+        if str(path) == "default":
+            path = Path(get_plane_default(PLANE_SHORT[type], key, default_path))
         if not path.is_absolute():
-            path = FASTSURFER_ROOT / filepath
+            path = FASTSURFER_ROOT / path
         # find the first vowel in the key
         flag = key.strip().lower()
         index = min(i for i in (flag.find(v) for v in "aeiou") if i >= 0)


### PR DESCRIPTION
This PR adds:
* Backup URL feature, where the checkpoint download can have multiple URLs, in case the first one is unreachable or similar
* New yaml files ([CerebNet/config/checkpoint_paths.yaml](CerebNet/config/checkpoint_paths.yaml) and [FastSurferCNN/config/checkpoint_paths.yaml](FastSurferCNN/config/checkpoint_paths.yaml)) for default values for the configuration path, the checkpoint path as well as the URLs