### PR TITLE
Fix BUGS in recon_surf/functions.sh and fs_time

### DIFF
--- a/recon_surf/fs_time
+++ b/recon_surf/fs_time
@@ -106,7 +106,6 @@ If the env variable FSTIME_LOAD is set to 1, the output looks something like
 The 3 numbers are the system load averages for the past 1, 5, and 15
 minutes as given by uptime.
 EOF
-
 }
 
 function   arg1err()
@@ -173,6 +172,17 @@ do
 
 done
 
+if [[ "$verbose" == 1 ]]
+then
+  echo "Parameters to fs_time:"
+  if [[ -n "$outfile" ]] ; then echo "-o $outfile" ; fi
+  if [[ "$key" != "@#@FSTIME " ]] ; then echo "-k $key" ; fi
+  echo "FSTIME_LOAD=$FSTIME_LOAD"
+  echo "command:"
+  echo "${cmd[*]}"
+  echo ""
+fi
+
 # CHECK PARAMS
 if [[ ! -e /usr/bin/time ]]
 then
@@ -189,13 +199,21 @@ fi
 
 command="${cmd[0]}"
 npyargs=0
-if [[ "${cmd[0]}" =~ python(3(.[0-9])?)?$ ]]
+# remove python from command
+if [[ "$command" =~ python(3(.[0-9])?)?$ ]]
 then
   npyargs=1
   for c in "${cmd[@]:1}" ; do
     if [[ ! "$c" =~ "^-" ]] ; then command="$c" ; break ; fi
     npyargs=$((npyargs + 1))
   done
+fi
+# remove $FASTSURFER_HOME path from command
+command_short="${command:0:${#FASTSURFER_HOME}}"
+if [[ -n "$FASTSURFER_HOME" ]] && [[ "$command_short" == "$FASTSURFER_HOME" ]]
+then
+  command="$command_short"
+  while [[ "${command:0:1}" == "/" ]] ; do command="${command:1}" ; done
 fi
 
 nargs=$((${#cmd[@]} - 1 - npyargs))

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -25,17 +25,17 @@ function RunIt()
   # $2 : LF   (log file)
   # $3 : CMDF (command file) optional
   # if CMDF is passed, then LF is ignored and cmd is echoed into CMDF and not run
-  cmd=$1
-  LF=$2
+  local cmd=$1
+  local LF=$2
   if [[ $# -eq 3 ]]
   then
-    CMDF=$3
+    local CMDF=$3
     echo "echo ${cmd@Q}" |& tee -a $CMDF
     echo "$timecmd $cmd" |& tee -a $CMDF
     echo "if [ \${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi" >> $CMDF
   else
     echo $cmd |& tee -a $LF
-    $timecmd $cmd |& tee -a $LF
+    $timecmd -debug $cmd |& tee -a $LF
     if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   fi
 }
@@ -45,7 +45,7 @@ function RunBatchJobs()
 # parameters
 # $1 : LF
 # $2 ... : CMDFS
-  LOG_FILE=$1
+  local LOG_FILE=$1
   # launch jobs found in command files (shift past first logfile arg).
   # job output goes to a logfile named after the command file, which
   # later gets appended to LOG_FILE
@@ -53,9 +53,11 @@ function RunBatchJobs()
   echo
   echo "RunBatchJobs: Logfile: $LOG_FILE"
 
-  PIDS=()
-  LOGS=()
+  local PIDS=()
+  local LOGS=()
   shift
+  local JOB
+  local LOG
   for cmdf in $*; do
     echo "RunBatchJobs: CMDF: $cmdf"
     chmod u+x $cmdf
@@ -70,7 +72,7 @@ function RunBatchJobs()
 
   done
   # wait till all processes have finished
-  PIDS_STATUS=()
+  local PIDS_STATUS=()
   for pid in "${PIDS[@]}"; do
     echo "Waiting for PID $pid of (${PIDS[*]}) to complete..."
     wait $pid


### PR DESCRIPTION
fs_time
- add support for the -debug option
- remove the FASTSURFER_HOME path from logged commands

functions.sh
- make sure all local variables are declared as local (otherwise values might leak into the global script context)