### PR TITLE
Fallback for unoriented triangles in sample_parc

### DIFF
--- a/doc/api/recon_surf.rst
+++ b/doc/api/recon_surf.rst
@@ -15,6 +15,7 @@ recon_surf
     map_surf_label
     N4_bias_correct
     paint_cc_into_pred
+    rewrite_oriented_surface
     rewrite_mc_surface
     rotate_sphere
     sample_parc

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -690,12 +690,10 @@ for hemi in lh rh; do
   cmd="recon-all -subject $subject -hemi $hemi -fix -no-isrunning $hiresflag $fsthreads"
   RunIt "$cmd" $LF $CMDF
 
-  # rename the freesurfer preaparc surface
-  cmd="mv $sdir/$hemi.orig.premesh $sdir/$hemi.orig.premesh.noorient"
-  RunIt "$cmd" $LF $CMDF
-
   # fix the surfaces if they are corrupt
-  cmd="$python ${binpath}rewrite_oriented_surface.py -i $sdir/$hemi.orig.premesh.noorient -o $sdir/$hemi.orig.premesh"
+  cmd="$python ${binpath}rewrite_oriented_surface.py --file $sdir/$hemi.orig.premesh --backup $sdir/$hemi.orig.premesh.noorient"
+  RunIt "$cmd" $LF $CMDF
+  cmd="$python ${binpath}rewrite_oriented_surface.py --file $sdir/$hemi.orig --backup $sdir/$hemi.orig.noorient"
   RunIt "$cmd" $LF $CMDF
 
   cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -white-preaparc -cortex-label -no-isrunning $hiresflag $fsthreads"

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -703,6 +703,14 @@ for hemi in lh rh; do
   cmd="recon-all -subject $subject -hemi $hemi -smooth2 -inflate2 -curvHK -no-isrunning $hiresflag $fsthreads"
   RunIt "$cmd" $LF $CMDF
 
+  # rename the freesurfer preaparc surface
+  cmd="mv $sdir/$hemi.white.preaparc $sdir/$hemi.white.preaparc.nofix"
+  RunIt "$cmd" $LF $CMDF
+
+  # fix the surfaces if they are corrupt
+  cmd="$python ${binpath}rewrite_oriented_surface.py -i $sdir/$hemi.white.preaparc.nofix -o $sdir/$hemi.white.preaparc"
+  RunIt "$cmd" $LF $CMDF
+
 
 # ============================= MAP-DKT ==========================================================
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -687,7 +687,18 @@ for hemi in lh rh; do
   echo "echo " | tee -a $CMDF
   echo "echo \"=================== Creating surfaces $hemi - fix ========================\"" | tee -a $CMDF
   echo "echo " | tee -a $CMDF
-  cmd="recon-all -subject $subject -hemi $hemi -fix -autodetgwstats -white-preaparc -cortex-label -no-isrunning $hiresflag $fsthreads"
+  cmd="recon-all -subject $subject -hemi $hemi -fix -no-isrunning $hiresflag $fsthreads"
+  RunIt "$cmd" $LF $CMDF
+
+  # rename the freesurfer preaparc surface
+  cmd="mv $sdir/$hemi.orig.premesh $sdir/$hemi.orig.premesh.noorient"
+  RunIt "$cmd" $LF $CMDF
+
+  # fix the surfaces if they are corrupt
+  cmd="$python ${binpath}rewrite_oriented_surface.py -i $sdir/$hemi.orig.premesh.noorient -o $sdir/$hemi.orig.premesh"
+  RunIt "$cmd" $LF $CMDF
+
+  cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -white-preaparc -cortex-label -no-isrunning $hiresflag $fsthreads"
   RunIt "$cmd" $LF $CMDF
   ## copy nofix to orig and inflated for next step
   # -white (don't know how to call this from recon-all as it needs -whiteonly setting and by default it also creates the pial.
@@ -701,14 +712,6 @@ for hemi in lh rh; do
   echo "echo \" \"" | tee -a $CMDF
   # create nicer inflated surface from topo fixed (not needed, just later for visualization)
   cmd="recon-all -subject $subject -hemi $hemi -smooth2 -inflate2 -curvHK -no-isrunning $hiresflag $fsthreads"
