### PR TITLE
Remove -debug flag for timing

### DIFF
--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -35,7 +35,7 @@ function RunIt()
     echo "if [ \${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi" >> $CMDF
   else
     echo $cmd |& tee -a $LF
-    $timecmd -debug $cmd |& tee -a $LF
+    $timecmd $cmd |& tee -a $LF
     if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   fi
 }


### PR DESCRIPTION
If `fs_time` fails (this would usually not happen in Linux), `timecmd` is set to empty (no timing is performed) and the `-debug` flag in line 38 becomes the "command". This raises an error.

This addresses #528 .