### PR TITLE
Fixes of HypVINN & options for conform that disable critieria

### DIFF
--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -1,4 +1,5 @@
-# Copyright 2019 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+# Copyright 2019
+# AI in Medical Imaging, German Center for Neurodegenerative Diseases (DZNE), Bonn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +15,14 @@
 
 
 # IMPORTS
-import logging
-from typing import Optional, Type, Tuple, Union, Iterable, cast
 import argparse
+from enum import Enum
+import logging
 import sys
+from typing import Optional, Type, Tuple, Union, Iterable, cast
 
 import numpy as np
+import numpy.typing as npt
 import nibabel as nib
 
 from FastSurferCNN.utils.arg_types import (
@@ -40,16 +43,34 @@ conform.py  -i <input> --check_only <options>
 Dependencies:
     Python 3.8+
     Numpy
-    http://www.numpy.org
+    https://www.numpy.org
     Nibabel to read and write FreeSurfer data
-    http://nipy.org/nibabel/
+    https://nipy.org/nibabel/
 Original Author: Martin Reuter
 Date: Jul-09-2019
 """
 
 h_input = "path to input image"
 h_output = "path to output image"
-h_order = "order of interpolation (0=nearest,1=linear(default),2=quadratic,3=cubic)"
+h_order = "order of interpolation (0=nearest, 1=linear(default), 2=quadratic, 3=cubic)"
+
+LIA_AFFINE = np.array([[-1, 0, 0], [0, 0, 1], [0, -1, 0]])
+
+
+class Criteria(Enum):
+    FORCE_LIA_STRICT = "lia strict"
+    FORCE_LIA = "lia"
+    FORCE_IMG_SIZE = "img size"
+    FORCE_VOX_SIZE = "vox size"
+
+
+DEFAULT_CRITERIA_DICT = {
+    "lia": Criteria.FORCE_LIA,
+    "strict_lia": Criteria.FORCE_LIA_STRICT,
+    "vox_size": Criteria.FORCE_VOX_SIZE,
+    "img_size": Criteria.FORCE_IMG_SIZE,
+}
+DEFAULT_CRITERIA = frozenset(DEFAULT_CRITERIA_DICT.values())
 
 
 def options_parse():
@@ -75,25 +96,26 @@ def options_parse():
         dest="check_only",
         default=False,
         action="store_true",
-        help="If True, only checks if the input image is conformed, and does not return an output.",
+        help="If True, only checks if the input image is conformed, and does not "
+             "return an output.",
     )
     parser.add_argument(
         "--seg_input",
         dest="seg_input",
         default=False,
         action="store_true",
-        help="Specifies whether the input is a seg image. If true, the check for conformance "
-        "disregards the uint8 dtype criteria. Use --dtype any for equivalent results. "
-        "--seg_input overwrites --dtype arguments.",
+        help="Specifies whether the input is a seg image. If true, the check for "
+             "conformance disregards the uint8 dtype criteria. Use --dtype any for "
+             "equivalent results. --seg_input overwrites --dtype arguments.",
     )
     parser.add_argument(
         "--vox_size",
         dest="vox_size",
         default=1.0,
         type=__vox_size,
-        help="Specifies the target voxel size to conform to. Also allows 'min' for conforming to the "
-        "minimum voxel size, otherwise similar to mri_convert's --conform_size <size> "
-        "(default: 1, conform to 1mm).",
+        help="Specifies the target voxel size to conform to. Also allows 'min' for "
+             "conforming to the minimum voxel size, otherwise similar to mri_convert's "
+             "--conform_size <size> (default: 1, conform to 1mm).",
     )
     parser.add_argument(
         "--conform_min",
@@ -107,16 +129,42 @@ def options_parse():
     advanced.add_argument(
         "--conform_to_1mm_threshold",
         type=__conform_to_one_mm,
-        help="Advanced option to change the threshold beyond which images are conformed to 1"
-        "(default: infinity, all images are conformed to their minimum voxel size).",
+        help="Advanced option to change the threshold beyond which images are "
+             "conformed to 1 (default: infinity, all images are conformed to their "
+             "minimum voxel size).",
     )
-    parser.add_argument(
+    advanced.add_argument(
         "--dtype",
         dest="dtype",
         default="uint8",
         type=__target_dtype,
-        help="Specifies the target data type of the target image or 'any' (default: 'uint8', "
-        "as in FreeSurfer)",
+        help="Specifies the target data type of the target image or 'any' (default: "
+             "'uint8', as in FreeSurfer)",
+    )
+    advanced.add_argument(
+        "--no_strict_lia",
+        dest="force_strict_lia",
+        action="store_false",
+        help="Ignore the forced lia reorientation.",
+    )
+    advanced.add_argument(
+        "--no_lia",
+        dest="force_lia",
+        action="store_false",
+        help="Ignore the reordering of data into lia (without interpolation). "
+             "Superceeds --no_strict_lia",
+    )
+    advanced.add_argument(
+        "--no_vox_size",
+        dest="force_vox_size",
+        action="store_false",
+        help="Ignore the forced isometric voxel size (depends on --conform_min).",
+    )
+    advanced.add_argument(
+        "--no_img_size",
+        dest="force_img_size",
+        action="store_false",
+        help="Ignore the forced image dimensions (depends on --conform_min).",
     )
     parser.add_argument(
         "--verbose",
@@ -127,15 +175,18 @@ def options_parse():
     )
     args = parser.parse_args()
     if args.input is None:
-        sys.exit("ERROR: Please specify input image")
+        raise RuntimeError("ERROR: Please specify input image")
     if not args.check_only and args.output is None:
-        sys.exit("ERROR: Please specify output image")
+        raise RuntimeError("ERROR: Please specify output image")
     if args.check_only and args.output is not None:
-        sys.exit(
+        raise RuntimeError(
             "ERROR: You passed in check_only. Please do not also specify output image"
         )
     if args.seg_input and args.dtype not in ["uint8", "any"]:
         print("WARNING: --seg_input overwrites the --dtype arguments.")
+    if not args.force_lia and args.force_strict_lia:
+        print("INFO: --no_lia includes --no_strict_lia.")
+        args.force_strict_lia = False
     return args
 
 
@@ -158,12 +209,13 @@ def map_image(
         Trg image affine.
     out_shape : tuple[int, ...], np.ndarray
         The trg shape information.
-    ras2ras : Optional[np.ndarray]
+    ras2ras : np.ndarray, optional
         An additional mapping that should be applied (default=id to just reslice).
-    order : int
-        Order of interpolation (0=nearest,1=linear(default),2=quadratic,3=cubic).
-    dtype : Optional[Type]
-        Target dtype of the resulting image (relevant for reorientation, default=same as img).
+    order : int, default=1
+        Order of interpolation (0=nearest,1=linear,2=quadratic,3=cubic).
+    dtype : Type, optional
+        Target dtype of the resulting image (relevant for reorientation,
+        default=keep dtype of img).
 
     Returns
     -------
@@ -209,8 +261,12 @@ def map_image(
     if dtype is not None:
         image_data = image_data.astype(dtype)
 
+    if not is_resampling_vox2vox(vox2vox):
+        # this is a shortcut to reordering resampling
+        order = 0
+
     return affine_transform(
-        image_data, inv(vox2vox), output_shape=out_shape, order=order
+        image_data, inv(vox2vox), output_shape=out_shape, order=order,
     )
 
 
@@ -222,7 +278,7 @@ def getscale(
         f_high: float = 0.999
 ) -> Tuple[float, float]:
     """
-    Get offset and scale of image intensities to robustly rescale to range dst_min..dst_max.
+    Get offset and scale of image intensities to robustly rescale to dst_min..dst_max.
 
     Equivalent to how mri_convert conforms images.
 
@@ -234,10 +290,10 @@ def getscale(
         Future minimal intensity value.
     dst_max : float
         Future maximal intensity value.
-    f_low : float
-        Robust cropping at low end (0.0 no cropping, default).
-    f_high : float
-        Robust cropping at higher end (0.999 crop one thousandth of high intensity voxels, default).
+    f_low : float, default=0.0
+        Robust cropping at low end (0.0=no cropping).
+    f_high : float, default=0.999
+        Robust cropping at higher end (0.999=crop one thousandth of highest intensity).
 
     Returns
     -------
@@ -378,10 +434,10 @@ def rescale(
         Future minimal intensity value.
     dst_max : float
         Future maximal intensity value.
-    f_low : float
-        Robust cropping at low end (0.0 no cropping, default).
-    f_high : float
-        Robust cropping at higher end (0.999 crop one thousandth of high intensity voxels, default).
+    f_low : float, default=0.0
+        Robust cropping at low end (0.0=no cropping).
+    f_high : float, default=0.999
+        Robust cropping at higher end (0.999=crop one thousandth of highest intensity).
 
     Returns
     -------
@@ -466,9 +522,10 @@ def conform(
         order: int = 1,
         conform_vox_size: VoxSizeOption = 1.0,
         dtype: Optional[Type] = None,
-        conform_to_1mm_threshold: Optional[float] = None
+        conform_to_1mm_threshold: Optional[float] = None,
+        criteria: set[Criteria] = DEFAULT_CRITERIA,
 ) -> nib.MGHImage:
-    """Python version of mri_convert -c.
+    f"""Python version of mri_convert -c.
 
     mri_convert -c by default turns image intensity values
     into UCHAR, reslices images to standard position, fills up slices to standard
@@ -490,6 +547,9 @@ def conform(
     conform_to_1mm_threshold : Optional[float]
         The threshold above which the image is conformed to 1mm
         (default: ignore).
+    criteria : set[Criteria], default={DEFAULT_CRITERIA}
+        Whether to force the conforming to include a lia data layout, an image size
+        requirement and/or a voxel size requirement.
 
     Returns
     -------
@@ -502,28 +562,73 @@ def conform(
     to uchar. mri_convert is doing it the other way around. However, we compute
     the scale factor from the input to increase similarity.
     """
+    conformed_vox_size, conformed_img_size = get_conformed_vox_img_size(
+        img, conform_vox_size, conform_to_1mm_threshold=conform_to_1mm_threshold,
+    )
     from nibabel.freesurfer.mghformat import MGHHeader
 
-    conformed_vox_size, conformed_img_size = get_conformed_vox_img_size(
-        img, conform_vox_size, conform_to_1mm_threshold=conform_to_1mm_threshold
-    )
+    # may copy some parameters if input was MGH format
+    h1 = MGHHeader.from_header(img.header)
+    mdc_affine = h1["Mdc"]
+    img_shape = img.header.get_data_shape()
+    vox_size = img.header.get_zooms()
+    do_interp = False
+    affine = img.affine[:3, :3]
+    if {Criteria.FORCE_LIA, Criteria.FORCE_LIA_STRICT} & criteria != {}:
+        do_interp = bool(Criteria.FORCE_LIA_STRICT in criteria and is_lia(affine, True))
+        re_order_axes = [np.abs(affine[:, j]).argmax() for j in (0, 2, 1)]
+    else:
+        re_order_axes = [0, 1, 2]
 
-    h1 = MGHHeader.from_header(
-        img.header
-    )  # may copy some parameters if input was MGH format
+    if Criteria.FORCE_IMG_SIZE in criteria:
+        h1.set_data_shape([conformed_img_size] * 3 + [1])
+    else:
+        h1.set_data_shape([img_shape[i] for i in re_order_axes] + [1])
+    if Criteria.FORCE_VOX_SIZE in criteria:
+        h1.set_zooms([conformed_vox_size] * 3)  # --> h1['delta']
+        do_interp |= not np.allclose(vox_size, conformed_vox_size)
+    else:
+        h1.set_zooms([vox_size[i] for i in re_order_axes])
 
-    h1.set_data_shape([conformed_img_size, conformed_img_size, conformed_img_size, 1])
-    h1.set_zooms(
-        [conformed_vox_size, conformed_vox_size, conformed_vox_size]
-    )  # --> h1['delta']
-    h1["Mdc"] = [[-1, 0, 0], [0, 0, -1], [0, 1, 0]]
-    h1["fov"] = conformed_img_size * conformed_vox_size
-    h1["Pxyz_c"] = img.affine.dot(np.hstack((np.array(img.shape[:3]) / 2.0, [1])))[:3]
+    if Criteria.FORCE_LIA_STRICT in criteria:
+        mdc_affine = LIA_AFFINE
+    elif Criteria.FORCE_LIA in criteria:
+        mdc_affine = affine[:3, re_order_axes]
+        if mdc_affine[0, 0] > 0:  # make 0,0 negative
+            mdc_affine[:, 0] = -mdc_affine[:, 0]
+        if mdc_affine[1, 2] < 0:  # make 1,2 positive
+            mdc_affine[:, 2] = -mdc_affine[:, 2]
+        if mdc_affine[2, 1] > 0:  # make 2,1 negative
+            mdc_affine[:, 1] = -mdc_affine[:, 1]
+    else:
+        mdc_affine = img.affine[:3, :3]
+
+    mdc_affine = mdc_affine / np.linalg.norm(mdc_affine, axis=1)
+    h1["Mdc"] = np.linalg.inv(mdc_affine)
+
+    print(h1.get_zooms())
+    h1["fov"] = max(i * v for i, v in zip(h1.get_data_shape(), h1.get_zooms()))
+    center = np.asarray(img.shape[:3], dtype=float) / 2.0
+    h1["Pxyz_c"] = img.affine.dot(np.hstack((center, [1.0])))[:3]
+
+    # There is a special case here, where an interpolation is triggered, but it is not
+    # necessary, if the position of the center could "fix this"
+    # condition: 1. no rotation, no vox-size resampling,
+    if not is_resampling_vox2vox(np.linalg.inv(h1.get_affine()) @ img.affine):
+        # 2. img_size changes from odd to even and vice versa
+        ishape = np.asarray(img.shape)[re_order_axes]
+        delta_shape = np.subtract(ishape, h1.get_data_shape()[:3])
+        # 2. img_size changes from odd to even and vice versa
+        if not np.allclose(np.remainder(delta_shape, 2), 0):
+            # invert axis reordering
+            delta_shape[re_order_axes] = delta_shape
+            new_center = (center + delta_shape / 2.0, [1.0])
+            h1["Pxyz_c"] = img.affine.dot(np.hstack(new_center))[:3]
 
     # Here, we are explicitly using MGHHeader.get_affine() to construct the affine as
-    # MdcD = np.asarray(h1['Mdc']).T * h1['delta']
-    # vol_center = MdcD.dot(hdr['dims'][:3]) / 2
-    # affine = from_matvec(MdcD, h1['Pxyz_c'] - vol_center)
+    # MdcD = np.asarray(h1["Mdc"]).T * h1["delta"]
+    # vol_center = MdcD.dot(hdr["dims"][:3]) / 2
+    # affine = from_matvec(MdcD, h1["Pxyz_c"] - vol_center)
     affine = h1.get_affine()
 
     # from_header does not compute Pxyz_c (and probably others) when importing from nii
@@ -536,10 +641,8 @@ def conform(
     src_min, scale = 0, 1.0
     # get scale for conversion on original input before mapping to be more similar to
     # mri_convert
-    if (
-        img.get_data_dtype() != np.dtype(np.uint8)
-        or img.get_data_dtype() != target_dtype
-    ):
+    img_dtype = img.get_data_dtype()
+    if any(img_dtype != dtyp for dtyp in (np.dtype(np.uint8), target_dtype)):
         src_min, scale = getscale(np.asanyarray(img.dataobj), 0, 255)
 
     kwargs = {}
@@ -547,9 +650,7 @@ def conform(
         kwargs["dtype"] = "float"
     mapped_data = map_image(img, affine, h1.get_data_shape(), order=order, **kwargs)
 
-    if img.get_data_dtype() != np.dtype(np.uint8) or (
-        img.get_data_dtype() != target_dtype and scale != 1.0
-    ):
+    if img_dtype != np.dtype(np.uint8) or (img_dtype != target_dtype and scale != 1.0):
         scaled_data = scalecrop(mapped_data, 0, 255, src_min, scale)
         # map zero in input to zero in output (usually background)
         scaled_data[mapped_data == 0] = 0
@@ -560,21 +661,44 @@ def conform(
     new_img = nib.MGHImage(sctype(mapped_data), affine, h1)
 
     # make sure we store uchar
+    from nibabel.freesurfer import mghformat
     try:
         new_img.set_data_dtype(target_dtype)
-    except nib.freesurfer.mghformat.MGHError as e:
-        if "not recognized" in e.args[0]:
-            codes = set(
-                k.name
-                for k in nib.freesurfer.mghformat.data_type_codes.code.keys()
-                if isinstance(k, np.dtype)
-            )
-            print(
-                f'The data type "{options.dtype}" is not recognized for MGH images, switching '
-                f'to "{new_img.get_data_dtype()}" (supported: {tuple(codes)}).'
-            )
+    except mghformat.MGHError as e:
+        if "not recognized" not in e.args[0]:
+            raise
+        dtype_codes = mghformat.data_type_codes.code.keys()
+        codes = set(k.name for k in dtype_codes if isinstance(k, np.dtype))
+        print(
+            f"The data type '{options.dtype}' is not recognized for MGH images, "
+            f"switching to '{new_img.get_data_dtype()}' (supported: {tuple(codes)})."
+        )
 
     return new_img
+
+
+def is_resampling_vox2vox(
+        vox2vox: npt.NDArray[float],
+        eps: float = 1e-6,
+) -> bool:
+    """
+    Check whether the affine is resampling or just reordering.
+
+    Parameters
+    ----------
+    vox2vox : np.ndarray
+        The affine matrix.
+    eps : float, default=1e-6
+        The epsilon for the affine check.
+
+    Returns
+    -------
+    bool
+        The result.
+    """
+    _v2v = np.abs(vox2vox[:3, :3])
+    # check 1: have exactly 3 times 1/-1 rest 0, check 2: all 1/-1 or 0
+    return abs(_v2v.sum() - 3) > eps or np.any(np.maximum(_v2v, abs(_v2v - 1)) > eps)
 
 
 def is_conform(
@@ -584,9 +708,10 @@ def is_conform(
         check_dtype: bool = True,
         dtype: Optional[Type] = None,
         verbose: bool = True,
-        conform_to_1mm_threshold: Optional[float] = None
+        conform_to_1mm_threshold: Optional[float] = None,
+        criteria: set[Criteria] = DEFAULT_CRITERIA,
 ) -> bool:
-    """
+    f"""
     Check if an image is already conformed or not.
 
     Dimensions: 256x256x256, Voxel size: 1x1x1, LIA orientation, and data type UCHAR.
@@ -595,26 +720,27 @@ def is_conform(
     ----------
     img : nib.analyze.SpatialImage
         Loaded source image.
-    conform_vox_size : VoxSizeOption
+    conform_vox_size : VoxSizeOption, default=1.0
         Which voxel size to conform to. Can either be a float between 0.0 and
-        1.0 or 'min' check, whether the image is conformed to the minimal voxels size, i.e.
-        conforming to smaller, but isotropic voxel sizes for high-res (default: 1.0).
-    eps : float
-        Allowed deviation from zero for LIA orientation check (default: 1e-06).
+        1.0 or 'min' check, whether the image is conformed to the minimal voxels size, 
+        i.e. conforming to smaller, but isotropic voxel sizes for high-res.
+    eps : float, default=1e-06
+        Allowed deviation from zero for LIA orientation check.
         Small inaccuracies can occur through the inversion operation. Already conformed
         images are thus sometimes not correctly recognized. The epsilon accounts for
         these small shifts.
-    check_dtype : bool
+    check_dtype : bool, default=True
         Specifies whether the UCHAR dtype condition is checked for;
-        this is not done when the input is a segmentation (default: True).
-    dtype : Optional[Type]
-        Specifies the intended target dtype (default: uint8 = UCHAR).
-    verbose : bool
+        this is not done when the input is a segmentation.
+    dtype : Type, optional
+        Specifies the intended target dtype (default or None: uint8 = UCHAR).
+    verbose : bool, default=True
         If True, details of which conformance conditions are violated (if any)
-        are displayed (default: True).
-    conform_to_1mm_threshold : Optional[float]
-        The threshold above which the image is conformed to 1mm
-        (default: ignore).
+        are displayed.
+    conform_to_1mm_threshold : float, optional
+        Above this threshold the image is conformed to 1mm (default or None: ignore).
+    criteria : set[Criteria], default={DEFAULT_CRITERIA}
+        An enum/set of criteria to check.
 
     Returns
     -------
@@ -632,36 +758,37 @@ def is_conform(
     ishape = img.shape
     # check 3d
     if len(ishape) > 3 and ishape[3] != 1:
-        raise ValueError(
-            f"ERROR: Multiple input frames ({img.shape[3]}) not supported!"
-        )
+        raise ValueError(f"ERROR: Multiple input frames ({ishape[3]}) not supported!")
 
-    criteria = {}
+    checks = {
+        f"Number of Dimensions 3": (len(ishape) == 3, f"image ndim {img.ndim}")
+    }
     # check dimensions
-    criteria[f"Number of Dimensions 3"] = (len(ishape) == 3, f"image ndim {img.ndim}")
-    img_size_criteria = f"Dimensions {'x'.join([str(conformed_img_size)] * 3)}"
-    is_correct_img_size = all(s == conformed_img_size for s in ishape[:3])
-    criteria[img_size_criteria] = (is_correct_img_size, f"image dimensions {ishape}")
+    if Criteria.FORCE_IMG_SIZE in criteria:
+        img_size_criteria = f"Dimensions {'x'.join([str(conformed_img_size)] * 3)}"
+        is_correct_img_size = all(s == conformed_img_size for s in ishape[:3])
+        checks[img_size_criteria] = is_correct_img_size, f"image dimensions {ishape}"
 
     # check voxel size, drop voxel sizes of dimension 4 if available
     izoom = np.array(img.header.get_zooms())
     is_correct_vox_size = np.max(np.abs(izoom[:3] - conformed_vox_size)) < eps
-    vox_size_criteria = f"Voxel Size {'x'.join([str(conformed_vox_size)] * 3)}"
-    image_vox_size = f"image " + "x".join(map(str, izoom))
-    criteria[vox_size_criteria] = (is_correct_vox_size, image_vox_size)
+    _vox_sizes = conformed_vox_size if is_correct_vox_size else izoom[:3]
+    if Criteria.FORCE_VOX_SIZE in criteria:
+        vox_size_criteria = f"Voxel Size {'x'.join([str(conformed_vox_size)] * 3)}"
+        image_vox_size = f"image " + "x".join(map(str, izoom))
+        checks[vox_size_criteria] = (is_correct_vox_size, image_vox_size)
 
     # check orientation LIA
-    lia_affine = np.array([[-1, 0, 0], [0, 0, 1], [0, -1, 0]])
-    iaffine = img.affine[:3, :3] - lia_affine * (
-        conformed_vox_size if is_correct_vox_size else izoom[:3]
-    )
-    is_correct_lia = np.max(np.abs(iaffine)) <= eps
-    if not is_correct_lia:
-        import re
-        lia_text = re.sub("\s+", " ", str(img.affine[:3, :3]))
-    else:
-        lia_text = ""
-    criteria["Orientation LIA"] = (is_correct_lia, lia_text)
+    if {Criteria.FORCE_LIA, Criteria.FORCE_LIA_STRICT} & criteria != {}:
+        is_strict = Criteria.FORCE_LIA_STRICT in criteria
+        lia_text = "strict" if is_strict else "lia"
+        if not (is_correct_lia := is_lia(img.affine, is_strict, eps)):
+            import re
+            print_options = np.get_printoptions()
+            np.set_printoptions(precision=2)
+            lia_text += ": " + re.sub("\\s+", " ", str(img.affine[:3, :3]))
+            np.set_printoptions(**print_options)
+        checks["Orientation LIA"] = (is_correct_lia, lia_text)
 
     # check dtype uchar
     if check_dtype:
@@ -670,9 +797,9 @@ def is_conform(
         else:  # assume obj
             dtype = np.dtype(np.obj2sctype(dtype)).name
         is_correct_dtype = img.get_data_dtype() == dtype
-        criteria[f"Dtype {dtype}"] = (is_correct_dtype, f"dtype {img.get_data_dtype()}")
+        checks[f"Dtype {dtype}"] = (is_correct_dtype, f"dtype {img.get_data_dtype()}")
 
-    _is_conform = all(map(lambda x: x[0], criteria.values()))
+    _is_conform = all(map(lambda x: x[0], checks.values()))
 
     if verbose:
         if not _is_conform:
@@ -682,9 +809,45 @@ def is_conform(
             "conformed" if conform_vox_size == 1.0 else f"{conform_vox_size}-conformed"
         )
         print(f"A {conform_str} image must satisfy the following criteria:")
-        for condition, (value, message) in criteria.items():
+        for condition, (value, message) in checks.items():
             print(f" - {condition:<30}: {value if value else 'BUT ' + message}")
     return _is_conform
+
+
+def is_lia(
+        affine: npt.NDArray[float],
+        strict: bool = True,
+        eps: float = 1e-6,
+):
+    """
+    Checks whether the affine is lia-oriented.
+
+    Parameters
+    ----------
+    affine : np.ndarray
+        The affine to check.
+    strict : bool, default=True
+        Whether the orientation should be "exactly" LIA or just similar to LIA (i.e.
+        it is more LIA than other directions).
+    eps : float, default=1e-6
+        The threshold in strict mode.
+
+    Returns
+    -------
+    bool
+        Whether the affine is lia-oriented.
+    """
+    iaffine = affine[:3, :3]
+    lia_nonzero = LIA_AFFINE != 0
+    signs = np.all(np.sign(iaffine[lia_nonzero]) == LIA_AFFINE[lia_nonzero])
+    if strict:
+        directions = np.all(iaffine[np.logical_not(lia_nonzero)] <= eps)
+    else:
+        def get_primary_dirs(a): return np.argmax(abs(a), axis=0)
+
+        directions = np.all(get_primary_dirs(iaffine) == get_primary_dirs(LIA_AFFINE))
+    is_correct_lia = directions and signs
+    return is_correct_lia
 
 
 def get_conformed_vox_img_size(
@@ -707,7 +870,7 @@ def get_conformed_vox_img_size(
         size).
     conform_to_1mm_threshold : float, optional
         The threshold for which image voxel size should be conformed to 1mm instead of
-        conformed to the smallest voxel size (default: None = 1.0, never apply).
+        conformed to the smallest voxel size (default: None, never apply).
 
     Returns
     -------
@@ -717,15 +880,10 @@ def get_conformed_vox_img_size(
         The size of the image adjusted to the conformed voxel size.
     """
     # this is similar to mri_convert --conform_min
-    if isinstance(conform_vox_size, str) and conform_vox_size.lower() in [
-        "min",
-        "auto",
-    ]:
+    auto_values = ["min", "auto"]
+    if isinstance(conform_vox_size, str) and conform_vox_size.lower() in auto_values:
         conformed_vox_size = find_min_size(img)
-        if (
-            conform_to_1mm_threshold is not None
-            and conformed_vox_size > conform_to_1mm_threshold
-        ):
+        if conform_to_1mm_threshold and conformed_vox_size > conform_to_1mm_threshold:
             conformed_vox_size = 1.0
     # this is similar to mri_convert --conform_size <float>
     elif isinstance(conform_vox_size, float) and 0.0 < conform_vox_size <= 1.0:
@@ -812,19 +970,26 @@ def check_affine_in_nifti(
 
 if __name__ == "__main__":
     # Command Line options are error checking done here
-    options = options_parse()
+    try:
+        options = options_parse()
+    except RuntimeError as e:
+        sys.exit(*e.args)
 
     print(f"Reading input: {options.input} ...")
     image = nib.load(options.input)
 
+    if not isinstance(image, nib.analyze.SpatialImage):
+        sys.exit(f"ERROR: Input image is not a spatial image: {type(image).__name__}")
     if len(image.shape) > 3 and image.shape[3] != 1:
         sys.exit(f"ERROR: Multiple input frames ({image.shape[3]}) not supported!")
 
-    target_dtype = "uint8" if options.seg_input else options.dtype
-    opt_kwargs = {}
-    check_dtype = target_dtype != "any"
-    if check_dtype:
-        opt_kwargs["dtype"] = target_dtype
+    _target_dtype = "uint8" if options.seg_input else options.dtype
+    crit = DEFAULT_CRITERIA_DICT.items()
+    opt_kwargs = {
+        "criteria": set(c for n, c in crit if getattr(options, "force_" + n, True)),
+    }
+    if check_dtype := _target_dtype != "any":
+        opt_kwargs["dtype"] = _target_dtype
 
     if hasattr(options, "conform_to_1mm_threshold"):
         opt_kwargs["conform_to_1mm_threshold"] = options.conform_to_1mm_threshold
@@ -853,13 +1018,16 @@ if __name__ == "__main__":
 
     # If image is nifti image
     if options.input[-7:] == ".nii.gz" or options.input[-4:] == ".nii":
-
-        if not check_affine_in_nifti(image):
+        from nibabel import Nifti1Image, Nifti2Image
+        if not check_affine_in_nifti(cast(Nifti1Image | Nifti2Image, image)):
             sys.exit("ERROR: inconsistency in nifti-header. Exiting now.\n")
 
     try:
         new_image = conform(
-            image, order=options.order, conform_vox_size=_vox_size, dtype=options.dtype
+            image,
+            order=options.order,
+            conform_vox_size=_vox_size,
+            **opt_kwargs,
         )
     except ValueError as e:
         sys.exit(e.args[0])

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -61,13 +61,13 @@ class Criteria(Enum):
     FORCE_LIA_STRICT = "lia strict"
     FORCE_LIA = "lia"
     FORCE_IMG_SIZE = "img size"
-    FORCE_VOX_SIZE = "vox size"
+    FORCE_ISO_VOX = "iso vox"
 
 
 DEFAULT_CRITERIA_DICT = {
     "lia": Criteria.FORCE_LIA,
     "strict_lia": Criteria.FORCE_LIA_STRICT,
-    "vox_size": Criteria.FORCE_VOX_SIZE,
+    "iso_vox": Criteria.FORCE_ISO_VOX,
     "img_size": Criteria.FORCE_IMG_SIZE,
 }
 DEFAULT_CRITERIA = frozenset(DEFAULT_CRITERIA_DICT.values())
@@ -145,18 +145,18 @@ def options_parse():
         "--no_strict_lia",
         dest="force_strict_lia",
         action="store_false",
-        help="Ignore the forced lia reorientation.",
+        help="Ignore the forced LIA reorientation.",
     )
     advanced.add_argument(
         "--no_lia",
         dest="force_lia",
         action="store_false",
-        help="Ignore the reordering of data into lia (without interpolation). "
+        help="Ignore the reordering of data into LIA (without interpolation). "
              "Superceeds --no_strict_lia",
     )
     advanced.add_argument(
-        "--no_vox_size",
-        dest="force_vox_size",
+        "--no_iso_vox",
+        dest="force_iso_vox",
         action="store_false",
         help="Ignore the forced isometric voxel size (depends on --conform_min).",
     )
@@ -548,7 +548,7 @@ def conform(
         The threshold above which the image is conformed to 1mm
         (default: ignore).
     criteria : set[Criteria], default={DEFAULT_CRITERIA}
-        Whether to force the conforming to include a lia data layout, an image size
+        Whether to force the conforming to include a LIA data layout, an image size
         requirement and/or a voxel size requirement.
 
     Returns
@@ -584,7 +584,7 @@ def conform(
         h1.set_data_shape([conformed_img_size] * 3 + [1])
     else:
         h1.set_data_shape([img_shape[i] for i in re_order_axes] + [1])
-    if Criteria.FORCE_VOX_SIZE in criteria:
+    if Criteria.FORCE_ISO_VOX in criteria:
         h1.set_zooms([conformed_vox_size] * 3)  # --> h1['delta']
         do_interp |= not np.allclose(vox_size, conformed_vox_size)
     else:
@@ -773,7 +773,7 @@ def is_conform(
     izoom = np.array(img.header.get_zooms())
     is_correct_vox_size = np.max(np.abs(izoom[:3] - conformed_vox_size)) < eps
     _vox_sizes = conformed_vox_size if is_correct_vox_size else izoom[:3]
-    if Criteria.FORCE_VOX_SIZE in criteria:
+    if Criteria.FORCE_ISO_VOX in criteria:
         vox_size_criteria = f"Voxel Size {'x'.join([str(conformed_vox_size)] * 3)}"
         image_vox_size = f"image " + "x".join(map(str, izoom))
         checks[vox_size_criteria] = (is_correct_vox_size, image_vox_size)
@@ -820,7 +820,7 @@ def is_lia(
         eps: float = 1e-6,
 ):
     """
-    Checks whether the affine is lia-oriented.
+    Checks whether the affine is LIA-oriented.
 
     Parameters
     ----------
@@ -835,7 +835,7 @@ def is_lia(
     Returns
     -------
     bool
-        Whether the affine is lia-oriented.
+        Whether the affine is LIA-oriented.
     """
     iaffine = affine[:3, :3]
     lia_nonzero = LIA_AFFINE != 0

--- a/HypVINN/data_loader/data_utils.py
+++ b/HypVINN/data_loader/data_utils.py
@@ -1,4 +1,5 @@
-# Copyright 2024 AI in Medical Imaging, German Center for Neurodegenerative Diseases(DZNE), Bonn
+# Copyright 2024
+# AI in Medical Imaging, German Center for Neurodegenerative Diseases(DZNE), Bonn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +19,9 @@ import numpy as np
 from numpy import typing as npt
 
 from FastSurferCNN.data_loader.conform import getscale, scalecrop
-from HypVINN.config.hypvinn_global_var import hyposubseg_labels, SAG2FULL_MAP, HYPVINN_CLASS_NAMES, FS_CLASS_NAMES
+from HypVINN.config.hypvinn_global_var import (
+    hyposubseg_labels, SAG2FULL_MAP, HYPVINN_CLASS_NAMES, FS_CLASS_NAMES,
+)
 
 
 ##
@@ -44,12 +47,13 @@ def calculate_flip_orientation(iornt: np.ndarray, base_ornt: np.ndarray) -> np.n
     new_iornt : np.ndarray
         New orientation.
     """
-    new_iornt=iornt.copy()
+    new_iornt = iornt.copy()
 
-    # Find the axis to compared and then compared oriention, where 1 means no flip and -1 means flip.
+    # Find the axis to compared and then compared orientation, where 1 means no flip
+    # and -1 means flip.
     for axno, direction in np.asarray(base_ornt):
-        idx=np.where(iornt[:,0] == axno)
-        idirection=iornt[int(idx[0][0]),1]
+        idx = np.where(iornt[:, 0] == axno)
+        idirection = iornt[int(idx[0][0]), 1]
         if direction == idirection:
             new_iornt[int(idx[0][0]), 1] = 1.0
         else:
@@ -74,16 +78,16 @@ def reorient_img(img, ref_img):
     img : nibabel.Nifti1Image
         Reoriented image.
     """
-    ref_ornt =nib.io_orientation(ref_img.affine)
-    iornt=nib.io_orientation(img.affine)
+    ref_ornt = nib.io_orientation(ref_img.affine)
+    iornt = nib.io_orientation(img.affine)
 
-    if not np.array_equal(iornt,ref_ornt):
-        #first flip orientation
-        fornt = calculate_flip_orientation(iornt,ref_ornt)
+    if not np.array_equal(iornt, ref_ornt):
+        # first flip orientation
+        fornt = calculate_flip_orientation(iornt, ref_ornt)
         img = img.as_reoriented(fornt)
-        #the transpose axis
+        # the transpose axis
         tornt = np.ones_like(ref_ornt)
-        tornt[:,0] = ref_ornt[:,0]
+        tornt[:, 0] = ref_ornt[:, 0]
         img = img.as_reoriented(tornt)
 
     return img
@@ -93,17 +97,18 @@ def transform_axial2coronal(vol: np.ndarray, axial2coronal: bool = True) -> np.n
     """
     Transforms a volume into the coronal axis and back.
 
-    This function is used to transform a volume into the coronal axis and back. The transformation is done by moving
-    the axes of the volume. If the `axial2coronal` parameter is set to True, the function will transform from axial to
-    coronal. If it is set to False, the function will transform from coronal to axial.
+    This function is used to transform a volume into the coronal axis and back. The
+    transformation is done by moving the axes of the volume. If the `axial2coronal`
+    parameter is set to True, the function will transform from axial to coronal. If it
+    is set to False, the function will transform from coronal to axial.
 
     Parameters
     ----------
     vol : np.ndarray
         The image volume to transform.
     axial2coronal : bool, optional
-        A flag to determine the direction of the transformation. If True, transform from axial to coronal. If False,
-        transform from coronal to axial. (Default: True).
+        A flag to determine the direction of the transformation. If True, transform from
+        axial to coronal. If False, transform from coronal to axial. (Default: True).
 
     Returns
     -------
@@ -117,21 +122,23 @@ def transform_axial2coronal(vol: np.ndarray, axial2coronal: bool = True) -> np.n
         return np.moveaxis(vol, [0, 1, 2], [0, 2, 1])
 
 
-def transform_axial2sagittal(vol: np.ndarray, axial2sagittal: bool = True) -> np.ndarray:
+def transform_axial2sagittal(vol: np.ndarray,
+                             axial2sagittal: bool = True) -> np.ndarray:
     """
     Transforms a volume into the sagittal axis and back.
 
-    This function is used to transform a volume into the sagittal axis and back. The transformation is done by moving
-    the axes of the volume. If the `axial2sagittal` parameter is set to True, the function will transform from axial to
-    sagittal. If it is set to False, the function will transform from sagittal to axial.
+    This function is used to transform a volume into the sagittal axis and back. The
+    transformation is done by moving the axes of the volume. If the `axial2sagittal`
+    parameter is set to True, the function will transform from axial to sagittal. If it
+    is set to False, the function will transform from sagittal to axial.
 
     Parameters
     ----------
     vol : np.ndarray
         The image volume to transform.
     axial2sagittal : bool, default=True
-        A flag to determine the direction of the transformation. If True, transform from axial to sagittal. If False,
-        transform from sagittal to axial. (Default: True).
+        A flag to determine the direction of the transformation. If True, transform from
+        axial to sagittal. If False, transform from sagittal to axial. (Default: True).
 
     Returns
     -------
@@ -162,22 +169,23 @@ def rescale_image(img_data: np.ndarray) -> np.ndarray:
         The rescaled image data.
     """
     # Conform intensities
-    # TODO move function into FastSurferCNN, same: CerebNet.datasets.utils.rescale_image
+    # TODO move function to FastSurferCNN similar: CerebNet.datasets.utils.rescale_image
     src_min, scale = getscale(img_data, 0, 255)
     mapped_data = img_data
-    if not img_data.dtype == np.dtype(np.uint8):
-        if np.max(img_data) > 255:
-            mapped_data = scalecrop(img_data, 0, 255, src_min, scale)
 
-    new_data = np.uint8(np.rint(mapped_data))
-    return new_data
+    # this used to rescale, if the image was not uint8 and any intensity was > 255
+    if not np.allclose([src_min, scale], [0, 1]):
+        mapped_data = scalecrop(img_data, 0, 255, src_min, scale)
+
+    return np.uint8(np.rint(mapped_data))
 
 
 def hypo_map_label2subseg(mapped_subseg: npt.NDArray[int]) -> npt.NDArray[int]:
     """
     Perform look-up table mapping from label space to subseg space.
 
-    This function is used to perform a look-up table mapping from label space to subseg space.
+    This function is used to perform a look-up table mapping from label space to subseg
+    space.
 
     Parameters
     ----------
@@ -199,13 +207,13 @@ def hypo_map_label2subseg(mapped_subseg: npt.NDArray[int]) -> npt.NDArray[int]:
 
 
 def hypo_map_prediction_sagittal2full(
-prediction_sag: npt.NDArray[int],
+        prediction_sag: npt.NDArray[int],
 ) -> npt.NDArray[int]:
     """
     Remap the prediction on the sagittal network to full label space.
 
-    This function is used to remap the prediction on the sagittal network to the full label space used by the coronal
-    and axial networks.
+    This function is used to remap the prediction on the sagittal network to the full
+    label space used by the coronal and axial networks.
 
     Parameters
     ----------
@@ -231,17 +239,18 @@ def hypo_map_subseg_2_fsseg(
     """
     Remap HypVINN internal labels to FastSurfer Labels and vice versa.
 
-    This function is used to remap HypVINN internal labels to FastSurfer Labels and vice versa. If the `reverse`
-    parameter is set to False, the function will map HypVINN labels to FastSurfer labels. If it is set to True,
-    the function will map FastSurfer labels to HypVINN labels.
+    This function is used to remap HypVINN internal labels to FastSurfer Labels and vice
+    versa. If the `reverse` parameter is set to False, the function will map HypVINN
+    labels to FastSurfer labels. If it is set to True, the function will map FastSurfer
+    labels to HypVINN labels.
 
     Parameters
     ----------
     subseg : npt.NDArray[int]
         The input array with HypVINN or FastSurfer labels to be remapped.
-    reverse : bool, optional
-        A flag to determine the direction of the remapping. If False, remap HypVINN labels to FastSurfer labels.
-        If True, remap FastSurfer labels to HypVINN labels. (Default: False).
+    reverse : bool, default=False
+        A flag to determine the direction of the remapping. If False, remap HypVINN
+        labels to FastSurfer labels. If True, remap FastSurfer labels to HypVINN labels.
 
     Returns
     -------
@@ -257,7 +266,6 @@ def hypo_map_subseg_2_fsseg(
             fsseg[subseg == value] = FS_CLASS_NAMES[name]
     else:
         reverse_hypvinn = dict(map(reversed, HYPVINN_CLASS_NAMES.items()))
-        for name,value in FS_CLASS_NAMES.items():
+        for name, value in FS_CLASS_NAMES.items():
             fsseg[subseg == value] = reverse_hypvinn[name]
     return fsseg
-

--- a/HypVINN/data_loader/dataset.py
+++ b/HypVINN/data_loader/dataset.py
@@ -28,7 +28,7 @@ logger = logging.get_logger(__name__)
 
 
 # Operator to load imaged for inference
-class HypoVINN_dataset(Dataset):
+class HypVINNDataset(Dataset):
     """
     Class to load MRI-Image and process it to correct format for HypVINN network inference.
 
@@ -62,7 +62,7 @@ class HypoVINN_dataset(Dataset):
             transforms=None,
     ):
         """
-        Initialize the HypoVINN Dataset.
+        Initialize the HypVINN Dataset.
 
         Parameters
         ----------

--- a/HypVINN/inference.py
+++ b/HypVINN/inference.py
@@ -27,7 +27,7 @@ from FastSurferCNN.utils.common import find_device
 from FastSurferCNN.data_loader.augmentation import ToTensorTest, ZeroPad2DTest
 from HypVINN.models.networks import build_model
 from HypVINN.data_loader.data_utils import hypo_map_prediction_sagittal2full
-from HypVINN.data_loader.dataset import HypoVINN_dataset
+from HypVINN.data_loader.dataset import HypVINNDataset
 from HypVINN.utils import ModalityMode
 
 logger = logging.get_logger(__name__)
@@ -380,7 +380,7 @@ class Inference:
             The updated prediction probabilities.
         """
         # Set up DataLoader
-        test_dataset = HypoVINN_dataset(
+        test_dataset = HypVINNDataset(
             subject_name,
             modalities,
             orig_zoom,

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -282,11 +282,9 @@ def main(
 
         # Pre-processing -- T1 and T2 registration
         if mode == "t1t2":
-            # Note, that t1_path and t2_path are guaranteed to be not None
-            # via get_hypvinn_mode, which only returns t1t2, if t1 and t2
-            # exist.
-            # hypvinn_preproc returns the path to the t2 that is registered
-            # to the t1
+            # Note, that t1_path and t2_path are guaranteed to be not None via
+            # get_hypvinn_mode, which only returns t1t2, if t1 and t2 exist.
+            # hypvinn_preproc returns the path to the t2 that is registered to the t1
             prep_tasks["reg"] = pool.submit(
                 hypvinn_preproc,
                 mode,

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -108,7 +108,7 @@ def option_parse() -> argparse.ArgumentParser:
     # 3. Image processing options
     parser.add_argument(
         "--qc_snap",
-        default='store_true',
+        action='store_true',
         dest="qc_snapshots",
         help="Create qc snapshots in <sd>/<sid>/qc_snapshots.",
     )
@@ -122,14 +122,14 @@ def option_parse() -> argparse.ArgumentParser:
              "registration of T2 to T1, if both images are passed, "
              "images need to be register properly externally.",
     )
-    default_hypo_segfile = Path("mri") / HYPVINN_SEG_NAME
+
     parser.add_argument(
         "--hypo_segfile",
-        type=Path,
-        default=default_hypo_segfile,
+        type=str,
+        default=HYPVINN_SEG_NAME,
         dest="hypo_segfile",
         help=f"File pattern on where to save the hypothalamus segmentation file "
-             f"(default: {default_hypo_segfile})."
+             f"(default: {HYPVINN_SEG_NAME})."
     )
 
     # 4. Options for advanced, technical parameters
@@ -380,7 +380,7 @@ def main(
                 plot_qc_images,
                 subject_qc_dir=subject_dir / "qc_snapshots",
                 orig_path=orig_path,
-                prediction_path=Path(hypo_segfile),
+                prediction_path=Path(subject_dir / "mri" /hypo_segfile),
             )
             qc_future.add_done_callback(
                 lambda x: logger.info(f"QC snapshots saved in {x.result()} seconds."),
@@ -391,7 +391,7 @@ def main(
         logger.info("Computing stats")
         return_value = compute_stats(
             orig_path=orig_path,
-            prediction_path=Path(hypo_segfile),
+            prediction_path=Path(subject_dir / "mri" /hypo_segfile),
             stats_dir=subject_dir / "stats",
             threads=threads,
         )

--- a/HypVINN/utils/img_processing_utils.py
+++ b/HypVINN/utils/img_processing_utils.py
@@ -111,7 +111,7 @@ def save_segmentation(
     LOGGER.info(
         f"HypoVINN Prediction after re-orientation: {img2axcodes(pred_img)}"
     )
-    pred_img.set_data_dtype(np.int16)  # Maximum value 939
+    pred_img.set_data_dtype(np.int16)  # Maximum value 984
     nib.save(pred_img, subject_dir / "mri" / seg_file)
     return time() - starttime
 

--- a/HypVINN/utils/img_processing_utils.py
+++ b/HypVINN/utils/img_processing_utils.py
@@ -98,18 +98,18 @@ def save_segmentation(
 
     if save_mask:
         mask_img = nib.Nifti1Image(labels_cc, affine=ras_affine, header=ras_header)
-        LOGGER.info(f"HypoVINN Mask orientation: {img2axcodes(mask_img)}")
+        LOGGER.info(f"HypVINN Mask orientation: {img2axcodes(mask_img)}")
         mask_img = reorient_img(mask_img, orig_img)
         LOGGER.info(
-            f"HypoVINN Mask after re-orientation: {img2axcodes(mask_img)}"
+            f"HypVINN Mask after re-orientation: {img2axcodes(mask_img)}"
         )
         nib.save(mask_img, subject_dir / "mri" / mask_file)
 
     pred_img = nib.Nifti1Image(pred_arr, affine=ras_affine, header=ras_header)
-    LOGGER.info(f"HypoVINN Prediction orientation: {img2axcodes(pred_img)}")
+    LOGGER.info(f"HypVINN Prediction orientation: {img2axcodes(pred_img)}")
     pred_img = reorient_img(pred_img, orig_img)
     LOGGER.info(
-        f"HypoVINN Prediction after re-orientation: {img2axcodes(pred_img)}"
+        f"HypVINN Prediction after re-orientation: {img2axcodes(pred_img)}"
     )
     pred_img.set_data_dtype(np.int16)  # Maximum value 984
     nib.save(pred_img, subject_dir / "mri" / seg_file)
@@ -159,10 +159,10 @@ def save_logits(
         affine=ras_affine,
         header=ras_header,
     )
-    LOGGER.info(f"HypoVINN logits orientation: {img2axcodes(nifti_img)}")
+    LOGGER.info(f"HypVINN logits orientation: {img2axcodes(nifti_img)}")
     nifti_img = reorient_img(nifti_img, orig_img)
     LOGGER.info(
-        f"HypoVINN logits after re-orientation: {img2axcodes(nifti_img)}"
+        f"HypVINN logits after re-orientation: {img2axcodes(nifti_img)}"
     )
     nifti_img.set_data_dtype(np.float32)
     save_as = save_dir / f"HypVINN_logits_{mode}.nii.gz"

--- a/doc/scripts/advanced.rst
+++ b/doc/scripts/advanced.rst
@@ -9,4 +9,3 @@ Advanced scripts
     hypvinn
     recon_surf
     segstats
-    util

--- a/doc/scripts/index.rst
+++ b/doc/scripts/index.rst
@@ -6,3 +6,4 @@ Scripts
 
     SLURM.md
     advanced
+    util

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -710,6 +710,7 @@ def main(
                     cap_dtype = prefix.upper() + cap_dtype[len(prefix):]
             sitk_dtype = getattr(sitk, "sitk" + cap_dtype)
             itk_outvol = sitk.Cast(itk_outvol, sitk_dtype)
+            image_header.set_dtype(np.dtype(out_dtype))
 
         # write image
         logger.info(f"writing {type(outvol).__name__}: {outvol}")

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -31,11 +31,11 @@ function RunIt()
   then
     local CMDF=$3
     printf -v tmp %q "$cmd"
-    echo "echo $tmp" 2>&1 | tee -a $CMDF
-    echo "$timecmd $cmd" 2>&1 | tee -a $CMDF
+    echo "echo $tmp" | tee -a $CMDF
+    echo "$timecmd $cmd" | tee -a $CMDF
     echo "if [ \${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi" >> $CMDF
   else
-    echo $cmd 2>&1 | tee -a $LF
+    echo $cmd | tee -a $LF
     $timecmd $cmd 2>&1 | tee -a $LF
     if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   fi
@@ -108,20 +108,20 @@ function softlink_or_copy()
   if [[ $# -eq 4 ]]
   then
     local CMDF=$4
-    echo "echo \"$ln_cmd\" " 2>&1 | tee -a $CMDF
-    echo "$timecmd $ln_cmd " 2>&1 | tee -a $CMDF
-    echo "if [ \${PIPESTATUS[0]} -ne 0 ]" 2>&1 | tee -a $CMDF
-    echo "then " 2>&1 | tee -a $CMDF
-    echo "  echo \"$cp_cmd\" " 2>&1 | tee -a $CMDF
-    echo "  $timecmd $cp_cmd " 2>&1 | tee -a $CMDF
+    echo "echo \"$ln_cmd\" " | tee -a $CMDF
+    echo "$timecmd $ln_cmd " | tee -a $CMDF
+    echo "if [ \${PIPESTATUS[0]} -ne 0 ]" | tee -a $CMDF
+    echo "then " | tee -a $CMDF
+    echo "  echo \"$cp_cmd\" " | tee -a $CMDF
+    echo "  $timecmd $cp_cmd " | tee -a $CMDF
     echo "  if [ \${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi" >> $CMDF
-    echo "fi" 2>&1 | tee -a $CMDF
+    echo "fi" | tee -a $CMDF
   else
-    echo $ln_cmd 2>&1 | tee -a $LF
+    echo $ln_cmd | tee -a $LF
     $timecmd $ln_cmd 2>&1 | tee -a $LF
     if [ ${PIPESTATUS[0]} -ne 0 ]
     then
-      echo $cp_cmd 2>&1 | tee -a $LF
+      echo $cp_cmd | tee -a $LF
       $timecmd $cp_cmd 2>&1 | tee -a $LF
       if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
     fi

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -528,9 +528,9 @@ fi
 # ============================= TALAIRACH ==============================================
 
 if [[ ! -f "$mdir/transforms/talairach.lta" ]] || [[ ! -f "$mdir/transforms/talairach_with_skull.lta" ]]; then
-  echo " " 2>&1 | tee -a $LF
-  echo "============= Computing Talairach Transform ============" 2>&1 | tee -a $LF
-  echo " " 2>&1 | tee -a $LF
+  echo " " | tee -a $LF
+  echo "============= Computing Talairach Transform ============" | tee -a $LF
+  echo " " | tee -a $LF
   echo "\"$binpath/talairach-reg.sh\" \"$mdir\" \"$atlas3T\" \"$LF\"" | tee -a "$LF"
   "$binpath/talairach-reg.sh" "$mdir" "$atlas3T" "$LF"
 fi
@@ -562,9 +562,9 @@ fi
 
 # ============================= CC SEGMENTATION ============================================
 
-echo " " 2>&1 | tee -a $LF
-echo "============ Creating and adding CC Segmentation ============" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "============ Creating and adding CC Segmentation ============" | tee -a $LF
+echo " " | tee -a $LF
 # create aseg.auto including corpus callosum segmentation and 46 sec, requires norm.mgz
 # Note: if original input segmentation already contains CC, this will exit with ERROR
 # in the future maybe check and skip this step (and next)

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -396,45 +396,45 @@ LF="$SUBJECTS_DIR/$subject/scripts/recon-surf.log"
 if [ $LF != /dev/null ] ; then  rm -f $LF ; fi
 echo "Log file for recon-surf.sh" >> $LF
 date  2>&1 | tee -a $LF
-echo "" 2>&1 | tee -a $LF
-echo "export SUBJECTS_DIR=$SUBJECTS_DIR" 2>&1 | tee -a $LF
-echo "cd `pwd`"  2>&1 | tee -a $LF
-echo $0 ${inputargs[*]} 2>&1 | tee -a $LF
-echo "" 2>&1 | tee -a $LF
+echo "" | tee -a $LF
+echo "export SUBJECTS_DIR=$SUBJECTS_DIR" | tee -a $LF
+echo "cd `pwd`"  | tee -a $LF
+echo $0 ${inputargs[*]} | tee -a $LF
+echo "" | tee -a $LF
 cat $FREESURFER_HOME/build-stamp.txt 2>&1 | tee -a $LF
-echo $VERSION 2>&1 | tee -a $LF
+echo $VERSION | tee -a $LF
 uname -a  2>&1 | tee -a $LF
 
-echo " " 2>&1 | tee -a $LF
-echo "==================== Checking validity of inputs =================================" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "==================== Checking validity of inputs =================================" | tee -a $LF
+echo " " | tee -a $LF
 
 # Print parallelization parameters
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
 if [ "$DoParallel" == "1" ]
 then
-  echo " RUNNING both hemis in PARALLEL " 2>&1 | tee -a $LF
+  echo " RUNNING both hemis in PARALLEL " | tee -a $LF
 else
-  echo " RUNNING both hemis SEQUENTIALLY " 2>&1 | tee -a $LF
+  echo " RUNNING both hemis SEQUENTIALLY " | tee -a $LF
 fi
-echo " RUNNING $OMP_NUM_THREADS number of OMP THREADS " 2>&1 | tee -a $LF
-echo " RUNNING $ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS number of ITK THREADS " 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " RUNNING $OMP_NUM_THREADS number of OMP THREADS " | tee -a $LF
+echo " RUNNING $ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS number of ITK THREADS " | tee -a $LF
+echo " " | tee -a $LF
 
 # Check input segmentation quality
-echo "Checking Input Segmentation Quality ..." 2>&1 | tee -a "$LF"
+echo "Checking Input Segmentation Quality ..." | tee -a "$LF"
 cmd="$python $FASTSURFER_HOME/FastSurferCNN/quick_qc.py --asegdkt_segfile $asegdkt_segfile"
 RunIt "$cmd" "$LF"
-echo "" 2>&1 | tee -a "$LF"
+echo "" | tee -a "$LF"
 
 
 
 
 ########################################## START ########################################################
 
-echo " " 2>&1 | tee -a $LF
-echo "================== Creating orig and rawavg from input =========================" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "================== Creating orig and rawavg from input =========================" | tee -a $LF
+echo " " | tee -a $LF
 
 CONFORM_LF=$SUBJECTS_DIR/$subject/scripts/conform.log
 if [ $CONFORM_LF != /dev/null ] ; then  rm -f $CONFORM_LF ; fi
@@ -455,12 +455,12 @@ RunIt "$cmd" $LF
 
 if (( $(echo "$vox_size < $hires_voxsize_threshold" | bc -l) ))
 then
-  echo "The voxel size $vox_size is less than $hires_voxsize_threshold, so we are proceeding with hires options." 2>&1 | tee -a $LF
+  echo "The voxel size $vox_size is less than $hires_voxsize_threshold, so we are proceeding with hires options." | tee -a $LF
   hiresflag="-hires"
   noconform_if_hires=" -noconform"
   hires_surface_suffix=".predec"
 else
-  echo "The voxel size $vox_size is not less than $hires_voxsize_threshold, so we are proceeding with standard options." 2>&1 | tee -a $LF
+  echo "The voxel size $vox_size is not less than $hires_voxsize_threshold, so we are proceeding with standard options." | tee -a $LF
   hiresflag=""
   noconform_if_hires=""
   hires_surface_suffix=""
@@ -491,9 +491,9 @@ popd
 
 if [ ! -f "$mask" ] || [ ! -f "$mdir/aseg.auto_noCCseg.mgz" ] ; then
   # Mask or aseg.auto_noCCseg not found; create them from aparc.DKTatlas+aseg
-  echo " " 2>&1 | tee -a $LF
-  echo "============= Creating aseg.auto_noCCseg (map aparc labels back) ===============" 2>&1 | tee -a $LF
-  echo " " 2>&1 | tee -a $LF
+  echo " " | tee -a $LF
+  echo "============= Creating aseg.auto_noCCseg (map aparc labels back) ===============" | tee -a $LF
+  echo " " | tee -a $LF
   # reduce labels to aseg, then create mask (dilate 5, erode 4, largest component), also mask aseg to remove outliers
   # output will be uchar (else mri_cc will fail below)
   cmd="$python ${binpath}/../FastSurferCNN/reduce_to_aseg.py -i $mdir/aparc.DKTatlas+aseg.orig.mgz -o $mdir/aseg.auto_noCCseg.mgz --outmask $mask --fixwm"
@@ -504,9 +504,9 @@ fi
 
 if [ ! -f "$mdir/orig_nu.mgz" ]; then
   # only run the bias field correction, if the bias field corrected does not exist already
-  echo " " 2>&1 | tee -a $LF
-  echo "============= Computing NU (bias corrected) ============" 2>&1 | tee -a $LF
-  echo " " 2>&1 | tee -a $LF
+  echo " " | tee -a $LF
+  echo "============= Computing NU (bias corrected) ============" | tee -a $LF
+  echo " " | tee -a $LF
   # nu processing is changed here compared to recon-all: we use the brainmask from the
   # segmentation to improve the nu correction (and speedup)
   # orig_nu N3 in FS6 took 44 sec, FS 7.3.2 uses --ants-n4 (takes 3 min and does not accept
@@ -531,16 +531,16 @@ if [[ ! -f "$mdir/transforms/talairach.lta" ]] || [[ ! -f "$mdir/transforms/tala
   echo " " 2>&1 | tee -a $LF
   echo "============= Computing Talairach Transform ============" 2>&1 | tee -a $LF
   echo " " 2>&1 | tee -a $LF
-  echo "\"$binpath/talairach-reg.sh\" \"$mdir\" \"$atlas3T\" \"$LF\"" 2>&1 | tee -a "$LF"
+  echo "\"$binpath/talairach-reg.sh\" \"$mdir\" \"$atlas3T\" \"$LF\"" | tee -a "$LF"
   "$binpath/talairach-reg.sh" "$mdir" "$atlas3T" "$LF"
 fi
 
 
 # ============================= BRAINMASK ==============================================
 
-echo " " 2>&1 | tee -a $LF
-echo "============ Creating brainmask from aseg and nu or T1 ============" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "============ Creating brainmask from aseg and nu or T1 ============" | tee -a $LF
+echo " " | tee -a $LF
 # create norm by masking nu
 cmd="mri_mask $mdir/nu.mgz $mdir/mask.mgz $mdir/norm.mgz"
 RunIt "$cmd" $LF
@@ -577,9 +577,9 @@ RunIt "$cmd" $LF
 
 # ============================= FILLED =====================================================
 
-echo " " 2>&1 | tee -a $LF
-echo "========= Creating filled from brain (brainfinalsurfs, wm.asegedit, wm)  =======" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "========= Creating filled from brain (brainfinalsurfs, wm.asegedit, wm)  =======" | tee -a $LF
+echo " " | tee -a $LF
 
 # filled is needed to generate initial WM surfaces
 cmd="recon-all -s $subject -asegmerge -normalization2 -maskbfs -segmentation -fill $hiresflag $fsthreads"
@@ -603,9 +603,9 @@ for hemi in lh rh; do
 
 # ============================= TESSELATE - SMOOTH =====================================================
 
-  echo "echo " 2>&1 | tee -a $CMDF
-  echo "echo \"================== Creating surfaces $hemi - orig.nofix ==================\"" 2>&1 | tee -a $CMDF
-  echo "echo " 2>&1 | tee -a $CMDF
+  echo "echo " | tee -a $CMDF
+  echo "echo \"================== Creating surfaces $hemi - orig.nofix ==================\"" | tee -a $CMDF
+  echo "echo " | tee -a $CMDF
   if [ "$fstess" == "1" ]
   then
     cmd="recon-all -subject $subject -hemi $hemi -tessellate -smooth1 -no-isrunning $hiresflag $fsthreads"
@@ -634,8 +634,8 @@ for hemi in lh rh; do
 
     # Check if the surfaceRAS was correctly set and exit otherwise (sanity check in case nibabel changes their default header behaviour)
     cmd="mris_info $outmesh | tr -s ' ' | grep -q 'vertex locs : surfaceRAS'"
-    echo "echo \"$cmd\" " 2>&1 | tee -a $CMDF
-    echo "$timecmd $cmd " 2>&1 | tee -a $CMDF
+    echo "echo \"$cmd\" " | tee -a $CMDF
+    echo "$timecmd $cmd " | tee -a $CMDF
     echo "if [ \${PIPESTATUS[1]} -ne 0 ] ; then echo \"Incorrect header information detected in $outmesh: vertex locs is not set to surfaceRAS. Exiting... \"; exit 1 ; fi" >> $CMDF
 
     # Reduce to largest component (usually there should only be one)
@@ -661,9 +661,9 @@ for hemi in lh rh; do
 
 # ============================= INFLATE1 - QSPHERE =====================================================
 
-  echo "echo  " 2>&1 | tee -a $CMDF
-  echo "echo \"=================== Creating surfaces $hemi - qsphere ====================\"" 2>&1 | tee -a $CMDF
-  echo "echo " 2>&1 | tee -a $CMDF
+  echo "echo  " | tee -a $CMDF
+  echo "echo \"=================== Creating surfaces $hemi - qsphere ====================\"" | tee -a $CMDF
+  echo "echo " | tee -a $CMDF
   #surface inflation (54sec both hemis) (needed for qsphere and for topo-fixer)
   cmd="recon-all -subject $subject -hemi $hemi -inflate1 -no-isrunning $hiresflag $fsthreads"
   RunIt "$cmd" $LF $CMDF
@@ -684,9 +684,9 @@ for hemi in lh rh; do
 
 # ============================= FIX - WHITEPREAPARC - CORTEXLABEL ============================================
 
-  echo "echo " 2>&1 | tee -a $CMDF
-  echo "echo \"=================== Creating surfaces $hemi - fix ========================\"" 2>&1 | tee -a $CMDF
-  echo "echo " 2>&1 | tee -a $CMDF
+  echo "echo " | tee -a $CMDF
+  echo "echo \"=================== Creating surfaces $hemi - fix ========================\"" | tee -a $CMDF
+  echo "echo " | tee -a $CMDF
   cmd="recon-all -subject $subject -hemi $hemi -fix -autodetgwstats -white-preaparc -cortex-label -no-isrunning $hiresflag $fsthreads"
   RunIt "$cmd" $LF $CMDF
   ## copy nofix to orig and inflated for next step
@@ -696,9 +696,9 @@ for hemi in lh rh; do
 
 # ============================= INFLATE2 - CURVHK ===================================================
 
-  echo "echo \" \"" 2>&1 | tee -a $CMDF
-  echo "echo \"================== Creating surfaces $hemi - inflate2 ====================\"" 2>&1 | tee -a $CMDF
-  echo "echo \" \"" 2>&1 | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
+  echo "echo \"================== Creating surfaces $hemi - inflate2 ====================\"" | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
   # create nicer inflated surface from topo fixed (not needed, just later for visualization)
   cmd="recon-all -subject $subject -hemi $hemi -smooth2 -inflate2 -curvHK -no-isrunning $hiresflag $fsthreads"
   RunIt "$cmd" $LF $CMDF
@@ -706,9 +706,9 @@ for hemi in lh rh; do
 
 # ============================= MAP-DKT ==========================================================
 
-  echo "echo \" \"" 2>&1 | tee -a $CMDF
-  echo "echo \"=========== Creating surfaces $hemi - map input asegdkt_segfile to surf ===============\"" 2>&1 | tee -a $CMDF
-  echo "echo \" \"" 2>&1 | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
+  echo "echo \"=========== Creating surfaces $hemi - map input asegdkt_segfile to surf ===============\"" | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
   # sample input segmentation (aparc.DKTatlas+aseg orig) onto wm surface:
   # map input aparc to surface (requires thickness (and thus pail) to compute projfrac 0.5), here we do projmm which allows us to compute based only on white
   # this is dangerous, as some cortices could be < 0.6 mm, but then there is no volume label probably anyway.
@@ -718,7 +718,7 @@ for hemi in lh rh; do
   #RunIt "$cmd" $LF $CMDF
   #cmd="$python ${binpath}smooth_aparc.py --insurf $sdir/$hemi.white.preaparc --inaparc $ldir/$hemi.aparc.DKTatlas.mapped.prefix.annot --incort $ldir/$hemi.cortex.label --outaparc $ldir/$hemi.aparc.DKTatlas.mapped.annot"
   #RunIt "$cmd" $LF $CMDF
-  cmd="$python ${binpath}sample_parc.py --inseg $mdir/aparc.DKTatlas+aseg.orig.mgz --insurf $sdir/$hemi.white.preaparc --incort $ldir/$hemi.cortex.label --outaparc $ldir/$hemi.aparc.DKTatlas.mapped.annot --seglut ${binpath}$hemi.DKTatlaslookup.txt --surflut ${binpath}DKTatlaslookup.txt --projmm 0.6 --radius 2" 
+  cmd="$python ${binpath}sample_parc.py --inseg $mdir/aparc.DKTatlas+aseg.orig.mgz --insurf $sdir/$hemi.white.preaparc --incort $ldir/$hemi.cortex.label --outaparc $ldir/$hemi.aparc.DKTatlas.mapped.annot --seglut ${binpath}$hemi.DKTatlaslookup.txt --surflut ${binpath}DKTatlaslookup.txt --projmm 0.6 --radius 2"
   RunIt "$cmd" $LF $CMDF
 
 
@@ -726,17 +726,17 @@ for hemi in lh rh; do
 
   # if we segment with FS or if surface registration is requested do it here:
   if [ "$fsaparc" == "1" ] || [ "$fssurfreg" == "1" ] ; then
-    echo "echo \" \"" 2>&1 | tee -a $CMDF
-    echo "echo \"============ Creating surfaces $hemi - FS sphere, surfreg ===============\"" 2>&1 | tee -a $CMDF
-    echo "echo \" \"" 2>&1 | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
+  echo "echo \"============ Creating surfaces $hemi - FS sphere, surfreg ===============\"" | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
 
     # Surface registration for cross-subject correspondence (registration to fsaverage)
     cmd="recon-all -subject $subject -hemi $hemi -sphere $hiresflag -no-isrunning $fsthreads"
     RunIt "$cmd" $LF "$CMDF"
   
-    # (mr) FIX: sometimes FreeSurfer Sphere Reg. fails and moves pre and post central 
-    # one gyrus too far posterior, FastSurferCNN's image-based segmentation does not 
-    # seem to do this, so we initialize the spherical registration with the better 
+    # (mr) FIX: sometimes FreeSurfer Sphere Reg. fails and moves pre and post central
+    # one gyrus too far posterior, FastSurferCNN's image-based segmentation does not
+    # seem to do this, so we initialize the spherical registration with the better
     # cortical segmentation from FastSurferCNN, this replaces recon-all -surfreg
     # 1. get alpha, beta, gamma for global alignment (rotation) based on aseg centers
     # (note the former fix, initializing with pre-central label, is not working in FS7.2
@@ -765,18 +765,18 @@ for hemi in lh rh; do
 # ============================= WHITE & PIAL & (FSSURFSEG optional) ===============================================
 
   if [ "$fsaparc" == "1" ] ; then
-    echo "echo \" \"" 2>&1 | tee -a $CMDF
-    echo "echo \"============ Creating surfaces $hemi - FS asegdkt_segfile..pial ===============\"" 2>&1 | tee -a $CMDF
-    echo "echo \" \"" 2>&1 | tee -a $CMDF
+    echo "echo \" \"" | tee -a $CMDF
+    echo "echo \"============ Creating surfaces $hemi - FS asegdkt_segfile..pial ===============\"" | tee -a $CMDF
+    echo "echo \" \"" | tee -a $CMDF
     # 20-25 min for traditional surface segmentation (each hemi)
     # this creates aparc and creates pial using aparc, also computes jacobian
     cmd="recon-all -subject $subject -hemi $hemi -jacobian_white -avgcurv -cortparc -white -pial -no-isrunning $hiresflag $fsthreads"
     RunIt "$cmd" $LF $CMDF
     # Here insert DoT2Pial  later!
   else
-    echo "echo \" \"" 2>&1 | tee -a $CMDF
-    echo "echo \"================ Creating surfaces $hemi - white and pial direct ===================\"" 2>&1 | tee -a $CMDF
-    echo "echo \" \"" 2>&1 | tee -a $CMDF
+    echo "echo \" \"" | tee -a $CMDF
+    echo "echo \"================ Creating surfaces $hemi - white and pial direct ===================\"" | tee -a $CMDF
+    echo "echo \" \"" | tee -a $CMDF
 
     # 4 min compute white :
     echo "pushd $mdir" >> $CMDF
@@ -824,9 +824,9 @@ for hemi in lh rh; do
 
 
   if [ "$DoParallel" == "0" ] ; then
-    echo " " 2>&1 | tee -a $LF
-    echo " RUNNING $hemi sequentially ... " 2>&1 | tee -a $LF
-    echo " " 2>&1 | tee -a $LF
+    echo " " | tee -a $LF
+    echo " RUNNING $hemi sequentially ... " | tee -a $LF
+    echo " " | tee -a $LF
     chmod u+x $CMDF
     RunIt "$CMDF" $LF
   fi
@@ -837,9 +837,9 @@ done  # hemi loop ----------------------------------
 
 
 if [ "$DoParallel" == 1 ] ; then
-    echo " " 2>&1 | tee -a $LF
-    echo " RUNNING HEMIs in PARALLEL !!! " 2>&1 | tee -a $LF
-    echo " " 2>&1 | tee -a $LF
+    echo " " | tee -a $LF
+    echo " RUNNING HEMIs in PARALLEL !!! " | tee -a $LF
+    echo " " | tee -a $LF
     RunBatchJobs $LF $CMDFS
 fi
 
@@ -847,9 +847,9 @@ fi
 # ============================= RIBBON ===============================================
 
 
-  echo " " 2>&1 | tee -a $LF
-  echo "============================ Creating surfaces - ribbon ===========================" 2>&1 | tee -a $LF
-  echo " " 2>&1 | tee -a $LF
+  echo " " | tee -a $LF
+  echo "============================ Creating surfaces - ribbon ===========================" | tee -a $LF
+  echo " " | tee -a $LF
   # -cortribbon 4 minutes, ribbon is used in mris_anatomical stats to remove voxels from surface-based volumes that should not be cortex
   # anatomical stats can run without ribbon, but will omit some surface-based measures then
   # wmparc needs ribbon, probably other stuff (aparc to aseg etc).
@@ -861,22 +861,24 @@ fi
 # ============================= FSAPARC - parc23 surfcon hypo ... =========================================
 
   if [ "$fsaparc" == "1" ] ; then
-    echo " " 2>&1 | tee -a $LF
-    echo "============= Creating surfaces - other FS asegdkt_segfile and stats =======================" 2>&1 | tee -a $LF
-    echo " " 2>&1 | tee -a $LF
+    echo " " | tee -a $LF
+    echo "============= Creating surfaces - other FS asegdkt_segfile and stats =======================" | tee -a $LF
+    echo " " | tee -a $LF
     cmd="recon-all -subject $subject -cortparc2 -cortparc3 -pctsurfcon -hyporelabel $hiresflag $fsthreads"
     RunIt "$cmd" $LF
+  RunIt "$cmd" $LF
     cmd="recon-all -subject $subject -apas2aseg -aparc2aseg -wmparc -parcstats -parcstats2 -parcstats3 -segstats $hiresflag $fsthreads"
     RunIt "$cmd" $LF
     # removed -balabels here and do that below independent of fsaparc flag
+  # removed -balabels here and do that below independent of fsaparc flag
   fi  # (FS-APARC)
 
 
 # ============================= MAPPED SURF-STATS =========================================
 
-  echo " " 2>&1 | tee -a $LF
-  echo "===================== Creating surfaces - mapped stats =========================" 2>&1 | tee -a $LF
-  echo " " 2>&1 | tee -a $LF
+  echo " " | tee -a $LF
+  echo "===================== Creating surfaces - mapped stats =========================" | tee -a $LF
+  echo " " | tee -a $LF
   # 2x18sec create stats from mapped aparc
   for hemi in lh rh; do
     cmd="mris_anatomical_stats -th3 -mgz -cortex $ldir/$hemi.cortex.label -f $sdir/../stats/$hemi.aparc.DKTatlas.mapped.stats -b -a $ldir/$hemi.aparc.DKTatlas.mapped.annot -c $ldir/aparc.annot.mapped.ctab $subject $hemi white"
@@ -888,9 +890,9 @@ fi
 
   if [ "$fsaparc" == "0" ] ; then
 
-    echo " " 2>&1 | tee -a $LF
-    echo "============= Creating surfaces - pctsurfcon, hypo, segstats ====================" 2>&1 | tee -a $LF
-    echo " " 2>&1 | tee -a $LF
+  echo " " | tee -a $LF
+  echo "============= Creating surfaces - pctsurfcon, hypo, segstats ====================" | tee -a $LF
+  echo " " | tee -a $LF
 
     # pctsurfcon (has no way to specify which annot to use, so we need to link ours as aparc is not available)
     pushd $ldir
@@ -911,6 +913,7 @@ fi
     # -apas2aseg creates aseg.mgz by editing aseg.presurf.hypos.mgz with surfaces
     cmd="recon-all -subject $subject -hyporelabel -apas2aseg $hiresflag $fsthreads"
     RunIt "$cmd" $LF
+  RunIt "$cmd" $LF
   fi
 
 
@@ -924,18 +927,20 @@ fi
 
 # ============================= FASTSURFER - STATS =========================================
 
+if [ "$fsaparc" == "0" ] ; then
   if [ "$fsaparc" == "0" ] ; then
     # get stats for the aseg (note these are surface fine tuned, that may be good or bad, below we also do the stats for the input aseg (plus some processing)
     cmd="recon-all -subject $subject -segstats $hiresflag $fsthreads"
     RunIt "$cmd" $LF
+  RunIt "$cmd" $LF
   fi
 
 
 # ============================= MAPPED-WMPARC =========================================
 
-  echo " " 2>&1 | tee -a $LF
-  echo "===================== Creating wmparc from mapped =======================" 2>&1 | tee -a $LF
-  echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "===================== Creating wmparc from mapped =======================" | tee -a $LF
+echo " " | tee -a $LF
 
   # 1m 11sec also create stats for aseg.presurf.hypos (which is basically the aseg derived from the input with CC and hypos)
   # difference between this and the surface improved one above are probably tiny, so the surface improvement above can probably be skipped to save time
@@ -979,7 +984,7 @@ fi
   if [ "$fssurfreg" == "1" ] ; then
     # can be produced if surf registration exists
     #cmd="recon-all -subject $subject -balabels $hiresflag $fsthreads"
-    #RunIt "$cmd" $LF 
+    #RunIt "$cmd" $LF
     # here we run our version of balabels: mapping and annot creation is very fast
     # time is used in mris_anatomical_stats (called 4 times, BA and BA-thresh for each hemi)
     cmd="$python ${binpath}/fs_balabels.py --sd $SUBJECTS_DIR --sid $subject"
@@ -988,9 +993,9 @@ fi
 
 
 
-echo " " 2>&1 | tee -a $LF
-echo "================= DONE =========================================================" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "================= DONE =========================================================" | tee -a $LF
+echo " " | tee -a $LF
 
 # Collect info
 EndTime=`date`
@@ -998,9 +1003,9 @@ tSecEnd=`date '+%s'`
 tRunHours=`echo \($tSecEnd - $tSecStart\)/3600|bc -l`
 tRunHours=`printf %6.3f $tRunHours`
 
-echo "Started at $StartTime " 2>&1 | tee -a $LF
-echo "Ended   at $EndTime" 2>&1 | tee -a $LF
-echo "#@#%# recon-surf-run-time-hours $tRunHours" 2>&1 | tee -a $LF
+echo "Started at $StartTime " | tee -a $LF
+echo "Ended   at $EndTime" | tee -a $LF
+echo "#@#%# recon-surf-run-time-hours $tRunHours" | tee -a $LF
 
 # Create the Done File
 echo "------------------------------" > $DoneFile
@@ -1017,7 +1022,7 @@ echo "VERSION $VERSION"           >> $DoneFile
 echo "CMDPATH $0"                 >> $DoneFile
 echo "CMDARGS ${inputargs[*]}"    >> $DoneFile
 
-echo "recon-surf.sh $subject finished without error at `date`"  2>&1 | tee -a $LF
+echo "recon-surf.sh $subject finished without error at `date`"  | tee -a $LF
 
 cmd="$python ${binpath}utils/extract_recon_surf_time_info.py -i $LF -o $SUBJECTS_DIR/$subject/scripts/recon-surf_times.yaml"
 RunIt "$cmd" "/dev/null"

--- a/recon_surf/recon-surfreg.sh
+++ b/recon_surf/recon-surfreg.sh
@@ -109,11 +109,11 @@ function RunIt()
   if [[ $# -eq 3 ]]
   then
     CMDF=$3
-    echo "echo \"$cmd\" " 2>&1 | tee -a $CMDF
-    echo "$timecmd $cmd " 2>&1 | tee -a $CMDF
+    echo "echo \"$cmd\" " | tee -a $CMDF
+    echo "$timecmd $cmd " | tee -a $CMDF
     echo "if [ \${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi" >> $CMDF
   else
-    echo $cmd 2>&1 | tee -a $LF
+    echo $cmd | tee -a $LF
     $timecmd $cmd 2>&1 | tee -a $LF
     #if [ ${PIPESTATUS[0]} -ne 0 ] ; then exit 1 ; fi
   fi
@@ -357,27 +357,27 @@ LF=$SUBJECTS_DIR/$subject/scripts/recon-surfreg.log
 if [ $LF != /dev/null ] ; then  rm -f $LF ; fi
 echo "Log file for recon-surfreg.sh" >> $LF
 date  2>&1 | tee -a $LF
-echo "" 2>&1 | tee -a $LF
-echo "export SUBJECTS_DIR=$SUBJECTS_DIR" 2>&1 | tee -a $LF
-echo "cd `pwd`"  2>&1 | tee -a $LF
-echo $0 ${inputargs[*]} 2>&1 | tee -a $LF
-echo "" 2>&1 | tee -a $LF
+echo "" | tee -a $LF
+echo "export SUBJECTS_DIR=$SUBJECTS_DIR" | tee -a $LF
+echo "cd `pwd`"  | tee -a $LF
+echo $0 ${inputargs[*]} | tee -a $LF
+echo "" | tee -a $LF
 cat $FREESURFER_HOME/build-stamp.txt 2>&1 | tee -a $LF
-echo $VERSION 2>&1 | tee -a $LF
+echo $VERSION | tee -a $LF
 uname -a  2>&1 | tee -a $LF
 
 
 # Print parallelization parameters
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
 if [ "$DoParallel" == "1" ]
 then
-  echo " RUNNING both hemis in PARALLEL " 2>&1 | tee -a $LF
+  echo " RUNNING both hemis in PARALLEL " | tee -a $LF
 else
-  echo " RUNNING both hemis SEQUENTIALLY " 2>&1 | tee -a $LF
+  echo " RUNNING both hemis SEQUENTIALLY " | tee -a $LF
 fi
-echo " RUNNING $OMP_NUM_THREADS number of OMP THREADS " 2>&1 | tee -a $LF
-echo " RUNNING $ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS number of ITK THREADS " 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " RUNNING $OMP_NUM_THREADS number of OMP THREADS " | tee -a $LF
+echo " RUNNING $ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS number of ITK THREADS " | tee -a $LF
+echo " " | tee -a $LF
 
 
 #if false; then
@@ -396,9 +396,9 @@ for hemi in lh rh; do
   CMDFS="$CMDFS $CMDF"
   rm -rf $CMDF
 
-  echo "echo \" \"" 2>&1 | tee -a $CMDF
-  echo "echo \"============ Creating surfaces $hemi - FS sphere, surfreg ===============\"" 2>&1 | tee -a $CMDF
-  echo "echo \" \"" 2>&1 | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
+  echo "echo \"============ Creating surfaces $hemi - FS sphere, surfreg ===============\"" | tee -a $CMDF
+  echo "echo \" \"" | tee -a $CMDF
 
   # Surface registration for cross-subject correspondence (registration to fsaverage)
   cmd="recon-all -subject $subject -hemi $hemi -sphere -no-isrunning $fsthreads"
@@ -432,9 +432,9 @@ for hemi in lh rh; do
   #     $SUBJECTS_DIR/$subject/label/${hemi}.aparc.DKTatlas-guided.annot"
 
   if [ "$DoParallel" == "0" ] ; then
-      echo " " 2>&1 | tee -a $LF
-      echo " RUNNING $hemi sequentially ... " 2>&1 | tee -a $LF
-      echo " " 2>&1 | tee -a $LF
+      echo " " | tee -a $LF
+      echo " RUNNING $hemi sequentially ... " | tee -a $LF
+      echo " " | tee -a $LF
     chmod u+x $CMDF
     RunIt "$CMDF" $LF
   fi
@@ -444,16 +444,16 @@ done  # hemi loop ----------------------------------
 
 
 if [ "$DoParallel" == 1 ] ; then
-    echo " " 2>&1 | tee -a $LF
-    echo " RUNNING HEMIs in PARALLEL !!! " 2>&1 | tee -a $LF
-    echo " " 2>&1 | tee -a $LF
+    echo " " | tee -a $LF
+    echo " RUNNING HEMIs in PARALLEL !!! " | tee -a $LF
+    echo " " | tee -a $LF
     RunBatchJobs $LF $CMDFS
 fi
 
 
-echo " " 2>&1 | tee -a $LF
-echo "================= DONE =========================================================" 2>&1 | tee -a $LF
-echo " " 2>&1 | tee -a $LF
+echo " " | tee -a $LF
+echo "================= DONE =========================================================" | tee -a $LF
+echo " " | tee -a $LF
 
 # Collect info
 EndTime=`date`
@@ -461,9 +461,9 @@ tSecEnd=`date '+%s'`
 tRunHours=`echo \($tSecEnd - $tSecStart\)/3600|bc -l`
 tRunHours=`printf %6.3f $tRunHours`
 
-echo "Started at $StartTime " 2>&1 | tee -a $LF
-echo "Ended   at $EndTime" 2>&1 | tee -a $LF
-echo "#@#%# recon-surfreg-run-time-hours $tRunHours" 2>&1 | tee -a $LF
+echo "Started at $StartTime " | tee -a $LF
+echo "Ended   at $EndTime" | tee -a $LF
+echo "#@#%# recon-surfreg-run-time-hours $tRunHours" | tee -a $LF
 
 # Create the Done File
 echo "------------------------------" > $DoneFile
@@ -480,7 +480,7 @@ echo "VERSION $VERSION"           >> $DoneFile
 echo "CMDPATH $0"                 >> $DoneFile
 echo "CMDARGS ${inputargs[*]}"    >> $DoneFile
 
-echo "recon-surfreg.sh $subject finished without error at `date`"  2>&1 | tee -a $LF
+echo "recon-surfreg.sh $subject finished without error at `date`"  | tee -a $LF
 
 cmd="$python ${binpath}utils/extract_recon_surf_time_info.py -i $LF -o $SUBJECTS_DIR/$subject/scripts/recon-surfreg_times.yaml"
 RunIt "$cmd" "/dev/null"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -872,8 +872,8 @@ if [[ "$run_seg_pipeline" == "1" ]]
         "${cmd[@]}" 2>&1 | tee -a "$seg_log"
 
         echo "INFO: Robust scaling (partial conforming) of T2 image..." | tee -a "$seg_log"
-        cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_force_lia
-             --no_force_vox_size --no_force_img_size "$t2" "$conformed_name_t2")
+        cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_strict_lia
+             --no_vox_size --no_img_size "$t2" "$conformed_name_t2")
         "${cmd[@]}" 2>&1 | tee -a "$seg_log"
         echo "Done." | tee -a "$seg_log"
     fi


### PR DESCRIPTION
- Some fixes to the HypVINN pipeline 
  - formatting/doc
  - naming of HypoVINN->HypVINN (unified)
  - fix some errors with default hypvinn file names and arguments
  - generally improve and clean up the hypvinn interface and functions
- conform.py gets new flags `--no_lia`, `--no_strict_lia`, `--no_img_size`, `--no_vox_size` which deactivate parts of the conform script:
  - `no_lia`: rotation of the affine is not touched, image may remain RAS
  - `no_strict_lia`: rotation of the affine is adapted, but only towards LIA such that no interpolation would be necessary, but will also be LIA (never RAS)
  - `no_img_size` no padding/cropping of the image
  - `no_iso_vox`~`no_vox_size`~ no harmonization of voxel size, for example in combination with `no_strict_lia`, the image is not made iso. voxelsize
-  Cleanup of shell scripts
  -  Remove extra "2&>1" in shell scripts in echo statements (they never have stderr output)