### PR TITLE
BUG: --allow_root does not work for segstats module in hypvinn.

### DIFF
--- a/HypVINN/utils/stats_utils.py
+++ b/HypVINN/utils/stats_utils.py
@@ -71,5 +71,7 @@ def compute_stats(
     args.patch_size = 32
     args.device = "auto"
     args.lut = FASTSURFER_ROOT / "FastSurferCNN/config/FreeSurferColorLUT.txt"
-    args.allow_root = False
+    # We check for this in the parent code
+    # TODO: it would be better to populate this properly
+    args.allow_root = True
     return main(args)


### PR DESCRIPTION
Because `allow_root` is hard coded to `False` in hypvinn/utils/stats_utils.py, computing stats for hypvinn crashes Fastsurfer when running as root despite passing the flag `--allow_root`. 

This PR changes allow_root (hard coded) to True, which is suboptimal, but fine. This always satisfies the check in segstats (for hypvinn). But this check is also performed in hypvinn/run_prediction.py (so the check in segstats is redundant anyways).