### PR TITLE
Fix fs_time check for number of arguments and line duplication in recon-surf

### DIFF
--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -104,7 +104,6 @@ wget --no-check-certificate -qO- $fslink  | tar zxv --no-same-owner -C $where \
       --exclude='freesurfer/average/Buckner_JNeurophysiol11_MNI152' \
       --exclude='freesurfer/average/Choi_JNeurophysiol12_MNI152' \
       --exclude='freesurfer/average/mult-comp-cor' \
-      --exclude='freesurfer/average/mult-comp-cor' \
       --exclude='freesurfer/average/samseg' \
       --exclude='freesurfer/average/Yeo_Brainmap_MNI152' \
       --exclude='freesurfer/average/Yeo_JNeurophysiol11_MNI152' \
@@ -270,7 +269,6 @@ copy_files="
   bin/mris_euler_number
   bin/mris_extract_main_component
   bin/mris_fix_topology
-  bin/mris_inflate
   bin/mris_inflate
   bin/mris_info
   bin/mris_jacobian

--- a/recon_surf/fs_time
+++ b/recon_surf/fs_time
@@ -117,7 +117,6 @@ function   arg1err()
 }
 
 inputargs=("$@")
-if [[ "$#" == 1 ]] ; then usage ; exit 0 ; fi
 any_help=$(echo "$@" | grep -e -help)
 if [[ -n "$any_help" ]]
 then
@@ -125,10 +124,10 @@ then
   help
   exit 0
 fi
-any_version=$(echo $argv | grep -e -version)
+any_version=$(echo "$@" | grep -e -version)
 if [[ -n "$any_version" ]]
 then
-  echo $VERSION
+  echo "$VERSION"
   exit 0
 fi
 
@@ -144,12 +143,12 @@ do
 
   case $flag in
     -o)
-      if [[ "$#" -lt 1 ]] ; then arg1err $flag; fi
+      if [[ "$#" -lt 1 ]] ; then arg1err "$flag"; fi
       outfile=$1
       shift
       ;;
     -k)
-      if [[ "$#" -lt 1 ]] ; then arg1err $flag ; fi
+      if [[ "$#" -lt 1 ]] ; then arg1err "$flag" ; fi
       key=$1
       shift
       ;;
@@ -161,7 +160,6 @@ do
       ;;
     -debug)
       verbose=1
-      echo=1
       ;;
     *)
       # must be at the start of the command to run
@@ -185,16 +183,16 @@ then
 fi
 
 # CHECK PARAMS
-if [[ ! -e /usr/bin/time ]]
-then
-  echo "ERROR: cannot find /usr/bin/time"
-  exit 1
-fi
-
 if [[ "${#cmd[@]}" == 0 ]]
 then
   usage
   echo "ERROR: no command passed to execute"
+  exit 1
+fi
+
+if [[ ! -e /usr/bin/time ]]
+then
+  echo "ERROR: cannot find /usr/bin/time"
   exit 1
 fi
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -866,11 +866,9 @@ fi
     echo " " | tee -a $LF
     cmd="recon-all -subject $subject -cortparc2 -cortparc3 -pctsurfcon -hyporelabel $hiresflag $fsthreads"
     RunIt "$cmd" $LF
-  RunIt "$cmd" $LF
     cmd="recon-all -subject $subject -apas2aseg -aparc2aseg -wmparc -parcstats -parcstats2 -parcstats3 -segstats $hiresflag $fsthreads"
     RunIt "$cmd" $LF
     # removed -balabels here and do that below independent of fsaparc flag
-  # removed -balabels here and do that below independent of fsaparc flag
   fi  # (FS-APARC)
 
 
@@ -890,9 +888,9 @@ fi
 
   if [ "$fsaparc" == "0" ] ; then
 
-  echo " " | tee -a $LF
-  echo "============= Creating surfaces - pctsurfcon, hypo, segstats ====================" | tee -a $LF
-  echo " " | tee -a $LF
+    echo " " | tee -a $LF
+    echo "============= Creating surfaces - pctsurfcon, hypo, segstats ====================" | tee -a $LF
+    echo " " | tee -a $LF
 
     # pctsurfcon (has no way to specify which annot to use, so we need to link ours as aparc is not available)
     pushd $ldir
@@ -913,7 +911,6 @@ fi
     # -apas2aseg creates aseg.mgz by editing aseg.presurf.hypos.mgz with surfaces
     cmd="recon-all -subject $subject -hyporelabel -apas2aseg $hiresflag $fsthreads"
     RunIt "$cmd" $LF
-  RunIt "$cmd" $LF
   fi
 
 
@@ -927,12 +924,10 @@ fi
 
 # ============================= FASTSURFER - STATS =========================================
 
-if [ "$fsaparc" == "0" ] ; then
   if [ "$fsaparc" == "0" ] ; then
     # get stats for the aseg (note these are surface fine tuned, that may be good or bad, below we also do the stats for the input aseg (plus some processing)
     cmd="recon-all -subject $subject -segstats $hiresflag $fsthreads"
     RunIt "$cmd" $LF
-  RunIt "$cmd" $LF
   fi
 
 


### PR DESCRIPTION
This PR addresses a bug in recon_surf that caused errors, if --parallel was not passed. This Bug was reported in #543 .
It also addresses duplicate lines in recon-surf.sh, which seems to be a rebase artifact.