### PR TITLE
Separate doc for stable and remove doctrees folder

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,7 +5,7 @@ concurrency:
 on:
   pull_request:
   push:
-    branches: [dev]
+    branches: [dev, stable]
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          path: ./dev
+          path: src
       - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
@@ -29,14 +29,16 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --progress-bar off --upgrade pip setuptools wheel
-          python -m pip install --progress-bar off dev/.[doc]
+          python -m pip install --progress-bar off src/.[doc]
       - name: Build doc
-        run: PYTHONPATH=$PYTHONPATH:./dev TZ=UTC sphinx-build ./dev/doc ./doc-build/dev -W --keep-going
+        run: PYTHONPATH=$PYTHONPATH:src TZ=UTC sphinx-build src/doc doc-build -W --keep-going
       - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:
-          name: doc-dev
-          path: ./doc-build/dev
+          name: doc
+          path: |
+            doc-build
+            !doc-build/.doctrees
 
   deploy:
     if: github.event_name == 'push'
@@ -52,13 +54,14 @@ jobs:
       - name: Download documentation
         uses: actions/download-artifact@v4
         with:
-          name: doc-dev
-          path: ./doc-dev
+          name: doc
+          path: doc
       - name: Deploy dev documentation
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc-dev
-          destination_dir: ./dev
+          publish_dir: doc
+          # destination_dir: github.event.ref_name will be dev or stable
+          destination_dir: ${{ github.event.ref_name }}
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ doc = [
     'memory-profiler',
     'myst-parser',
     'numpydoc',
-    'sphinx!=7.2.*',
+    # sphinx 8 handles importing of files differently in some manner and will cause the
+    # build of the doc to fail. This will need to be addressed before we up to sphinx 8.
+    'sphinx>=7.3,<8',
     'sphinxcontrib-bibtex',
     'sphinxcontrib-programoutput',
     'sphinx-argparse',


### PR DESCRIPTION
Add stable targets as an additional target
Remove doctree files from deployment: doctree files are binary files bloating the gh_pages branch unnecessarily.