### PR TITLE
Fix the whitespace formatting of segstats

### DIFF
--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -495,6 +495,11 @@ class Inference:
                                 segfile=subject.segfile,
                                 normfile=norm_file,
                                 lut=self.freesurfer_lut_file,
+                                volume_precision="3",
+                                exclude=0,
+                                pvfile=norm_file,
+                                report_empty=True,
+                                extra_header=[],
                             )
                         )
 

--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -26,7 +26,7 @@ from tqdm import tqdm
 
 from FastSurferCNN.utils import logging, Plane, PLANES
 from FastSurferCNN.utils.threads import get_num_threads
-from FastSurferCNN.utils.mapper import JsonColorLookupTable, TSVLookupTable
+from FastSurferCNN.utils.mapper import JsonColorLookupTable, TSVLookupTable, Mapper
 from FastSurferCNN.utils.common import (
     find_device,
     SubjectList,
@@ -50,6 +50,11 @@ class Inference:
     Manages inference operations, including batch processing, data loading, and model
     predictions for neuroimaging data.
     """
+
+    cerebnet_labels: Mapper[str, int]
+    cereb_name2fs_id: Mapper[str, int]
+    freesurfer_name2id: Mapper[str, int]
+
     def __init__(
         self,
         cfg: "yacs.config.CfgNode",
@@ -128,8 +133,12 @@ class Inference:
 
         self.cerebnet_labels = _cerebnet_mapper.result().labelname2id()
         self.freesurfer_name2id = fs_color_map.result().labelname2id()
-        cereb_name2fs_name = cereb2freesurfer_mapper.result().labelname2id()
-        cerebsag_name2cereb_name = sagittal_cereb2cereb_mapper.result().labelname2id()
+        cereb_name2fs_name: Mapper[str, str] = (
+            cereb2freesurfer_mapper.result().labelname2id()
+        )
+        cerebsag_name2cereb_name: Mapper[str, str] = (
+            sagittal_cereb2cereb_mapper.result().labelname2id()
+        )
 
         cereb_id2name = self.cerebnet_labels.__reversed__()
         self.cereb_name2fs_id = cereb_name2fs_name.chain(self.freesurfer_name2id)
@@ -421,7 +430,7 @@ class Inference:
             norm_file, _, norm_data = norm.result()
         return norm_data, norm_file, subject_dataset
 
-    def run(self, subject_directories: SubjectList):
+    def run(self, subject_dirs: SubjectList):
         logger.info(time.strftime("%y-%m-%d_%H:%M:%S"))
 
         from tqdm.contrib.logging import logging_redirect_tqdm
@@ -432,12 +441,10 @@ class Inference:
                 from FastSurferCNN.utils.common import pipeline as iterate
             else:
                 from FastSurferCNN.utils.common import iterate
-            iter_subjects = iterate(
-                self.pool, self._get_subject_dataset, subject_directories
-            )
+            iter_subjects = iterate(self.pool, self._get_subject_dataset, subject_dirs)
             futures = []
             for idx, (subject, (norm, norm_file, subject_dataset)) in tqdm(
-                enumerate(iter_subjects), total=len(subject_directories), desc="Subject"
+                enumerate(iter_subjects), total=len(subject_dirs), desc="Subject",
             ):
                 try:
                     # predict CerebNet, returns logits
@@ -465,9 +472,8 @@ class Inference:
                         target_shape=bounding_box["source_shape"],
                     ).numpy()
 
-                    _ = (
-                        _mkdir.result()
-                    )  # this is None, but synchronizes the creation of the directory
+                    # this is None, but synchronizes the creation of the directory
+                    _ = _mkdir.result()
                     futures.append(
                         self._save_cerebnet_seg(
                             full_cereb_seg,
@@ -504,7 +510,7 @@ class Inference:
                         )
 
                     logger.info(
-                        f"Subject {idx + 1}/{len(subject_directories)} with id "
+                        f"Subject {idx + 1}/{len(subject_dirs)} with id "
                         f"'{subject.id}' processed in {pred_time - start_time :.2f} "
                         f"sec."
                     )

--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -502,7 +502,7 @@ class Inference:
                                 normfile=norm_file,
                                 lut=self.freesurfer_lut_file,
                                 volume_precision="3",
-                                exclude=0,
+                                exclude=[0],
                                 pvfile=norm_file,
                                 report_empty=True,
                                 extra_header=[],

--- a/CerebNet/run_prediction.py
+++ b/CerebNet/run_prediction.py
@@ -162,7 +162,7 @@ def main(args: argparse.Namespace) -> int | str:
 
     # Check input and output options and get all subjects of interest
     subjects = SubjectList(
-        args, asegdkt_segfile="pred_name", segfile="cereb_segfile", **subjects_kwargs
+        args, asegdkt_segfile="pred_name", segfile="cereb_segfile", **subjects_kwargs,
     )
 
     try:

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -1324,6 +1324,9 @@ def write_statsfile(
     if segfile is not None and not isinstance(segfile, Path):
         segfile = Path(segfile)
 
+    if exclude is not None and not isinstance(exclude, Sequence):
+        raise RuntimeError("exclude must be a sequence of ints or None!")
+
     segstatsfile.parent.mkdir(exist_ok=True)
     with open(segstatsfile, "w") as fp:
         _title(fp)

--- a/FastSurferCNN/utils/mapper.py
+++ b/FastSurferCNN/utils/mapper.py
@@ -461,22 +461,24 @@ class Mapper(Generic[KT, VT]):
         Returns
         -------
         Mapper : "Mapper[KT, T_OtherValue]"
-            A mapper mapping from the input space of this mapper to the target-space of the `other_mapper`.
+            A mapper mapping from the input space of this mapper to the target-space of
+            the `other_mapper`.
         """
         target_space = list(self.target_space)
         is_target_set = [not isinstance(t, Hashable) for t in target_space]
         if any(is_target_set):
             index = is_target_set.index(True)
             raise ValueError(
-                f"The target space must be hashable, but {is_target_set.count(True)} values are not "
-                f"hashable, for example {index}: {target_space[index]}."
+                f"The target space must be hashable, but {is_target_set.count(True)} "
+                f"values are not hashable, for example {index}: {target_space[index]}."
             )
         target_space = set(target_space)
         if not target_space <= other_mapper.source_space:
-            # test whether every element in self.target_space is also in other_mapper.source_space
+            # test whether every element in self.target_space is also in
+            # other_mapper.source_space
             raise ValueError(
-                f"The first set ({self.name}) maps to the following keys, that the second mapper "
-                f"({other_mapper.name}) does not map from:\n  "
+                f"The first set ({self.name}) maps to the following keys, that the "
+                f"second mapper ({other_mapper.name}) does not map from:\n  "
                 + ", ".join(f"'{v}'" for v in target_space - other_mapper.source_space)
             )
         return Mapper(
@@ -1060,7 +1062,8 @@ class TSVLookupTable(ColorLookupTable[str]):
         Returns
         -------
         Mapper[KT, Any]
-            A Mapper object that links keys to their corresponding values based on the class and data index.
+            A Mapper object that links keys to their corresponding values based on the
+            class and data index.
 
         Raises
         ------

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1006,12 +1006,8 @@ fi
          # --excl-ctxgmwm: exclude Left/Right WM / Cortex despite ASegStatsLUT.txt
          --excludeid 0 2 3 41 42
          --lut "$FREESURFER_HOME/ASegStatsLUT.txt" --threads "$threads" --empty
+         --volume_precision 1
          measures --file "$statsdir/aseg.stats" --import "all")
-    #    --compute "Mask($mask_name)" "BrainSeg" "BrainSegNotVent" "SupraTentorial"
-    #              "SupraTentorialNotVent" "SubCortGray" "EstimatedTotalIntraCranialVol"
-    #              "rhCerebralWhiteMatter" "lhCerebralWhiteMatter" "CerebralWhiteMatter"
-    #              "rhCortex" "lhCortex" "Cortex" "TotalGray" "rhSurfaceHoles"
-    #              "lhSurfaceHoles" "SurfaceHoles" "BrainSegVol-to-eTIV" "MaskVol-to-eTIV"
   fi
   RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
   # -wmparc based on mapped aparc labels (from input asegdkt_segfile) (1min40sec) needs ribbon and we need to point it to aparc.mapped:
@@ -1035,6 +1031,7 @@ fi
          --segfile "$mdir/wmparc.DKTatlas.mapped.mgz" --normfile "$mdir/norm.mgz"
          --lut "$FREESURFER_HOME/WMParcStatsLUT.txt" --threads "$threads"
          --segstatsfile "$statsdir/wmparc.DKTatlas.mapped.stats" --empty
+         --volume_precision 1
          measures --file "$statsdir/brainvol.stats" --import "Mask"
                   "VentricleChoroidVol" "rhCerebralWhiteMatter" "lhCerebralWhiteMatter"
                   "CerebralWhiteMatter")


### PR DESCRIPTION
This PR makes the whitespace patterns of segstats.py "more" identical with mri_segstats.

Both states work with mri_stats2table, but there other external scripts might be more strict in reading the csv portion of files and specifically using different scanf statements which might not match.

Users can still modify the formatting slightly, by adding more "volume_precision" (parameter to segstats.py), which will increase the number of digits after the colon, but by default, this is 1 in FreeSurfer's mri_segstats and thus we also pass --volume_precision 1 in recon-surf.

This PR also has some minor formatting changes in the code, but the key difference is formatting of the statsfile.