### PR TITLE
fixing issue with get_cmap on matplotlib 3.9.0

### DIFF
--- a/FastSurferCNN/utils/mapper.py
+++ b/FastSurferCNN/utils/mapper.py
@@ -49,7 +49,7 @@ from typing import (
 import numpy as np
 import pandas
 import torch
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 from matplotlib.colors import Colormap
 from numpy import typing as npt
 


### PR DESCRIPTION
- importing get_cmap from matplotlib,pyplot instead of matplotlib.cm in FastSurferCNN/utils/mapper.py