### PR TITLE
Fix BUG in recon_surf/functions.sh

### DIFF
--- a/recon_surf/fs_time
+++ b/recon_surf/fs_time
@@ -166,7 +166,7 @@ do
     *)
       # must be at the start of the command to run
       # put item back into the list
-      cmd=("$(which "$flag")" "$@")
+      cmd=("$flag" "$@")
       break
       ;;
   esac
@@ -187,7 +187,18 @@ then
   exit 1
 fi
 
-nargs=$((${#cmd[@]} - 1))
+command="${cmd[0]}"
+npyargs=0
+if [[ "${cmd[0]}" =~ python(3(.[0-9])?)?$ ]]
+then
+  npyargs=1
+  for c in "${cmd[@]:1}" ; do
+    if [[ ! "$c" =~ "^-" ]] ; then command="$c" ; break ; fi
+    npyargs=$((npyargs + 1))
+  done
+fi
+
+nargs=$((${#cmd[@]} - 1 - npyargs))
 
 function make_string ()
 {
@@ -202,13 +213,13 @@ function make_string ()
 
 if [[ "$FSTIME_LOAD" == 1 ]]
 then
-  make_string "@#@FSLOADPRE" "${cmd[0]}" "$nargs"
+  make_string "@#@FSLOADPRE" "$command" "$nargs"
 else
   upt=""
 fi
 
 dt=$(date '+%Y:%m:%d:%H:%M:%S')
-fmt="$key $dt ${cmd[0]} N $nargs e %e S %S U %U P %P M %M F %F R %R W %W c %c w %w I %I O %O $upt"
+fmt="$key $dt $command N $nargs e %e S %S U %U P %P M %M F %F R %R W %W c %c w %w I %I O %O $upt"
 
 timecmd=("/usr/bin/time")
 if [[ -n "$outfile" ]] ; then timecmd=("${timecmd[@]}" -o "$outfile"); fi
@@ -218,7 +229,7 @@ if [[ -n "$outfile" ]] ; then cat $outfile; fi
 
 if [[ "$FSTIME_LOAD" == 1 ]]
 then
-  make_string "@#@FSLOADPOST" "${cmd[0]}" "$nargs"
+  make_string "@#@FSLOADPOST" "$command" "$nargs"
 fi
 
 exit $st

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -99,13 +99,12 @@ function softlink_or_copy()
   # 2: target
   # 3: logfile
   # 4: cmdf
-  LF="$3"
-  CMDF="$4"
-  ln_cmd="ln -sf $1 $2"
-  cp_cmd="cp $1 $2"
+  local LF="$3"
+  local ln_cmd="ln -sf $1 $2"
+  local cp_cmd="cp $1 $2"
   if [[ $# -eq 4 ]]
   then
-    CMDF=$3
+    local CMDF=$4
     echo "echo \"$ln_cmd\" " |& tee -a $CMDF
     echo "$timecmd $ln_cmd " |& tee -a $CMDF
     echo "if [ \${PIPESTATUS[0]} -ne 0 ]" |& tee -a $CMDF

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -358,14 +358,6 @@ if [ -f "$SUBJECTS_DIR/$subject/mri/wm.mgz" ] || [ -f "$SUBJECTS_DIR/$subject/mr
   exit 1
 fi
 
-# Check input segmentation quality
-echo "Checking Input Segmentation Quality ..."
-cmd="$python ${binpath}/../FastSurferCNN/quick_qc.py --asegdkt_segfile $asegdkt_segfile"
-echo $cmd
-$cmd
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
-echo
-
 # collect info
 StartTime=`date`;
 tSecStart=`date '+%s'`;
@@ -420,6 +412,11 @@ echo " RUNNING $OMP_NUM_THREADS number of OMP THREADS " |& tee -a $LF
 echo " RUNNING $ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS number of ITK THREADS " |& tee -a $LF
 echo " " |& tee -a $LF
 
+# Check input segmentation quality
+echo "Checking Input Segmentation Quality ..." |& tee -a "$LF"
+cmd="$python $FASTSURFER_HOME/FastSurferCNN/quick_qc.py --asegdkt_segfile $asegdkt_segfile"
+RunIt "$cmd" "$LF"
+echo "" |& tee -a "$LF"
 
 
 


### PR DESCRIPTION
recon-surf.sh
- Remove which.
- make message for python not list python as the command but the python script.

functions.sh
- fix bug where CMDF is overwritten in softlink_or_copy (by not using local for variables inside of function).

recon-surf.sh
- move quick_qc.py Later so it can also be timed and documented in the logfile.