### PR TITLE
Update Checkpoint Priority from Juelich to Zenodo

### DIFF
--- a/CerebNet/config/checkpoint_paths.yaml
+++ b/CerebNet/config/checkpoint_paths.yaml
@@ -1,6 +1,6 @@
 url:
-- "https://b2share.fz-juelich.de/api/files/c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5"
 - "https://zenodo.org/records/10390742/files"
+- "https://b2share.fz-juelich.de/api/files/c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5"
 
 checkpoint:
   axial:  "checkpoints/CerebNet_axial_v1.0.0.pkl"

--- a/FastSurferCNN/config/checkpoint_paths.yaml
+++ b/FastSurferCNN/config/checkpoint_paths.yaml
@@ -1,6 +1,6 @@
 url:
-- "https://b2share.fz-juelich.de/api/files/a423a576-220d-47b0-9e0c-b5b32d45fc59"
 - "https://zenodo.org/records/10390573/files"
+- "https://b2share.fz-juelich.de/api/files/a423a576-220d-47b0-9e0c-b5b32d45fc59"
 
 checkpoint:
   axial: "checkpoints/aparc_vinn_axial_v2.0.0.pkl"

--- a/HypVINN/config/checkpoint_paths.yaml
+++ b/HypVINN/config/checkpoint_paths.yaml
@@ -1,6 +1,6 @@
 url:
-- "https://b2share.fz-juelich.de/api/files/d9e37247-5455-4c83-853d-21e31fb5bea5"
 - "https://zenodo.org/records/11184216/files"
+- "https://b2share.fz-juelich.de/api/files/d9e37247-5455-4c83-853d-21e31fb5bea5"
 
 checkpoint:
   axial: "checkpoints/HypVINN_axial_v1.1.0.pkl"


### PR DESCRIPTION
Summary:
This pull request updates the checkpoint priority from Juelich to Zenodo.

Motivation:
The Juelich server has been unreliable in the past, experiencing frequent downtimes and other issues. To ensure more stable and reliable service, we are switching the checkpoint priority to Zenodo.