### PR TITLE
Fix format specifier in find_device memory requirement check

### DIFF
--- a/FastSurferCNN/utils/common.py
+++ b/FastSurferCNN/utils/common.py
@@ -102,7 +102,7 @@ def find_device(
             giga = 1024**3
             logger.info(
                 f"Found {total_gpu_memory/giga:.1f} GB GPU memory, but "
-                f"{min_memory/giga:.f} GB was required."
+                f"{min_memory/giga:.1f} GB was required."
             )
             device = torch.device("cpu")
 


### PR DESCRIPTION
There was a small error in `utils/common.py` that led to a **ValueError** when attempting to print the required memory. The format specifier was missing precision, resulting in the error. I've included screenshots of the error and how it was resolved after correcting the format specifier.

PS: I'm using the latest FastSurfer docker image.

Command:
```bash
docker run --gpus all  deepmi/fastsurfer:latest --fs_license /fs_license/license.txt --t1 /data/structural.nii --sid 003_S_0907 --sd output --parallel
```

The error:
![error](https://github.com/Deep-MI/FastSurfer/assets/58423695/19276af5-a120-4647-9388-cfd7ddbb8948)

After resolution:
![resolved](https://github.com/Deep-MI/FastSurfer/assets/58423695/24633e40-c6f3-46fc-aa79-e4f8ea56ba1f)
