### PR TITLE
Fix bugs introduced by #501.

### DIFF
--- a/CerebNet/run_prediction.py
+++ b/CerebNet/run_prediction.py
@@ -20,18 +20,17 @@ import argparse
 from pathlib import Path
 
 from FastSurferCNN.utils import logging, parser_defaults, Plane, PLANES
-from CerebNet.utils.load_config import get_config
-from CerebNet.inference import Inference
 from FastSurferCNN.utils.checkpoint import (
     get_checkpoints,
     load_checkpoint_config_defaults,
 )
 from FastSurferCNN.utils.common import assert_no_root, SubjectList
-from FastSurferCNN.utils.parser_defaults import FASTSURFER_ROOT
+from CerebNet.inference import Inference
+from CerebNet.utils.checkpoint import YAML_DEFAULT as CHECKPOINT_PATHS_FILE
+from CerebNet.utils.load_config import get_config
 
 logger = logging.get_logger(__name__)
 DEFAULT_CEREBELLUM_STATSFILE = Path("stats/cerebellum.CerebNet.stats")
-CHECKPOINT_PATHS_FILE = FASTSURFER_ROOT / "CerebNet/config/checkpoint_paths.yaml"
 
 
 def setup_options():

--- a/CerebNet/utils/load_config.py
+++ b/CerebNet/utils/load_config.py
@@ -14,14 +14,16 @@
 
 
 # IMPORTS
-import argparse
-import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import yacs.config
 
 from CerebNet.config import get_cfg_cerebnet
 from FastSurferCNN.utils import PLANES
 
 
-def get_config(args) -> "yacs.CfgNode":
+def get_config(args) -> "yacs.config.CfgNode":
     """
     Given the arguments, load and initialize the config_files.
     """
@@ -35,8 +37,8 @@ def get_config(args) -> "yacs.CfgNode":
     if hasattr(args, "rng_seed"):
         cfg.RNG_SEED = args.rng_seed
     if hasattr(args, "out_dir"):
+        cfg.LOG_DIR = str(args.out_dir)
 
-        cfg.LOG_DIR = args.out_dir    
     path_ax, path_sag, path_cor = [
         getattr(args, name) for name in ["ckpt_ax", "ckpt_sag", "ckpt_cor"]
     ]
@@ -50,32 +52,3 @@ def get_config(args) -> "yacs.CfgNode":
         cfg.TEST.BATCH_SIZE = batch_size
 
     return cfg
-
-
-def setup_options():
-    """
-    Set up the command-line options for the segmentation.
-
-    Returns
-    -------
-    argparse.Namespace
-        The configured argument parser.
-    """
-    parser = argparse.ArgumentParser(description="Segmentation")
-    parser.add_argument(
-        "--cfg",
-        dest="cfg_file",
-        help="Path to the config file",
-        default="config_files/CerebNet.yaml",
-        type=str,
-    )
-    parser.add_argument(
-        "opts",
-        help="See CerebNet/config/cerebnet.py for all options",
-        default=None,
-        nargs=argparse.REMAINDER,
-    )
-
-    if len(sys.argv) == 1:
-        parser.print_help()
-    return parser.parse_args()

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -178,7 +178,7 @@ class SubjectDirectoryConfig:
         flags=("--csv_file",),
         default=None,
         help="Csv-file with subjects to analyze (alternative to --tag)",
