### PR TITLE
Fix python call to spherical_project

### DIFF
--- a/recon_surf/fs_time
+++ b/recon_surf/fs_time
@@ -38,8 +38,7 @@ If the env variable FSTIME_LOAD is set to 1 or not set at all, then
 uptime is run before and after each process to give the load on the
 system (see below for output)
 
-Default fs_time Output
-} (see also the manual page for /usr/bin/time):
+Default fs_time Output (see also the manual page for /usr/bin/time):
 1. Key (default is @#@FSTIME)
 2. Time stamp at the onset of execution
 3. Command name

--- a/recon_surf/fs_time
+++ b/recon_surf/fs_time
@@ -1,152 +1,33 @@
-#!/bin/tcsh -f
+#!/bin/bash
 # fs_time
 
-set VERSION = '$Id: fs_time,v 1.11 2016/02/16 17:17:20 zkaufman Exp $';
-set outfile = ();
-set key = ("@#@FSTIME ");
+VERSION='$Id: fs_time,v 1.0 2024/03/08 15:12:00 kueglerd Exp $'
+outfile=""
+key="@#@FSTIME "
+cmd=()
 
-if($?FSTIME_LOAD == 0) then
+if [[ -z "$FSTIME_LOAD" ]]
+then
   # Turn on by default
-  setenv FSTIME_LOAD 1
-endif
+  export FSTIME_LOAD=1
+fi
 
-set inputargs = ($argv);
-set PrintHelp = 0;
-if($#argv == 0) goto usage_exit;
-set n = `echo $argv | grep -e -help | wc -l` 
-if($n != 0) then
-  set PrintHelp = 1;
-  goto usage_exit;
-endif
-set n = `echo $argv | grep -e -version | wc -l` 
-if($n != 0) then
-  echo $VERSION
-  exit 0;
-endif
+function usage()
+{
+  cat << EOF
 
-source $FREESURFER_HOME/sources.csh
+fs_time [options] command args
+ options:
+  -o outputfile : save resource info into outputfile
+  -k key
+  -l : report on load averages as from uptime
+EOF
+}
 
-goto parse_args;
-parse_args_return:
-goto check_params;
-check_params_return:
-
-@ nargs = $#argv - 1
-
-if($FSTIME_LOAD) then
-  set upt = `uptime | sed 's/,/ /g'`;
-  @ a = $#upt - 2
-  @ b = $#upt - 1
-  #echo "@#@FSLOADPRE $dt $argv[1] N $nargs $upt[$a] $upt[$b] $upt[$#upt]"
-  set upt = "L $upt[$a] $upt[$b] $upt[$#upt]"
-else
-  set upt = ""
-endif
-
-set dt = `date '+%Y:%m:%d:%H:%M:%S'`
-set fmt = "$key $dt $argv[1] N $nargs e %e S %S U %U P %P M %M F %F R %R W %W c %c w %w I %I O %O $upt"
-
-set cmd = /usr/bin/time
-if($#outfile) set cmd = ($cmd -o $outfile)
-$cmd  -f "$fmt" $argv
-set st = $status
-if($#outfile) cat $outfile
-
-if($FSTIME_LOAD) then
-  set dt = `date '+%Y:%m:%d:%H:%M:%S'`
-  set upt = `uptime | sed 's/,/ /g'`;
-  @ a = $#upt - 2
-  @ b = $#upt - 1
-  echo "@#@FSLOADPOST $dt $argv[1] N $nargs $upt[$a] $upt[$b] $upt[$#upt]"
-endif
-
-exit $st
-
-###############################################
-
-############--------------##################
-parse_args:
-set cmdline = ($argv);
-while( $#argv != 0 )
-
-  set flag = $argv[1]; shift;
-  
-  switch($flag)
-
-    case "-o":
-      if($#argv < 1) goto arg1err;
-      set outfile = $argv[1]; shift;
-      breaksw
-
-    case "-k":
-      if($#argv < 1) goto arg1err;
-      set key = $argv[1]; shift;
-      breaksw
-
-    case "-l":
-    case "-load":
-      setenv FSTIME_LOAD 1
-      breaksw
-    case "-no-load":
-      setenv FSTIME_LOAD 0
-      breaksw
-
-    case "-debug":
-      set verbose = 1;
-      set echo = 1;
-      breaksw
-
-    default:
-      # must be at the start of the command to run
-      # put item back into the list
-      set argv = ($flag $argv)
-      break;
-      breaksw
-  endsw
-
-end
-
-goto parse_args_return;
-############--------------##################
-
-############--------------##################
-check_params:
-
-if(! -e /usr/bin/time) then
-  echo "ERROR: cannot find /usr/bin/time"
-  exit 1;
-endif
-
-if($#argv == 0) then
-  goto usage_exit;
-endif
-
-goto check_params_return;
-############--------------##################
-
-############--------------##################
-arg1err:
-  echo "ERROR: flag $flag requires one argument"
-  exit 1
-
-############--------------##################
-usage_exit:
-  echo ""
-  echo "fs_time [options] command args"
-  echo " options:"
-  echo "  -o outputfile : save resource info into outputfile"
-  echo "  -k key"
-  echo "  -l : report on load averages as from uptime"
-
-  if(! $PrintHelp) exit 1;
-  echo $VERSION
-  cat $0 | awk 'BEGIN{prt=0}{if(prt) print $0; if($1 == "BEGINHELP") prt = 1 }'
-exit 1;
-
-#---- Everything below here is printed out as part of help -----#
-BEGINHELP
-
-This is a frontend for the unix /usr/bin/time program to keep track of 
+function help()
+{
+  cat << EOF
+This is a frontend for the unix /usr/bin/time program to keep track of
 resources used by a process. The basic usage is like that of time, ie,
 
 fs_time [options] command args
@@ -157,7 +38,8 @@ If the env variable FSTIME_LOAD is set to 1 or not set at all, then
 uptime is run before and after each process to give the load on the
 system (see below for output)
 
-Default fs_time Output (see also the manual page for /usr/bin/time):
+Default fs_time Output
+} (see also the manual page for /usr/bin/time):
 1. Key (default is @#@FSTIME)
 2. Time stamp at the onset of execution
 3. Command name
@@ -169,16 +51,16 @@ Default fs_time Output (see also the manual page for /usr/bin/time):
 7. U Total number of CPU-seconds that the process spent in user mode.
 8. P Percentage of the CPU that this job got, computed as (U+S)/e.
 9. M Maximum resident set size of the process during its lifetime, in Kbytes.
-10. F Number  of major page faults that occurred while the process was running.  
+10. F Number  of major page faults that occurred while the process was running.
       These are faults where the page has to be read in from disk.
 11. R Number of minor, or recoverable, page faults.  These are
    faults for pages that are not valid but which have not yet been
    claimed by other virtual pages.  Thus the data in the page is
    still valid but the system tables must be updated.
 12.  W Number of times the process was swapped out of main memory.
-13. c Number of times the process was context-switched involuntarily 
-    (because the time slice expired). 
-14. w Number of waits: times that the program was context-switched voluntarily, 
+13. c Number of times the process was context-switched involuntarily
+    (because the time slice expired).
+14. w Number of waits: times that the program was context-switched voluntarily,
     for instance while  waiting  for an I/O operation to complete.
 15. I Number of file system inputs by the process.
 16. O Number of file system outputs by the process.
@@ -187,14 +69,14 @@ Default fs_time Output (see also the manual page for /usr/bin/time):
 Example:
 
 fs_time -o resource.dat mri_convert orig.mgz myfile.mgz
-mri_convert orig.mgz myfile.mgz 
+mri_convert orig.mgz myfile.mgz
 reading from orig.mgz...
 TR=2730.00, TE=3.44, TI=1000.00, flip angle=7.00
 i_ras = (-1, 0, 0)
 j_ras = (2.38419e-07, 0, -1)
 k_ras = (-1.93715e-07, 1, 0)
 writing to myfile.mgz...
-@#@FSTIME 2016:01:21:18:27:08 mri_convert N 2 e 2.20 S 0.05 U 1.64 P 77% M 23628 F 0 R 5504 W 0 c 7 w 3 I 0 O 20408 
+@#@FSTIME 2016:01:21:18:27:08 mri_convert N 2 e 2.20 S 0.05 U 1.64 P 77% M 23628 F 0 R 5504 W 0 c 7 w 3 I 0 O 20408
 
 The above command runs the mri_convert command with two arguments and
 produces the information about resources. It also creates a file
@@ -224,5 +106,120 @@ If the env variable FSTIME_LOAD is set to 1, the output looks something like
 
 The 3 numbers are the system load averages for the past 1, 5, and 15
 minutes as given by uptime.
+EOF
 
+}
 
+function   arg1err()
+{
+  # param 1 : flag
+  echo "ERROR: flag $1 requires one argument"
+  exit 1
+}
+
+inputargs=("$@")
+if [[ "$#" == 1 ]] ; then usage ; exit 0 ; fi
+any_help=$(echo "$@" | grep -e -help)
+if [[ -n "$any_help" ]]
+then
+  usage
+  help
+  exit 0
+fi
+any_version=$(echo $argv | grep -e -version)
+if [[ -n "$any_version" ]]
+then
+  echo $VERSION
+  exit 0
+fi
+
+# sourcing FreeSurfer should not be needed at this point,
+# source $FREESURFER_HOME/sources.sh
+
+cmdline=("$@")
+while [[ $# != 0 ]]
+do
+
+  flag=$1
+  shift
+
+  case $flag in
+    -o)
+      if [[ "$#" -lt 1 ]] ; then arg1err $flag; fi
+      outfile=$1
+      shift
+      ;;
+    -k)
+      if [[ "$#" -lt 1 ]] ; then arg1err $flag ; fi
+      key=$1
+      shift
+      ;;
+    -l|-load)
+      export FSTIME_LOAD=1
+      ;;
+    -no-load)
+      export FSTIME_LOAD=0
+      ;;
+    -debug)
+      verbose=1
+      echo=1
+      ;;
+    *)
+      # must be at the start of the command to run
+      # put item back into the list
+      cmd=($flag "$@")
+      break
+      ;;
+  esac
+
+done
+
+# CHECK PARAMS
+if [[ ! -e /usr/bin/time ]]
+then
+  echo "ERROR: cannot find /usr/bin/time"
+  exit 1
+fi
+
+if [[ "${#cmd[@]}" == 0 ]]
+then
+  usage
+  echo "ERROR: no command passed to execute"
+  exit 1
+fi
+
+nargs=$((${#cmd[@]} - 1))
+
+function make_string ()
+{
+  # param 1 : key
+  # param 2 : command
+  # param 3 : num args
+  dt=$(date '+%Y:%m:%d:%H:%M:%S')
+  uptime_data_array=($(uptime | sed 's/,/ /g'))
+  echo "$1 $dt $2 N $3 ${uptime_data_array[-3]} ${uptime_data_array[-2]} ${uptime_data_array[-1]}"
+  export upt="L ${uptime_data_array[-3]} ${uptime_data_array[-2]} ${uptime_data_array[-1]}"
+}
+
+if [[ "$FSTIME_LOAD" == 1 ]]
+then
+  make_string "@#@FSLOADPRE" "${cmd[0]}" "$nargs"
+else
+  upt=""
+fi
+
+dt=$(date '+%Y:%m:%d:%H:%M:%S')
+fmt="$key $dt ${cmd[0]} N $nargs e %e S %S U %U P %P M %M F %F R %R W %W c %c w %w I %I O %O $upt"
+
+timecmd=("/usr/bin/time")
+if [[ -n "$outfile" ]] ; then timecmd=("${timecmd[@]}" -o "$outfile"); fi
+"${timecmd[@]}" -f "$fmt" "${cmd[@]}"
+st=$?
+if [[ -n "$outfile" ]] ; then cat $outfile; fi
+
+if [[ "$FSTIME_LOAD" == 1 ]]
+then
+  make_string "@#@FSLOADPOST" "${cmd[0]}" "$nargs"
+fi
+
+exit $st

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -30,8 +30,8 @@ function RunIt()
   if [[ $# -eq 3 ]]
   then
     CMDF=$3
-    echo "echo \"$cmd\" " |& tee -a $CMDF
-    echo "$timecmd $cmd " |& tee -a $CMDF
+    echo "echo ${cmd@Q}" |& tee -a $CMDF
+    echo "$timecmd $cmd" |& tee -a $CMDF
     echo "if [ \${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi" >> $CMDF
   else
     echo $cmd |& tee -a $LF
@@ -64,7 +64,7 @@ function RunBatchJobs()
     echo "" >& $LOG
     echo " $JOB" >> $LOG
     echo "" >> $LOG
-    exec $JOB >> $LOG 2>&1 &
+    bash "$JOB" >> $LOG 2>&1 &
     PIDS=(${PIDS[@]} $!)
     LOGS=(${LOGS[@]} $LOG)
 

--- a/recon_surf/spherically_project.py
+++ b/recon_surf/spherically_project.py
@@ -19,8 +19,8 @@ import sys
 import nibabel.freesurfer.io as fs
 import numpy as np
 import math
-from lapy.diffGeo import tria_mean_curvature_flow
-from lapy.triaMesh import TriaMesh
+from lapy.diffgeo import tria_mean_curvature_flow
+from lapy import TriaMesh
 from lapy.solver import Solver
 
 HELPTEXT = """

--- a/recon_surf/spherically_project_wrapper.py
+++ b/recon_surf/spherically_project_wrapper.py
@@ -69,10 +69,14 @@ def call(command: str, **kwargs: Any) -> int:
     command_split = shlex.split(command)
 
     p = Popen(command_split, **kwargs)
-    stdout = p.communicate()[0]
+    stdout, stderr = p.communicate()
 
     if stdout:
         for line in stdout.decode("utf-8").split("\n"):
+            print(line)
+    if stderr:
+        print("stderr")
+        for line in stderr.decode("utf-8").split("\n"):
             print(line)
 
     return p.returncode
@@ -144,4 +148,8 @@ if __name__ == "__main__":
         + " -qsphere -no-isrunning "
         + threading
     )
-    spherical_wrapper(cmd1, cmd2)
+    # make sure the process has a username, so nibabel does not crash in write_geometry
+    from os import environ
+    env = dict(environ)
+    env.setdefault("USERNAME", "UNKNOWN")
+    spherical_wrapper(cmd1, cmd2, env=env)


### PR DESCRIPTION
This Commit fixes three issues:
1. tcsh does some weird argument splitting splits variables that should not be split, specifically: tcsh ... --py 'python3.10 -s' is split into "--py", "'python3.10", and "-s'". To fix this, the fs_time script was ported to bash, as it was impossible to accomplish this fix in tcsh.
2. spherical_project always failed, because lapy imports were outdated (lapy.diffGeo instead if lapy.diffgeo and lapy.triaMesh.TriaMesh instead of lapy.TriaMesh). This was a silent fail, as stderr was discarded in spherical_project_wrapper.py and so the fallback was always used.
3. spherical_project further "often" failed inside docker, when no user name could be found by getpass.getuser (in nibabel.io.freesurfer.write_geometry) -- raising an exception. (Happens if the user is defined for docker via -u, but there is no associated username inside the docker.) To fix this, we just add the environment variable "USERNAME" with value "UNKNOWN", if it is not set (this is a place getpass looks for the username last).

recon_surf/functions.sh
- proper quoting of cmd 

recon_surf/spherical_project.py
- fix lapy import

recon_surf/spherical_project_wrapper.py
- also print stderr output to the console
- call spherical_project with USERNAME set 

recon_surf/fs_time
- port to bash