### PR TITLE
The FreeSurfer license is often in the FREESURFER_HOME directory, but FastSurfer does not detect it there.

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -162,6 +162,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add FreeSurfer and python Environment variables
+# DO_NOT_SEARCH_FS_LICENSE_IN_FREESURFER_HOME=true deactivates the search for FS_LICENSE in FREESURFER_HOME
 ENV OS=Linux \
     FS_OVERRIDE=0 \
     FIX_VERTEX_AREA="" \
@@ -171,7 +172,8 @@ ENV OS=Linux \
     PYTHONUNBUFFERED=0 \
     MPLCONFIGDIR=/tmp \
     PATH=/venv/bin:/opt/freesurfer/bin:$PATH \
-    MPLCONFIGDIR=/tmp/matplotlib-config
+    MPLCONFIGDIR=/tmp/matplotlib-config \
+    DO_NOT_SEARCH_FS_LICENSE_IN_FREESURFER_HOME="true"
 
 # create matplotlib config dir; make sure we use bash and activate conda env
 #  (in case someone starts this interactively)

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -697,8 +697,24 @@ then
   msg="The surface pipeline and the talairach-registration in the segmentation pipeline require a FreeSurfer License"
   if [[ -z "$FS_LICENSE" ]]
   then
-    echo "ERROR: $msg, but no license was provided via --fs_license or the FS_LICENSE environment variable."
-    exit 1;
+    msg="$msg, but no license was provided via --fs_license or the FS_LICENSE environment variable."
+    if [[ "$DO_NOT_SEARCH_FS_LICENSE_IN_FREESURFER_HOME" != "true" ]] && [[ -n "$FREESURFER_HOME" ]]
+    then
+      echo "WARNING: $msg Checking common license files in \$FREESURFER_HOME."
+      for filename in "license.dat" "license.txt" ".license"
+      do
+        if [[ -f "$FREESURFER_HOME/$filename" ]]
+        then
+          echo "Trying with '$FREESURFER_HOME/$filename', specify a license with --fs_license to overwrite."
+          export FS_LICENSE="$FREESURFER_HOME/$filename"
+          break
+        fi
+      done
+      if [[ -z "$FS_LICENSE" ]]; then echo "ERROR: No license found..." ; exit 1 ; fi
+    else
+      echo "ERROR: $msg"
+      exit 1;
+    fi
   elif [[ ! -f "$FS_LICENSE" ]]
   then
     echo "ERROR: $msg, but the provided path is not a file: $FS_LICENSE."


### PR DESCRIPTION
Add Code to run_fastsurfer, that detects the license from FREESURFER_HOME. 
Also add an environment variable to deactivate this search from inside a container.