-    ),
+    )
     sid: Optional[str] = field(
         flags=("--sid",),
         default=None,
@@ -191,7 +191,7 @@ class SubjectDirectoryConfig:
         default="*",
         help="Search tag to process only certain subjects. If a single image should be "
              "analyzed, set the tag with its id. Default: processes all.",
-    ),
+    )
     brainmask_name: str = field(
         default="mri/mask.mgz",
         help="Name under which the brainmask image will be saved, in the same "
@@ -271,7 +271,12 @@ ALL_FLAGS = {
              "(no memory check will be done).",
     ),
     "in_dir": __arg("--in_dir", dc=SubjectDirectoryConfig, fieldname="in_dir"),
-    "tag": __arg("--tag", type=unquote_str, dc=SubjectDirectoryConfig, fieldname="search_tag"),
+    "tag": __arg(
+        "--tag",
+        type=unquote_str,
+        dc=SubjectDirectoryConfig,
+        fieldname="search_tag",
+    ),
     "csv_file": __arg("--csv_file", dc=SubjectDirectoryConfig),
     "batch_size": __arg(
         "--batch_size",

--- a/doc/overview/OUTPUT_FILES.md
+++ b/doc/overview/OUTPUT_FILES.md
@@ -4,26 +4,26 @@
 
 The segmentation module outputs the files shown in the table below. The two primary output files are the `aparc.DKTatlas+aseg.deep.mgz` file, which contains the FastSurfer segmentation of cortical and subcortical structures based on the DKT atlas, and the `aseg+DKT.stats` file, which contains summary statistics for these structures. Note, that the surface model (downstream) corrects these segmentations along the cortex with the created surfaces. So if the surface model is used, it is recommended to use the updated segmentations and stats (see below). 
 
-| directory   | filename                      | module    | description |
-|:------------|-------------------------------|-----------|-------------|
-| mri         | aparc.DKTatlas+aseg.deep.mgz  | asegdkt   | cortical and subcortical segmentation|
-| mri         | aseg.auto_noCCseg.mgz         | asegdkt   | simplified subcortical segmentation without corpus callosum labels|
-| mri         | mask.mgz                      | asegdkt   | brainmask|
-| mri         | orig.mgz                      | asegdkt   | conformed image|
-| mri         | orig_nu.mgz                   | asegdkt   | biasfield-corrected image|
-| mri/orig    | 001.mgz                       | asegdkt   | original image|
-| scripts     | deep-seg.log                  | asegdkt   | logfile|
-| stats       | aseg+DKT.stats                | asegdkt   | table of cortical and subcortical segmentation statistics|
+| directory | filename                     | module  | description                                                        |
+|:----------|------------------------------|---------|--------------------------------------------------------------------|
+| mri       | aparc.DKTatlas+aseg.deep.mgz | asegdkt | cortical and subcortical segmentation                              |
+| mri       | aseg.auto_noCCseg.mgz        | asegdkt | simplified subcortical segmentation without corpus callosum labels |
+| mri       | mask.mgz                     | asegdkt | brainmask                                                          |
+| mri       | orig.mgz                     | asegdkt | conformed image                                                    |
+| mri       | orig_nu.mgz                  | asegdkt | biasfield-corrected image                                          |
+| mri/orig  | 001.mgz                      | asegdkt | original image                                                     |
+| scripts   | deep-seg.log                 | asegdkt | logfile                                                            |
+| stats     | aseg+DKT.stats               | asegdkt | table of cortical and subcortical segmentation statistics          |
 
 ## Cerebnet module
 
 The cerebellum module outputs the files in the table shown below. Unless switched off by the `--no_cereb` argument, this module is automatically run whenever the segmentation module is run. It adds two files, an image with the sub-segmentation of the cerebellum and a text file with summary statistics.
 
 
-| directory   | filename                      | module    | description |
-|:------------|-------------------------------|-----------|-------------|
-| mri         | cerebellum.CerebNet.nii.gz    | cerebnet  | cerebellum sub-segmentation|
-| stats       | cerebellum.CerebNet.stats     | cerebnet  | table of cerebellum segmentation statistics|
+| directory | filename                   | module   | description                                 |
+|:----------|----------------------------|----------|---------------------------------------------|
+| mri       | cerebellum.CerebNet.nii.gz | cerebnet | cerebellum sub-segmentation                 |
+| stats     | cerebellum.CerebNet.stats  | cerebnet | table of cerebellum segmentation statistics |
 
 
 ## Surface module
@@ -34,26 +34,26 @@ After running this module, some of the initial segmentations and corresponding v
 
 The primary output files are pial, white, and inflated surface files, the thickness overlay files, and the cortical parcellation (annotation) files. The preferred way of assessing this output is the [FreeView](https://surfer.nmr.mgh.harvard.edu/fswiki/FreeviewGuide) software. Summary statistics for volume and thickness estimates per anatomical structure are reported in the stats files, in particular the `aseg.stats`, and the left and right `aparc.DKTatlas.mapped.stats` files. 
 
-| directory   | filename                      | module    | description |
-|:------------|-------------------------------|-----------|-------------|
-| mri         | aparc.DKTatlas+aseg.deep.withCC.mgz| surface | cortical and subcortical segmentation incl. corpus callosum after running the surface module|
-| mri         | aparc.DKTatlas+aseg.mapped.mgz| surface      | cortical and subcortical segmentation after running the surface module|
-| mri         | aparc.DKTatlas+aseg.mgz       | surface      | symlink to aparc.DKTatlas+aseg.mapped.mgz|
-| mri         | aparc+aseg.mgz                | surface      | symlink to aparc.DKTatlas+aseg.mapped.mgz|
-| mri         | aseg.mgz                      | surface      | subcortical segmentation after running the surface module|
-| mri         | wmparc.DKTatlas.mapped.mgz    | surface      | white matter parcellation|
-| mri         | wmparc.mgz                    | surface      | symlink to wmparc.DKTatlas.mapped.mgz|
-| surf        | lh.area, rh.area              | surface      | surface area overlay file|
-| surf        | lh.curv, rh.curv              | surface      | curvature overlay file|
-| surf        | lh.inflated, rh.inflated      | surface      | inflated cortical surface|
-| surf        | lh.pial, rh.pial              | surface      | pial surface|
-| surf        | lh.thickness, rh.thickness    | surface      | cortical thickness overlay file|
-| surf        | lh.volume, rh.volume          | surface      | gray matter volume overlay file|
-| surf        | lh.white, rh.white            | surface      | white matter surface|
-| label       | lh.aparc.DKTatlas.annot, rh.aparc.DKTatlas.annot| surface      | symlink to lh.aparc.DKTatlas.mapped.annot|
-| label       | lh.aparc.DKTatlas.mapped.annot, rh.aparc.DKTatlas.mapped.annot| surface      | annotation file for cortical parcellations, mapped from ASEGDKT segmentation to the surface|
-| stats       | aseg.stats                    | surface      | table of cortical and subcortical segmentation statistics after running the surface module|
-| stats       | lh.aparc.DKTatlas.mapped.stats, rh.aparc.DKTatlas.mapped.stats| surface      | table of cortical parcellation statistics, mapped from ASEGDKT segmentation to the surface|
-| stats       | lh.curv.stats, rh.curv.stats  | surface      | table of curvature statistics|
-| stats       | wmparc.DKTatlas.mapped.stats  | surface      | table of white matter segmentation statistics|
-| scripts     | recon-all.log                 | surface      | logfile|
+| directory | filename                                                       | module  | description                                                                                  |
+|:----------|----------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------|
+| mri       | aparc.DKTatlas+aseg.deep.withCC.mgz                            | surface | cortical and subcortical segmentation incl. corpus callosum after running the surface module |
+| mri       | aparc.DKTatlas+aseg.mapped.mgz                                 | surface | cortical and subcortical segmentation after running the surface module                       |
+| mri       | aparc.DKTatlas+aseg.mgz                                        | surface | symlink to aparc.DKTatlas+aseg.mapped.mgz                                                    |
+| mri       | aparc+aseg.mgz                                                 | surface | symlink to aparc.DKTatlas+aseg.mapped.mgz                                                    |
+| mri       | aseg.mgz                                                       | surface | subcortical segmentation after running the surface module                                    |
+| mri       | wmparc.DKTatlas.mapped.mgz                                     | surface | white matter parcellation                                                                    |
+| mri       | wmparc.mgz                                                     | surface | symlink to wmparc.DKTatlas.mapped.mgz                                                        |
+| surf      | lh.area, rh.area                                               | surface | surface area overlay file                                                                    |
+| surf      | lh.curv, rh.curv                                               | surface | curvature overlay file                                                                       |
+| surf      | lh.inflated, rh.inflated                                       | surface | inflated cortical surface                                                                    |
+| surf      | lh.pial, rh.pial                                               | surface | pial surface                                                                                 |
+| surf      | lh.thickness, rh.thickness                                     | surface | cortical thickness overlay file                                                              |
+| surf      | lh.volume, rh.volume                                           | surface | gray matter volume overlay file                                                              |
+| surf      | lh.white, rh.white                                             | surface | white matter surface                                                                         |
+| label     | lh.aparc.DKTatlas.annot, rh.aparc.DKTatlas.annot               | surface | symlink to lh.aparc.DKTatlas.mapped.annot                                                    |
+| label     | lh.aparc.DKTatlas.mapped.annot, rh.aparc.DKTatlas.mapped.annot | surface | annotation file for cortical parcellations, mapped from ASEGDKT segmentation to the surface  |
+| stats     | aseg.stats                                                     | surface | table of cortical and subcortical segmentation statistics after running the surface module   |
+| stats     | lh.aparc.DKTatlas.mapped.stats, rh.aparc.DKTatlas.mapped.stats | surface | table of cortical parcellation statistics, mapped from ASEGDKT segmentation to the surface   |
+| stats     | lh.curv.stats, rh.curv.stats                                   | surface | table of curvature statistics                                                                |
+| stats     | wmparc.DKTatlas.mapped.stats                                   | surface | table of white matter segmentation statistics                                                |
+| scripts   | recon-all.log                                                  | surface | logfile                                                                                      |


### PR DESCRIPTION
This PR fixes a couple of bugs introduced in #501. They should have been caught before...


CerebNet/utils/load_config.py
- remove unused setup_options
- fix typing of yacs.config
- fix assignment of cfg.LOG_DIR which cannot be a Path, but must be a string (yacs requirement)

CerebNet/run_prediction.py
- fix the path to the checkpoint_paths.yaml file
- clean up the imports

FastSurferCNN/utils/parser_defaults.py
- remove unwanted commas, they make the value a tuple

FastSurferCNN/run_prediction.py
- Fix parameter names in main function
- add a try-except block in main
- add/fix typing
- fix typo in main

recon_surf/N4_bias_correct.py
- Formatting (e.g. constants are UPPERCASE)
- fix typos
- fix incorrect conversion of default "do nothing strings" to Path

doc/overview/OUTPUT_FILES.md
- fix the formatting of the tables