### PR TITLE
Fix content of buildlog file

### DIFF
--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -740,7 +740,7 @@ trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" >> \"$s
 
 # create the build log, file with all version info in parallel
 printf "%s %s\n%s\n" "$THIS_SCRIPT" "${inputargs[*]}" "$(date -R)" >> "$build_log"
-$python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}" >> "$build_log" &
+$python "$FASTSURFER_HOME/FastSurferCNN/version.py" --sections all -o "$build_log" --prefer_cache &
 
 if [[ "$run_seg_pipeline" != "1" ]]
 then


### PR DESCRIPTION
The SUBJECTS_DIR/IMAGE_ID/scripts/build.log file currently only contains the information "specifically requested", which on principle only is the version number. This commit fixes the parameters to the version script, so build.log contains the expected information such as python packages, model checkpoints and git status.