### PR TITLE
The version script had a hard-coded flag to never use git

### DIFF
--- a/Docker/build.py
+++ b/Docker/build.py
@@ -500,7 +500,6 @@ def main(
         tag_dev: bool = True,
         **keywords
         ) -> int | str:
-    from shutil import which
     this_script = Path(__file__)
     if not this_script.is_absolute():
         this_script = Path.cwd() / __file__

--- a/FastSurferCNN/version.py
+++ b/FastSurferCNN/version.py
@@ -253,7 +253,7 @@ def main(
     build_cache : False, TextIOWrapper, optional
         A file-like object to read cached version information, the format should be
         formatted like the output of `main`. Defaults to $PROJECT_ROOT/BUILD.info.
-        If build_cache is false, it is ignored.
+        If build_cache is False, it is ignored.
     file : TextIOWrapper, optional
         A file-like object to write the output to, defaults to stdout if None or not
         passed.


### PR DESCRIPTION
This forced the build_script to not use git in its build script to generate a new BUILD.info file. Which in turn meant that the build script tried to read from the BUILD.info file to create a new BUILD.info file. This lead to a circular dependency and a crash during build.

This PR fixes this issue by:
- removing the hard-coded git flag
- adding an option to the version script to NOT read the BUILD.info file