-  RunIt "$cmd" $LF $CMDF
-
-  # rename the freesurfer preaparc surface
-  cmd="mv $sdir/$hemi.white.preaparc $sdir/$hemi.white.preaparc.nofix"
-  RunIt "$cmd" $LF $CMDF
-
-  # fix the surfaces if they are corrupt
-  cmd="$python ${binpath}rewrite_oriented_surface.py -i $sdir/$hemi.white.preaparc.nofix -o $sdir/$hemi.white.preaparc"
   RunIt "$cmd" $LF $CMDF
 
 

--- a/recon_surf/rewrite_oriented_surface.py
+++ b/recon_surf/rewrite_oriented_surface.py
@@ -1,0 +1,102 @@
+# Copyright 2024 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# IMPORTS
+import sys
+import argparse
+from pathlib import Path
+
+import lapy
+
+__version__ = "1.0"
+
+
+def make_parser() -> argparse.ArgumentParser:
+    """
+    Create a command line interface and return command line options.
+
+    Returns
+    -------
+    options
+        Namespace object holding options.
+    """
+    parser = argparse.ArgumentParser(
+        description="Script to load and safe surface (that are guaranteed to be "
+                    "correctly oriented) under a given name",
+    )
+    parser.add_argument(
+        "--input", "-i",
+        type=Path,
+        dest="input_surf",
+        help="path to input surface",
+        required=True,
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        dest="output_surf",
+        help="path to output surface",
+        required=True,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"{__version__} 2024/08/08 12:20:10 kueglerd",
+    )
+    return parser
+
+
+def resafe_surface(insurf: Path | str, outsurf: Path | str) -> None:
+    """
+    Take path to insurf and rewrite it to outsurf thereby fixing improperly oriented triangles.
+
+    Parameters
+    ----------
+    insurf : Path, str
+        Path and name of input surface.
+    outsurf : Path, str
+        Path and name of output surface.
+    """
+    import getpass
+    try:
+        getpass.getuser()
+    except Exception:
+        # nibabel crashes in write_geometry, if getpass.getuser does not return
+        # make sure the process has a username
+        from os import environ
+        environ.setdefault("USERNAME", "UNKNOWN")
+
+    triamesh = lapy.TriaMesh.read_fssurf(str(insurf))
+
+    # make sure the triangles are oriented (normals pointing to the same direction
+    if not triamesh.is_oriented():
+        print("Surface was not oriented, flipping corrupted normals.")
+        triamesh.orient_()
+    else:
+        print("Surface was oriented.")
+
+    triamesh.write_fssurf(str(outsurf))
+
+
+if __name__ == "__main__":
+    # Command Line options are error checking done here
+    parser = make_parser()
+    args = parser.parse_args()
+    surf_in = args.input_surf
+    surf_out = args.output_surf
+
+    print(f"Reading in surface: {surf_in} ...")
+    resafe_surface(surf_in, surf_out)
+    print(f"Outputting surface as: {surf_out}")
+    sys.exit(0)

--- a/recon_surf/sample_parc.py
+++ b/recon_surf/sample_parc.py
@@ -295,6 +295,12 @@ def sample_img(surf, img, cortex=None, projmm=0.0, radius=None):
     data = np.asarray(img.dataobj)
     # Use LaPy TriaMesh for vertex normal computation
     T = TriaMesh(surf[0], surf[1])
+
+    # make sure the triangles are oriented (normals pointing to the same direction
+    if not T.is_oriented():
+        print("WARNING: Surface is not oriented, flipping corrupted normals.")
+        T.orient_()
+
     # compute sample coordinates projmm mm along the surface normal
     # in surface RAS coordiante system:
     x = T.v + projmm * T.vertex_normals()


### PR DESCRIPTION
This fallback fixes rare crashes of the recon_surf pipeline, where mris_place_surface generates triangle meshes with inconsistent orientation. The added check detects and fixes these cases. I recommend to include the failing cases in the release testing for the next release to make sure there are no other effects somewhere else in the pipeline.