### PR TITLE
Update the documentation for release/changes

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -21,6 +21,27 @@ docker pull deepmi/fastsurfer:cpu-v2.2.2
 After pulling the image, you can start a FastSurfer container and process a T1-weighted image (both segmentation and surface reconstruction) with the following command:
 
 ```bash
+docker run --gpus all \
+         -B /share/my/my/mri_data \
+         -B /share/my/fastsurfer_analysis \
+         -B /share/software/freesurfer/license.txt:/.fslicense \
+         --rm --user $(id -u):$(id -g) \
+         deepmi/fastsurfer:cuda-v2.3.0 \
+         --t1 /share/my/mri_data/participant1/image1.nii.gz \
+         --sd /share/my/fastsurfer_analysis \
+         --sid part1_img1 \
+         --fs_license /.fslicense
+```
+
+
+   The `--gpus` flag is needed to allow FastSurfer to run on the GPU (otherwise FastSurfer will run on the CPU).
+
+   The `-v` flag is used to tell docker, which folders FastSurfer can read and write to.
+ 
+
+
+
+```bash
 docker run --gpus all -v /home/user/my_mri_data:/data \
                       -v /home/user/my_fastsurfer_analysis:/output \
                       -v /home/user/my_fs_license_dir:/fs_license \

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -42,9 +42,9 @@ docker run --gpus all \
 
 
 ```bash
-docker run --gpus all -v /home/user/my_mri_data:/data \
-                      -v /home/user/my_fastsurfer_analysis:/output \
-                      -v /home/user/my_fs_license_dir:/fs_license \
+docker run --gpus all -v $HOME/my_mri_data:/data \
+                      -v $HOME/my_fastsurfer_analysis:/output \
+                      -v $HOME/my_fs_license_dir:/fs_license \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
@@ -64,14 +64,14 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 
 #### FastSurfer Flags
 * The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the `my_fs_license_dir` that was mapped above. 
-* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
+* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: $HOME/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
-* The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
+* The `--sd` points to the output directory (its mounted name inside docker: $HOME/my_fastsurfer_analysis => /output)
 * The `--parallel` activates processing left and right hemisphere in parallel
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments. 
 
-A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory (specified via `--sd`). So in this example output will be written to /home/user/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory (specified via `--sd`). So in this example output will be written to $HOME/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
 
 All other available flags are identical to the ones explained on the main page [README](../README.md).
 
@@ -102,7 +102,7 @@ Also note, in order to run our Docker containers on a Mac, users need to increas
 The build script `build.py` supports additional args, targets and options, see `python Docker/build.py --help`.
 
 Note, that the build script's main function is to select parameters for build args, but also create the FastSurfer-root/BUILD.info file, which will be used by FastSurfer to document the version (including git hash of the docker container). This BUILD.info file must exist for the docker build to be successful.
-In general, if you specify `--dry_run` the command will not be executed but sent to stdout, so you can run `python build.py --device cuda --dry_run | bash` as well. Note, that build.py uses some dependencies from FastSurfer, so you will need to set the PYTHONPATH environment variable to the FastSurfer root (include of `FastSurferCNN` must be possible) and we only support Python 3.10.
+In general, if you specify `--dry_run` the command will not be executed but sent to stdout, so you can run `python build.py --device cuda --dry_run | bash` as well. Note, we only support Python 3.10.
 
 By default, the build script will tag your image as `"fastsurfer:[{device}-]{version_tag}"`, where `{version_tag}` is `{version-identifer from pyproject.toml}_{current git-hash}` and `{device}` is the value to `--device` (omitted for `cuda`), but a custom tag can be specified by `--tag {tag_name}`. 
 
@@ -114,20 +114,20 @@ Note, we recommend using BuildKit to build docker images (e.g. `DOCKER_BUILDKIT=
 In order to build your own Docker image for FastSurfer (FastSurferCNN + recon-surf; on GPU; including FreeSurfer) yourself simply execute the following command after traversing into the *Docker* directory: 
 
 ```bash
-PYTHONPATH=<FastSurferRoot>
-python build.py --device cuda --tag my_fastsurfer:cuda
+python Docker/build.py --device cuda --tag my_fastsurfer:cuda
 ```
 
 For running the analysis, the command is the same as above for the prebuild option:
 ```bash
-docker run --gpus all -v /home/user/my_mri_data:/data \
-                      -v /home/user/my_fastsurfer_analysis:/output \
-                      -v /home/user/my_fs_license_dir:/fs_license \
-                      --rm --user $(id -u):$(id -g) my_fastsurfer:cuda \
-                      --fs_license /fs_license/license.txt \
-                      --t1 /data/subjectX/t1-weighted.nii.gz \
-                      --sid subjectX --sd /output \
-                      --parallel
+docker run --gpus all \
+           -v $HOME/my_mri_data:$HOME/my_mri_data \
+           -v $HOME/my_fastsurfer_analysis:$HOME/my_fastsurfer_analysis \
+           -v $HOME/my_fs_license.txt:$HOME/my_fs_license.txt \
+               --rm --user $(id -u):$(id -g) my_fastsurfer:cuda \
+               --fs_license $HOME/my_fs_license.txt \
+               --t1 $HOME/my_mri_data/subjectX/t1-weighed.nii.gz \
+               --sid subjectX --sd $HOME/my_fastsurfer_analysis \
+               --parallel
 ```
 
 
@@ -136,21 +136,20 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 In order to build the docker image for FastSurfer (FastSurferCNN + recon-surf; on CPU; including FreeSurfer) simply go to the parent directory (FastSurfer) and execute the docker build command directly:
 
 ```bash
-PYTHONPATH=<FastSurferRoot>
-python build.py --device cpu --tag my_fastsurfer:cpu
+python Docker/build.py --device cpu --tag my_fastsurfer:cpu
 ```
 
 For running the analysis, the command is basically the same as above for the GPU option:
 ```bash
-docker run -v /home/user/my_mri_data:/data \
-           -v /home/user/my_fastsurfer_analysis:/output \
-           -v /home/user/my_fs_license_dir:/fs_license \
+docker run -v $HOME/my_mri_data:$HOME/my_mri_data \
+           -v $HOME/my_fastsurfer_analysis:$HOME/my_fastsurfer_analysis \
+           -v $HOME/my_fs_license.txt:$HOME/my_fs_license.txt \
            --rm --user $(id -u):$(id -g) my_fastsurfer:cpu \
-           --fs_license /fs_license/license.txt \
-           --t1 /data/subjectX/t1-weighed.nii.gz \
-           --device cpu \
-           --sid subjectX --sd /output \
-           --parallel
+               --fs_license $HOME/my_fs_license.txt \
+               --t1 $HOME/my_mri_data/subjectX/t1-weighed.nii.gz \
+               --device cpu \
+               --sid subjectX --sd $HOME/my_fastsurfer_analysis \
+               --parallel
 ```
 
 As you can see, only the tag of the image is changed from gpu to cpu and the standard docker is used (no --gpus defined). In addition, the `--device cpu` flag is passed to explicitly turn on CPU usage inside FastSurferCNN.
@@ -163,8 +162,7 @@ your host machine kernel (amdgpu-install --usecase=dkms) for the amd docker to w
 https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html#rocm-install-quick, https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/amdgpu-install.html#amdgpu-install-dkms and https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
 
 ```bash
-PYTHONPATH=<FastSurferRoot>
-python build.py --device rocm --tag my_fastsurfer:rocm
+python Docker/build.py --device rocm --tag my_fastsurfer:rocm
 ```
 
 and run segmentation only:
@@ -172,11 +170,15 @@ and run segmentation only:
 ```bash
 docker run --rm --security-opt seccomp=unconfined \
            --device=/dev/kfd --device=/dev/dri --group-add video \
-	   -v /home/user/my_mri_data:/data \
-	   -v /home/user/my_fastsurfer_analysis:/output \
-	   my_fastsurfer:rocm \
-	   --t1 /data/subjectX/t1-weighted.nii.gz \
-	   --sid subjectX --sd /output 
+	       -v $HOME/my_mri_data:$HOME/my_mri_data \
+           -v $HOME/my_fastsurfer_analysis:$HOME/my_fastsurfer_analysis \
+           -v $HOME/my_fs_license.txt:$HOME/my_fs_license.txt \
+           --rm --user $(id -u):$(id -g) my_fastsurfer:rocm \
+               --fs_license $HOME/my_fs_license.txt \
+               --t1 $HOME/my_mri_data/subjectX/t1-weighed.nii.gz \
+               --sid subjectX --sd $HOME/my_fastsurfer_analysis \
+               --parallel \
+               # alternatively: --device cuda is also possible (or --device cuda:0 to specify the GPU
 ```
 
 In conflict with the official ROCm documentation (above), we also needed to add the group render `--group-add render` (in addition to `--group-add video`).
@@ -186,12 +188,16 @@ Note, we tested on an AMD Radeon Pro W6600, which is [not officially supported](
 ```bash
 docker run --rm --security-opt seccomp=unconfined \
            --device=/dev/kfd --device=/dev/dri --group-add video --group-add render \
-	   -v /home/user/my_mri_data:/data \
-	   -v /home/user/my_fastsurfer_analysis:/output \
-	   -e HSA_OVERRIDE_GFX_VERSION=10.3.0 \
-	   my_fastsurfer:rocm \
-	   --t1 /data/subjectX/t1-weighted.nii.gz \
-	   --sid subjectX --sd /output 
+	       -v $HOME/my_mri_data:$HOME/my_mri_data \
+           -v $HOME/my_fastsurfer_analysis:$HOME/my_fastsurfer_analysis \
+           -v $HOME/my_fs_license.txt:$HOME/my_fs_license.txt \
+           -e HSA_OVERRIDE_GFX_VERSION=10.3.0 \
+           --rm --user $(id -u):$(id -g) my_fastsurfer:rocm \
+               --fs_license $HOME/my_fs_license.txt \
+               --t1 $HOME/my_mri_data/subjectX/t1-weighed.nii.gz \
+               --sid subjectX --sd $HOME/my_fastsurfer_analysis \
+               --parallel \
+               # alternatively: --device cuda is also possible (or --device cuda:0 to specify the GPU
 ```
 
 ## Build docker image with attestation and provenance

--- a/FastSurferCNN/README.md
+++ b/FastSurferCNN/README.md
@@ -171,7 +171,7 @@ python3 generate_hdf5.py \
 As an example, imagine you have 19 FreeSurfer processed subjects labeled subject1 to subject19 in the ../data directory:
 
 ```
-/home/user/FastSurfer/data
+$HOME/FastSurfer/data
 ├── subject1
 ├── subject2
 ├── subject3

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -165,7 +165,7 @@ def options_parse():
         "--no_iso_vox",
         dest="force_iso_vox",
         action="store_false",
-        help="Ignore the forced isotropic voxel size (depends on --conform_min).",
+        help="Ignore the forced isometric voxel size (depends on --conform_min).",
     )
     advanced.add_argument(
         "--no_img_size",

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -165,7 +165,7 @@ def options_parse():
         "--no_iso_vox",
         dest="force_iso_vox",
         action="store_false",
-        help="Ignore the forced isometric voxel size (depends on --conform_min).",
+        help="Ignore the forced isotropic voxel size (depends on --conform_min).",
     )
     advanced.add_argument(
         "--no_img_size",

--- a/FastSurferCNN/version.py
+++ b/FastSurferCNN/version.py
@@ -552,8 +552,7 @@ def read_and_close_version(project_file: TextIO | None = None) -> str:
     -----
     See also FastSurferCNN.version.read_version_from_project_file
     """
-    if project_file is None:
-        project_file = open(DEFAULTS.PROJECT_TOML)
+    project_file = open(project_file or DEFAULTS.PROJECT_TOML)
     try:
         version = read_version_from_project_file(project_file)
     finally:

--- a/README.md
+++ b/README.md
@@ -60,59 +60,73 @@ We recommended you use Singularity or Docker on a Linux host system with a GPU. 
 
 ### Usage
 
-All installation methods use the `run_fastsurfer.sh` call interface (replace `*fastsurfer-flags*` with [FastSurfer flags](doc/overview/FLAGS.md#required-arguments)), which is the general starting point for FastSurfer. However, there are different ways to call this script depending on the installation, which we explain here:
+All installation methods use the `run_fastsurfer.sh` call interface (replace the placeholder `<*fastsurfer-flags*>` with [FastSurfer flags](doc/scripts/RUN_FASTSURFER.md#required-arguments)), which is the general starting point for FastSurfer. However, there are different ways to call this script depending on the installation, which we explain here:
 
-1. For container installations, you need to define the hardware and mount the folders with the input (`/data`) and output data (`/output`):  
-   (a) For __singularity__, the syntax is 
-    ```
-    singularity exec --nv \
-                     --no-home \
-                     -B /home/user/my_mri_data:/data \
-                     -B /home/user/my_fastsurfer_analysis:/output \
-                     -B /home/user/my_fs_license_dir:/fs_license \
-                     ./fastsurfer-gpu.sif \
-                     /fastsurfer/run_fastsurfer.sh 
-                     *fastsurfer-flags*
+1. For container installations, you need to set up the container (`<*singularity-flags*>` or `<*docker-flags*>`) in addition to the `<*fastsurfer-flags*>`:  
+   1. For __Singularity__, the syntax is
+
+      ```bash
+      singularity run <*singularity-flags*> \
+                      fastsurfer.sif \
+                      <*fastsurfer-flags*>
+      ```
+      This command has two placeholders for flags: `<*singularity-flags*>` and `<*fastsurfer-flags*>`.
+      `<*singularity-flags*>` [set up the singularity environment](doc/overview/SINGULARITY.md), `<*fastsurfer-flags*>` include the options that determine the [behavior of FastSurfer](doc/scripts/RUN_FASTSURFER.md):
+      ### Basic FastSurfer Flags
+      
+      - `--t1`: the path to the image to process.
+      - `--sd`: the path to the "Subjects Directory", where all results will be stored.
+      - `--sid`: the identified for the results for this image (folder inside "Subjects Directory").
+      - `--fs_license`: path to the FreeSurfer license file.
+      
+      All options are explained in detail in the [run_fastsurfer.sh documentation](doc/scripts/RUN_FASTSURFER.md).  
+
+      An example for a simple full FastSurfer-Singularity command is
+      ```bash
+      singularity run --nv \
+                      -B /share/my/my/mri_data \
+                      -B /share/my/fastsurfer_analysis \
+                      -B /share/software/freesurfer/license.txt:/.fslicense \
+                      fastsurfer.sif \
+                      --t1 /share/my/mri_data/participant1/image1.nii.gz \
+                      --sd /share/my/fastsurfer_analysis \
+                      --sid part1_img1 \
+                      --fs_license /.fslicense
+      ```
+
+      See also __[Example 1](doc/overview/EXAMPLES.md#example-1-fastsurfer-singularity)__ for a full singularity FastSurfer run command and [the Singularity documentation](doc/overview/SINGULARITY.md#fastsurfer-singularity-image-usage) for details on more singularity flags and how to create the `fastsurfer.sif` file.  
+
+   2. For __docker__, the syntax is
+      ```bash
+      docker run <*docker-flags*> \
+                 deepmi/fastsurfer:<device>-v<version> \
+                 <*fastsurfer-flags*>
+      ```
+      
+      The options for `<*docker-flags*>` and [`<*fastsurfer-flags*>`](README.md#basic-fastsurfer-flags) follow very similar patterns as for Singularity ([but the names of `<*docker-flags*>` are different](Docker/README.md#docker-flags)).
+ 
+      __[Example 2](doc/overview/EXAMPLES.md#example-2-fastsurfer-docker)__ also details a full FastSurfer run inside a Docker container and [the Docker documentation](Docker/README.md#docker-flags) for more details on `*docker flags*` and the naming of docker images (`<device>-v<version>`).
+
+2. For a __native install__, call the `run_fastsurfer.sh` FastSurfer script directly. Your FastSurfer python/conda environment needs to be [set up](doc/overview/INSTALL.md#native-ubuntu-2004-or-ubuntu-2204) and activated. Also make sure that the `PYTHONPATH` variable includes the FastSurfer path.
+   
+   ```bash
+   # activate fastsurfer environment
+   conda activate fastsurfer
+   # set PYTHONPATH to the FastSurfer directory
+   export PYTHONPATH=/path/to/fastsurfer
+   
+   /path/to/fastsurfer/run_fastsurfer.sh <*fastsurfer-flags*>
    ```
-   The `--nv` flag is needed to allow FastSurfer to run on the GPU (otherwise FastSurfer will run on the CPU).
 
-   The `--no-home` flag tells singularity to not mount the home directory (see [Singularity documentation](Singularity/README.md#mounting-home) for more info).
+   See above for details on [`<*fastsurfer-flags*>`](README.md#basic-fastsurfer-flags).
 
-   The `-B` flag is used to tell singularity, which folders FastSurfer can read and write to.
- 
-   See also __[Example 2](doc/overview/EXAMPLES.md#example-2-fastsurfer-singularity)__ for a full singularity FastSurfer run command and [the Singularity documentation](Singularity/README.md#fastsurfer-singularity-image-usage) for details on more singularity flags.  
+   [Example 3](doc/overview/EXAMPLES.md#example-3-native-fastsurfer-on-subjectx-with-parallel-processing-of-hemis) also illustrates the running the FastSurfer pipeline natively.
 
-   (b) For __docker__, the syntax is
-    ```
-    docker run --gpus all \
-               -v /home/user/my_mri_data:/data \
-               -v /home/user/my_fastsurfer_analysis:/output \
-               -v /home/user/my_fs_license_dir:/fs_license \
-               --rm --user $(id -u):$(id -g) \
-               deepmi/fastsurfer:latest \
-               *fastsurfer-flags*
-    ```
-   The `--gpus` flag is needed to allow FastSurfer to run on the GPU (otherwise FastSurfer will run on the CPU).
-
-   The `-v` flag is used to tell docker, which folders FastSurfer can read and write to.
- 
-   See also __[Example 1](doc/overview/EXAMPLES.md#example-1-fastsurfer-docker)__ for a full FastSurfer run inside a Docker container and [the Docker documentation](Docker/README.md#docker-flags) for more details on the docker flags including `--rm` and `--user`.
-
-2. For a __native install__, you need to activate your FastSurfer environment (e.g. `conda activate fastsurfer_gpu`) and make sure you have added the FastSurfer path to your `PYTHONPATH` variable, e.g. `export PYTHONPATH=$(pwd)`. 
-
-   You will then be able to run fastsurfer with `./run_fastsurfer.sh *fastsurfer-flags*`.
-
-   See also [Example 3](doc/overview/EXAMPLES.md#example-3-native-fastsurfer-on-subjectx-with-parallel-processing-of-hemis) for an illustration of the commands to run the entire FastSurfer pipeline (FastSurferCNN + recon-surf) natively.
-
-<!-- start of flags -->
-### FastSurfer_Flags
-Please refer to [FASTSURFER_FLAGS](doc/overview/FLAGS.md).
-
-
+<!-- start of examples -->
 ## Examples
-All the examples can be found here: [FASTSURFER_EXAMPLES](doc/overview/EXAMPLES.md)
-- [Example 1: FastSurfer Docker](doc/overview/EXAMPLES.md#example-1-fastsurfer-docker)
-- [Example 2: FastSurfer Singularity](doc/overview/EXAMPLES.md#example-2-fastsurfer-singularity)
+The documentation includes [6 detailed Examples](doc/overview/EXAMPLES.md) on how to use FastSurfer. 
+- [Example 1: FastSurfer Singularity](doc/overview/EXAMPLES.md#example-1-fastsurfer-singularity)
+- [Example 2: FastSurfer Docker](doc/overview/EXAMPLES.md#example-2-fastsurfer-docker)
 - [Example 3: Native FastSurfer on subjectX with parallel processing of hemis](doc/overview/EXAMPLES.md#example-3-native-fastsurfer-on-subjectx-with-parallel-processing-of-hemis)
 - [Example 4: FastSurfer on multiple subjects](doc/overview/EXAMPLES.md#example-4-fastsurfer-on-multiple-subjects)
 - [Example 5: Quick Segmentation](doc/overview/EXAMPLES.md#example-5-quick-segmentation)
@@ -124,22 +138,28 @@ All the examples can be found here: [FASTSURFER_EXAMPLES](doc/overview/EXAMPLES.
 Modules output can be found here: [FastSurfer_Output_Files](doc/overview/OUTPUT_FILES.md)
 - [Segmentation module](doc/overview/OUTPUT_FILES.md#segmentation-module)
 - [Cerebnet module](doc/overview/OUTPUT_FILES.md#cerebnet-module)
+- [HypVINN module](doc/overview/OUTPUT_FILES.md#hypvinn-module)
 - [Surface module](doc/overview/OUTPUT_FILES.md#surface-module)
 
 <!-- start of system requirements -->
 ## System Requirements
 
-**Recommendation: At least 8 GB system memory and 8 GB NVIDIA graphics memory**
+**Recommendation**
 
-### Minimum Requirements:
+- intel or AMD CPU (6 or more cores)
+- 16 GB system memory
+- nVidia graphics card (2016 or newer) 
+- 12 GB graphics memory
 
-|       | --viewagg_device | Min GPU (in GB) | Min CPU (in GB) |
-|:------|------------------|----------------:|----------------:|
-| 1mm   | gpu              |               5 |               5 |
-| 1mm   | cpu              |               2 |               7 |
-| 0.7mm | gpu              |               8 |               6 |
-| 0.7mm | cpu              |               3 |               9 |
-| 0.7mm | --device cpu     |               0 |               9 |
+FastSurfer supports multiple hardware acceleration modes: fully CPU (`--device cpu`), partial GPU 
+(`--device cuda --viewagg_device cpu`) and fully GPU (`--device cuda`). By default, FastSurfer will try to pick the best
+option. These modes require different system and video memory capacities, see the table below. 
+
+| Voxel size | mode: fully CPU           | mode: partial gpu                       | mode: fully GPU       |
+|:-----------|---------------------------|-----------------------------------------|:----------------------|
+| 1mm        | system memory (RAM): 8 GB | RAM: 8 GB, graphics memory (VRAM): 2 GB | RAM: 8 GB, VRAM: 6 GB |
+| 0.8mm      | RAM: 8 GB                 | RAM: 8 GB, VRAM: 2 GB                   | RAM: 8 GB, VRAM: 8 GB |
+| 0.7mm      | RAM: 16 GB                | RAM: 16 GB, VRAM: 3 GB                  | RAM: 8 GB, VRAM: 8 GB |
 
 The default device is the GPU. The view-aggregation device can be switched to CPU and requires less GPU memory. CPU-only processing ```--device cpu``` is much slower and not recommended.
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,11 @@ All installation methods use the `run_fastsurfer.sh` call interface (replace the
  
       __[Example 2](doc/overview/EXAMPLES.md#example-2-fastsurfer-docker)__ also details a full FastSurfer run inside a Docker container and [the Docker documentation](Docker/README.md#docker-flags) for more details on `*docker flags*` and the naming of docker images (`<device>-v<version>`).
 
-2. For a __native install__, call the `run_fastsurfer.sh` FastSurfer script directly. Your FastSurfer python/conda environment needs to be [set up](doc/overview/INSTALL.md#native-ubuntu-2004-or-ubuntu-2204) and activated. Also make sure that the `PYTHONPATH` variable includes the FastSurfer path.
+2. For a __native install__, call the `run_fastsurfer.sh` FastSurfer script directly. Your FastSurfer python/conda environment needs to be [set up](doc/overview/INSTALL.md#native-ubuntu-2004-or-ubuntu-2204) and activated.
    
    ```bash
    # activate fastsurfer environment
    conda activate fastsurfer
-   # set PYTHONPATH to the FastSurfer directory
-   export PYTHONPATH=/path/to/fastsurfer
    
    /path/to/fastsurfer/run_fastsurfer.sh <*fastsurfer-flags*>
    ```

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,6 +13,12 @@ import sys
 import os
 from pathlib import Path
 
+try:
+    from FastSurferCNN.version import read_and_close_version as read_version
+except ImportError:
+    def read_version(project_file):
+        return "undefined"
+
 # here i added the relative path because sphinx was not able
 # to locate FastSurferCNN module directly for autosummary
 sys.path.append(os.path.dirname(__file__) + "/..")
@@ -72,6 +78,17 @@ suppress_warnings = [
 
 # create anchors for which headings?
 myst_heading_anchors = 7
+
+# myst extensions
+myst_enable_extensions = {
+    "substitution",
+}
+
+# configure substitutions
+myst_substitutions = {
+    # for now, the FASTSURFER_VERSION is hard-coded to 2.4.0
+    "FASTSURFER_VERSION": read_version(Path(__file__).resolve().parents[1] / "pyproject.toml"),
+}
 
 templates_path = ["_templates"]
 exclude_patterns = [

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -63,7 +63,7 @@ export FREESURFER_HOME=/path/to/freesurfer
 source $FREESURFER_HOME/SetUpFreeSurfer.sh
 
 # Define data directory
-export SUBJECTS_DIR=/home/user/my_fastsurfer_analysis
+export SUBJECTS_DIR=$HOME/my_fastsurfer_analysis
 
 # Run FastSurfer
 $FASTSURFER_HOME/run_fastsurfer.sh \

--- a/doc/overview/EXAMPLES.md
+++ b/doc/overview/EXAMPLES.md
@@ -1,47 +1,7 @@
 # Examples
 
-## Example 1: FastSurfer Docker
-After pulling one of our images from Dockerhub, you do not need to have a separate installation of FreeSurfer on your computer (it is already included in the Docker image). However, if you want to run ___more than just the segmentation CNN___, you need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license for free. The directory containing the license needs to be mounted and passed to the script via the `--fs_license` flag. Basically for Docker (as for Singularity below) you are starting a container image (with the run command) and pass several parameters for that, e.g. if GPUs will be used and mounting (linking) the input and output directories to the inside of the container image. In the second half of that call you pass parameters to our run_fastsurfer.sh script that runs inside the container (e.g. where to find the FreeSurfer license file, and the input data and other flags). 
-
-To run FastSurfer on a given subject using the provided GPU-Docker, execute the following command:
-
-```bash
-# 1. get the fastsurfer docker image (if it does not exist yet)
-docker pull deepmi/fastsurfer 
-
-# 2. Run command
-docker run --gpus all -v /home/user/my_mri_data:/data \
-                      -v /home/user/my_fastsurfer_analysis:/output \
-                      -v /home/user/my_fs_license_dir:/fs_license \
-                      --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
-                      --fs_license /fs_license/license.txt \
-                      --t1 /data/subjectX/t1-weighted.nii.gz \
-                      --sid subjectX --sd /output \
-                      --parallel --3T
-```
-
-Docker Flags:
-* The `--gpus` flag is used to allow Docker to access GPU resources. With it, you can also specify how many GPUs to use. In the example above, _all_ will use all available GPUS. To use a single one (e.g. GPU 0), set `--gpus device=0`. To use multiple specific ones (e.g. GPU 0, 1 and 3), set `--gpus 'device=0,1,3'`.
-* The `-v` commands mount your data, output, and directory with the FreeSurfer license file into the docker container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs_license). 
-* The `--rm` flag takes care of removing the container once the analysis finished. 
-* The `--user $(id -u):$(id -g)` part automatically runs the container with your group- (id -g) and user-id (id -u). All generated files will then belong to the specified user. Without the flag, the docker container will be run as root which is discouraged.
-
-FastSurfer Flag:
-* The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
-* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
-* The `--sid` is the subject ID name (output folder name)
-* The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
-* The `--parallel` activates processing left and right hemisphere in parallel
-* The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
-
-Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon). 
-
-A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory if it does not exist. So in this example output will be written to /home/user/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
-
-If you do not have a GPU, you can also run our CPU-Docker by dropping the `--gpus all` flag and specifying `--device cpu` at the end as a FastSurfer flag, see also [FastSurfer's docker documentation](../../Docker/README.md) for more details.
-
-## Example 2: FastSurfer Singularity
-After building the Singularity image (see below or [these instructions](../../Singularity/README.md)), you also need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license (for free) - same as when using Docker. This license needs to be passed to the script via the `--fs_license` flag. This is not necessary if you want to run the segmentation only.
+## Example 1: FastSurfer Singularity
+After building the Singularity image (see [these instructions](SINGULARITY.md)), you also need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license (for free) - same as when using Docker. This license needs to be passed to the script via the `--fs_license` flag. This is not necessary if you want to run the segmentation only.
 
 To run FastSurfer on a given subject using the Singularity image with GPU access, execute the following commands from a directory where you want to store singularity images. This will create a singularity image from our Dockerhub image and execute it:
 
@@ -82,8 +42,49 @@ A directory with the name as specified in `--sid` (here subjectX) will be create
 
 You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image and excluding the `--nv` argument in your Singularity exec command. Also append `--device cpu` as a FastSurfer flag.
 
+## Example 2: FastSurfer Docker
+After pulling one of our images from Dockerhub, you do not need to have a separate installation of FreeSurfer on your computer (it is already included in the Docker image). However, if you want to run ___more than just the segmentation CNN___, you need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license for free. The directory containing the license needs to be mounted and passed to the script via the `--fs_license` flag. Basically for Docker (as for Singularity below) you are starting a container image (with the run command) and pass several parameters for that, e.g. if GPUs will be used and mounting (linking) the input and output directories to the inside of the container image. In the second half of that call you pass parameters to our run_fastsurfer.sh script that runs inside the container (e.g. where to find the FreeSurfer license file, and the input data and other flags). 
+
+To run FastSurfer on a given subject using the provided GPU-Docker, execute the following command:
+
+```bash
+# 1. get the fastsurfer docker image (if it does not exist yet)
+docker pull deepmi/fastsurfer 
+
+# 2. Run command
+docker run --gpus all -v /home/user/my_mri_data:/data \
+                      -v /home/user/my_fastsurfer_analysis:/output \
+                      -v /home/user/my_fs_license_dir:/fs_license \
+                      --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
+                      --fs_license /fs_license/license.txt \
+                      --t1 /data/subjectX/t1-weighted.nii.gz \
+                      --sid subjectX --sd /output \
+                      --parallel --3T
+```
+
+Docker Flags:
+* The `--gpus` flag is used to allow Docker to access GPU resources. With it, you can also specify how many GPUs to use. In the example above, _all_ will use all available GPUS. To use a single one (e.g. GPU 0), set `--gpus device=0`. To use multiple specific ones (e.g. GPU 0, 1 and 3), set `--gpus 'device=0,1,3'`.
+* The `-v` commands mount your data, output, and directory with the FreeSurfer license file into the docker container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs_license). 
+* The `--rm` flag takes care of removing the container once the analysis finished. 
+* The `--user $(id -u):$(id -g)` part automatically runs the container with your group- (id -g) and user-id (id -u). All generated files will then belong to the specified user. Without the flag, the docker container will be run as root which is discouraged.
+
+FastSurfer Flag:
+* The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
+* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
+* The `--sid` is the subject ID name (output folder name)
+* The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
+* The `--parallel` activates processing left and right hemisphere in parallel
+* The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
+
+Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon). 
+
+A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory if it does not exist. So in this example output will be written to /home/user/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+
+If you do not have a GPU, you can also run our CPU-Docker by dropping the `--gpus all` flag and specifying `--device cpu` at the end as a FastSurfer flag, see also [FastSurfer's docker documentation](../../Docker/README.md) for more details.
 
 ## Example 3: Native FastSurfer on subjectX with parallel processing of hemis
+
+ (e.g. `conda activate fastsurfer`)
 
 For a native install you may want to make sure that you are on our stable branch, as the default dev branch is for development and could be broken at any time. For that you can directly clone the stable branch:
 

--- a/doc/overview/EXAMPLES.md
+++ b/doc/overview/EXAMPLES.md
@@ -12,9 +12,9 @@ singularity build fastsurfer-gpu.sif docker://deepmi/fastsurfer
 # 2. Run command
 singularity exec --nv \
                  --no-home \
-                 -B /home/user/my_mri_data:/data \
-                 -B /home/user/my_fastsurfer_analysis:/output \
-                 -B /home/user/my_fs_license_dir:/fs_license \
+                 -B $HOME/my_mri_data:/data \
+                 -B $HOME/my_fastsurfer_analysis:/output \
+                 -B $HOME/my_fs_license_dir:/fs_license \
                  ./fastsurfer-gpu.sif \
                  /fastsurfer/run_fastsurfer.sh \
                  --fs_license /fs_license/license.txt \
@@ -30,15 +30,15 @@ singularity exec --nv \
 
 ### FastSurfer Flags
 * The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
-* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
+* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: $HOME/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
-* The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
+* The `--sd` points to the output directory (its mounted name inside docker: $HOME/my_fastsurfer_analysis => /output)
 * The `--parallel` activates processing left and right hemisphere in parallel
 * The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon).
 
-A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory. So in this example output will be written to /home/user/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory. So in this example output will be written to $HOME/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
 
 You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image and excluding the `--nv` argument in your Singularity exec command. Also append `--device cpu` as a FastSurfer flag.
 
@@ -52,9 +52,9 @@ To run FastSurfer on a given subject using the provided GPU-Docker, execute the 
 docker pull deepmi/fastsurfer 
 
 # 2. Run command
-docker run --gpus all -v /home/user/my_mri_data:/data \
-                      -v /home/user/my_fastsurfer_analysis:/output \
-                      -v /home/user/my_fs_license_dir:/fs_license \
+docker run --gpus all -v $HOME/my_mri_data:/data \
+                      -v $HOME/my_fastsurfer_analysis:/output \
+                      -v $HOME/my_fs_license_dir:/fs_license \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
@@ -70,15 +70,15 @@ Docker Flags:
 
 FastSurfer Flag:
 * The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above. 
-* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
+* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: $HOME/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
-* The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
+* The `--sd` points to the output directory (its mounted name inside docker: $HOME/my_fastsurfer_analysis => /output)
 * The `--parallel` activates processing left and right hemisphere in parallel
 * The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon). 
 
-A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory if it does not exist. So in this example output will be written to /home/user/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory if it does not exist. So in this example output will be written to $HOME/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
 
 If you do not have a GPU, you can also run our CPU-Docker by dropping the `--gpus all` flag and specifying `--device cpu` at the end as a FastSurfer flag, see also [FastSurfer's docker documentation](../../Docker/README.md) for more details.
 
@@ -93,7 +93,7 @@ git clone --branch stable https://github.com/Deep-MI/FastSurfer.git
 ```
 
 More details (e.g. you need all dependencies in the right versions and also FreeSurfer locally) can be found in our [Installation guide](INSTALL.md).
-Given you want to analyze data for subject which is stored on your computer under /home/user/my_mri_data/subjectX/t1-weighted.nii.gz, run the following command from the console (do not forget to source FreeSurfer!):
+Given you want to analyze data for subject which is stored on your computer under $HOME/my_mri_data/subjectX/t1-weighted.nii.gz, run the following command from the console (do not forget to source FreeSurfer!):
 
 ```bash
 # Source FreeSurfer
@@ -101,8 +101,8 @@ export FREESURFER_HOME=/path/to/freesurfer
 source $FREESURFER_HOME/SetUpFreeSurfer.sh
 
 # Define data directory
-datadir=/home/user/my_mri_data
-fastsurferdir=/home/user/my_fastsurfer_analysis
+datadir=$HOME/my_mri_data
+fastsurferdir=$HOME/my_fastsurfer_analysis
 
 # Run FastSurfer
 ./run_fastsurfer.sh --t1 $datadir/subjectX/t1-weighted-nii.gz \
@@ -130,9 +130,9 @@ The `brun_fastsurfer.sh` script can then be invoked in docker, singularity or on
 
 ### Docker
 ```bash
-docker run --gpus all -v /home/user/my_mri_data:/data \
-                      -v /home/user/my_fastsurfer_analysis:/output \
-                      -v /home/user/my_fs_license_dir:/fs_license \
+docker run --gpus all -v $HOME/my_mri_data:/data \
+                      -v $HOME/my_fastsurfer_analysis:/output \
+                      -v $HOME/my_fs_license_dir:/fs_license \
                       --entrypoint "/fastsurfer/brun_fastsurfer.sh" \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
@@ -143,9 +143,9 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 ```bash
 singularity exec --nv \
                  --no-home \
-                 -B /home/user/my_mri_data:/data \
-                 -B /home/user/my_fastsurfer_analysis:/output \
-                 -B /home/user/my_fs_license_dir:/fs_license \
+                 -B $HOME/my_mri_data:/data \
+                 -B $HOME/my_fastsurfer_analysis:/output \
+                 -B $HOME/my_fs_license_dir:/fs_license \
                  ./fastsurfer-gpu.sif \
                  /fastsurfer/brun_fastsurfer.sh \
                  --fs_license /fs_license/license.txt \
@@ -158,9 +158,9 @@ singularity exec --nv \
 export FREESURFER_HOME=/path/to/freesurfer
 source $FREESURFER_HOME/SetUpFreeSurfer.sh
 
-cd /home/user/FastSurfer
-datadir=/home/user/my_mri_data
-fastsurferdir=/home/user/my_fastsurfer_analysis
+cd $HOME/FastSurfer
+datadir=$HOME/my_mri_data
+fastsurferdir=$HOME/my_fastsurfer_analysis
 
 # Run FastSurfer
 ./brun_fastsurfer.sh --subject_list $datadir/subjects_list.txt \

--- a/doc/overview/INSTALL.md
+++ b/doc/overview/INSTALL.md
@@ -22,9 +22,9 @@ Assuming you have singularity installed already (by a system admin), you can bui
 ```bash
 singularity build fastsurfer-gpu.sif docker://deepmi/fastsurfer:latest
 ```
-Additionally, [the Singularity README](../../Singularity/README.md) contains detailed directions for building your own Singularity images from Docker.
+Additionally, [the Singularity README](README.md) contains detailed directions for building your own Singularity images from Docker.
 
-[Example 2](EXAMPLES.md#example-2-fastsurfer-singularity) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to build your own images here: [Docker](../../Docker/README.md) and [Singularity](../../Singularity/README.md). 
+[Example 1](EXAMPLES.md#example-1-fastsurfer-singularity) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to build your own images here: [Docker](../../Docker/README.md) and [Singularity](README.md). 
 
 
 ### Docker
@@ -35,7 +35,7 @@ This is very similar to Singularity. Assuming you have Docker installed (by a sy
 docker pull deepmi/fastsurfer:latest
 ```
 
-[Example 1](EXAMPLES.md#example-1-fastsurfer-docker) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to [build your own image](https://github.com/Deep-MI/FastSurfer/blob/dev/Docker/README.md). 
+[Example 2](EXAMPLES.md#example-2-fastsurfer-docker) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to [build your own image](https://github.com/Deep-MI/FastSurfer/blob/dev/Docker/README.md). 
 
 
 ### Native (Ubuntu 20.04 or Ubuntu 22.04)
@@ -130,12 +130,12 @@ Build the Docker container with ROCm support.
 python Docker/build.py --device rocm --tag my_fastsurfer:rocm
 ```
 
-You will need to add a couple of flags to your docker run command for AMD, see [Example 1](EXAMPLES.md#example-1-fastsurfer-docker) for `**other-docker-flags**` or `**fastsurfer-flags**`:
+You will need to add a couple of flags to your docker run command for AMD, see [Example 2](EXAMPLES.md#example-2-fastsurfer-docker) for `**other-docker-flags**` or `*<*fastsurfer-flags*>*`:
 ```bash
 docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --device=/dev/kfd \
         --device=/dev/dri --group-add video --ipc=host --shm-size 8G \
         **other-docker-flags** my_fastsurfer:rocm \
-                **fastsurfer-flags**
+                *<*fastsurfer-flags*>*
 ```
 Note, that this docker image is experimental, uses a different Python version and python packages, so results can differ from our validation results. Please do visual QC.
 
@@ -160,7 +160,7 @@ Second, pull one of our Docker containers. Open a terminal window and run:
 docker pull deepmi/fastsurfer:latest
 ```
 
-Continue with the example in [Example 1](EXAMPLES.md#example-1-fastsurfer-docker). 
+Continue with the example in [Example 2](EXAMPLES.md#example-2-fastsurfer-docker). 
 
 
 ### Native
@@ -242,7 +242,7 @@ After everything is installed, start Windows PowerShell and run the following co
 docker pull deepmi/fastsurfer:cpu-latest
 ```
 
-Now you can run Fastsurfer the same way as described in [Example 1](EXAMPLES.md#example-1-fastsurfer-docker) for the CPU build, for example:
+Now you can run Fastsurfer the same way as described in [Example 2](EXAMPLES.md#example-2-fastsurfer-docker) for the CPU build, for example:
 ```bash
 docker run -v C:/Users/user/my_mri_data:/data \
            -v C:/Users/user/my_fastsurfer_analysis:/output \
@@ -274,7 +274,7 @@ After everything is installed, start Windows PowerShell and run the following co
 docker pull deepmi/fastsurfer:latest
 ```
 
-Now you can run Fastsurfer the same way as described in [Example 1](EXAMPLES.md#example-1-fastsurfer-docker), for example:
+Now you can run Fastsurfer the same way as described in [Example 2](EXAMPLES.md#example-2-fastsurfer-docker), for example:
 ```bash
 docker run --gpus all
            -v C:/Users/user/my_mri_data:/data \

--- a/doc/overview/INSTALL.md
+++ b/doc/overview/INSTALL.md
@@ -98,20 +98,11 @@ conda activate fastsurfer
 If you do not have an NVIDIA GPU, you can create appropriate ymls on the fly with `python ./Docker/install_env.py -m $MODE -i ./env/FastSurfer.yml -o ./fastsurfer_$MODE.yml`. Here `$MODE` can be for example `cpu`, see also `python ./Docker/install_env.py --help` for other options like rocm or cuda versions. Finally, replace `./env/fastsurfer.yml`  with your custom environment file `./fastsurfer_$MODE.yml`.
 If you only want to run the surface pipeline, use `./env/fastsurfer_reconsurf.yml`.
 
-Next, add the fastsurfer directory to the python path (make sure you have changed into it already):
-```bash
-export PYTHONPATH="${PYTHONPATH}:$PWD"
-```
-
-This will need to be done every time you want to run FastSurfer, or you need to add this line to your `~/.bashrc` if you are using bash, for example:
-```bash
-echo "export PYTHONPATH=\"\${PYTHONPATH}:$PWD\"" >> ~/.bashrc
-```
-
 You can also download all network checkpoint files (this should be done if you are installing for multiple users):
 ```bash
-python3 FastSurferCNN/download_checkpoints.py --all
+PYTHONPATH=. python3 FastSurferCNN/download_checkpoints.py --all
 ```
+Note: Setting the PYTHONPATH variable explicitly (such as for this call, is required for all calls to python scripts, i.e. only for expert users).
 
 Once all dependencies are installed, you are ready to run the FastSurfer segmentation-only (!!) pipeline by calling ```./run_fastsurfer.sh --seg_only ....``` , see [Example 3](EXAMPLES.md#example-3-native-fastsurfer-on-subjectx-with-parallel-processing-of-hemis) for command line flags.
 
@@ -190,7 +181,6 @@ Clone FastSurfer:
 ```sh
 git clone --branch stable https://github.com/Deep-MI/FastSurfer.git
 cd FastSurfer
-export PYTHONPATH="${PYTHONPATH}:$PWD"
 ```
 
 Install the FastSurfer requirements

--- a/doc/overview/INSTALL.md
+++ b/doc/overview/INSTALL.md
@@ -22,9 +22,9 @@ Assuming you have singularity installed already (by a system admin), you can bui
 ```bash
 singularity build fastsurfer-gpu.sif docker://deepmi/fastsurfer:latest
 ```
-Additionally, [the Singularity README](README.md) contains detailed directions for building your own Singularity images from Docker.
+Additionally, [the Singularity documentation](SINGULARITY.md) contains detailed directions for building your own Singularity images from Docker.
 
-[Example 1](EXAMPLES.md#example-1-fastsurfer-singularity) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to build your own images here: [Docker](../../Docker/README.md) and [Singularity](README.md). 
+[Example 1](EXAMPLES.md#example-1-fastsurfer-singularity) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to build your own images here: [Docker](../../Docker/README.md) and [Singularity](SINGULARITY.md). 
 
 
 ### Docker
@@ -35,7 +35,7 @@ This is very similar to Singularity. Assuming you have Docker installed (by a sy
 docker pull deepmi/fastsurfer:latest
 ```
 
-[Example 2](EXAMPLES.md#example-2-fastsurfer-docker) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to [build your own image](https://github.com/Deep-MI/FastSurfer/blob/dev/Docker/README.md). 
+[Example 2](EXAMPLES.md#example-2-fastsurfer-docker) explains how to run FastSurfer (for the full pipeline you will also need a FreeSurfer .license file!) and you can find details on how to [build your own image](https://github.com/Deep-MI/FastSurfer/blob/dev/ME.md). 
 
 
 ### Native (Ubuntu 20.04 or Ubuntu 22.04)
@@ -212,7 +212,7 @@ You can also download all network checkpoint files at this point already:
 python3.10 FastSurferCNN/download_checkpoints.py --all
 ```
 
-Once all dependencies are installed, you can run the FastSurfer segmentation only by calling ```./run_fastsurfer.sh --seg_only ....``` with the appropriate command line flags, see the [commandline documentation](../../README.md#usage). 
+Once all dependencies are installed, you can run the FastSurfer segmentation only by calling ```./run_fastsurfer.sh --seg_only ....``` with the appropriate command line flags, see the [commandline documentation](../scripts/RUN_FASTSURFER.md). 
 
 To run the full pipeline, install and source also the supported FreeSurfer version according to their [Instructions](https://surfer.nmr.mgh.harvard.edu/fswiki/rel7downloads). There is a freesurfer email list, if you run into problems during this step. Note, that currently FreeSurfer for MacOS supports no ARM, but only Intel, so on modern M-chips it will be slow due to the emulation. This is why we recommend using a Linux host system to run FastSurfer on larger datasets.
 

--- a/doc/overview/LONG.md
+++ b/doc/overview/LONG.md
@@ -29,7 +29,7 @@ export FREESURFER_HOME=/path/to/freesurfer
 source $FREESURFER_HOME/SetUpFreeSurfer.sh
 
 # Define data directory
-export SUBJECTS_DIR=/home/user/my_fastsurfer_analysis
+export SUBJECTS_DIR=$HOME/my_fastsurfer_analysis
 
 # Run FastSurfer longitudinally
 $FASTSURFER_HOME/long_fastsurfer.sh \
@@ -47,9 +47,9 @@ The above command will, of course, be slightly different when using the preferre
 ```bash
 singularity exec --nv \
                  --no-home \
-                 -B /home/user/my_mri_data:/data \
-                 -B /home/user/my_fastsurfer_analysis:/output \
-                 -B /home/user/my_fs_license_dir:/fs_license \
+                 -B $HOME/my_mri_data:/data \
+                 -B $HOME/my_fastsurfer_analysis:/output \
+                 -B $HOME/my_fs_license_dir:/fs_license \
                  ./fastsurfer-gpu.sif \
                  /fastsurfer/long_fastsurfer.sh \
                  --fs_license /fs_license/license.txt \

--- a/doc/overview/SINGULARITY.md
+++ b/doc/overview/SINGULARITY.md
@@ -1,5 +1,18 @@
 # FastSurfer Singularity Support
 
+
+## Sandbox
+
+
+## 
+
+`<*singularity-flags*>` includes flags that set up the singularity container:
+- `--nv`: enable nVidia GPUs in Singularity (otherwise FastSurfer will run on the CPU),
+- `-B <path>`: is used to share data between the host and Singularity (only paths listed here will be available to FastSurfer, see [Singularity documentation](doc/overview/README.md#sandbox) for more info).
+  This should specifically include the "Subject Directory". If two paths are given like `-B /my/path/host:/other`, this means `/my/path/host/somefile` will be accessible inside Singularity in directory as `/other/somefile`.  
+      
+
+
 For use on HPCs (or in other cases where Docker is not available or preferred) you can easily create a Singularity image from the Docker image. 
 Singularity uses its own image format, so the Docker images must be converted (we publish our releases as docker images available on [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags)). 
 
@@ -21,7 +34,7 @@ If you want to manually convert the local Docker image `fastsurfer:myimage`, run
 singularity build /home/user/my_singlarity_images/fastsurfer-myimage.sif docker-daemon://fastsurfer:myimage
 ```
 
-For more information on how to create your own Docker images, see our [Docker guide](../Docker/README.md).
+For more information on how to create your own Docker images, see our [Docker guide](../../Docker/README.md).
 
 ## FastSurfer Singularity Image Usage
 

--- a/doc/overview/SINGULARITY.md
+++ b/doc/overview/SINGULARITY.md
@@ -3,12 +3,14 @@
 
 ## Sandbox
 
+Containerization tools like Singularity (or Apptainer) and Docker provide several advantages.
+
 
 ## 
 
 `<*singularity-flags*>` includes flags that set up the singularity container:
 - `--nv`: enable nVidia GPUs in Singularity (otherwise FastSurfer will run on the CPU),
-- `-B <path>`: is used to share data between the host and Singularity (only paths listed here will be available to FastSurfer, see [Singularity documentation](doc/overview/README.md#sandbox) for more info).
+- `-B <path>`: is used to share data between the host and Singularity (only paths listed here will be available to FastSurfer, see [Singularity documentation](SINGULARITY.md#sandbox) for more info).
   This should specifically include the "Subject Directory". If two paths are given like `-B /my/path/host:/other`, this means `/my/path/host/somefile` will be accessible inside Singularity in directory as `/other/somefile`.  
       
 
@@ -62,7 +64,7 @@ singularity exec --nv \
 
 ### FastSurfer Flags
 * The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above, if you want to run the full surface analysis. 
-* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
+* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside Docker: /home/user/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
 * The `--parallel` activates processing left and right hemisphere in parallel

--- a/doc/overview/SINGULARITY.md
+++ b/doc/overview/SINGULARITY.md
@@ -1,57 +1,66 @@
 # FastSurfer Singularity Support
 
 
-## Sandbox
+## Containerization
 
-Containerization tools like Singularity (or Apptainer) and Docker provide several advantages.
+Containerization tools like Singularity, or Apptainer or Docker provide several advantages.
 Most importantly, they allow for exactly same setup across different machines and even data centers and compute clusters. They thus increase reproducibility by reducing software differences between evaluations.
-Additionally, errors and unexpected behavior is easier to track down, since 
+Additionally, errors and unexpected behavior is easier to track down, since the setup is significantly easier to reproduce for developers.
+Finally, containers provide a security advantage, because the access to data is restricted to explicitly shared data reducing both the risk of data theft and data encryption attacks. This is strategy also called [sandboxing](https://en.wikipedia.org/wiki/Sandbox_(computer_security)). 
 
-## 
+## Using Singularity (or Apptainer)
 
-`<*singularity-flags*>` includes flags that set up the singularity container:
-- `--nv`: enable nVidia GPUs in Singularity (otherwise FastSurfer will run on the CPU),
-- `-B <path>`: is used to share data between the host and Singularity (only paths listed here will be available to FastSurfer, see [Singularity documentation](SINGULARITY.md#sandbox) for more info).
-  This should specifically include the "Subject Directory". If two paths are given like `-B /my/path/host:/other`, this means `/my/path/host/somefile` will be accessible inside Singularity in directory as `/other/somefile`.  
-      
+In the following, we write "Singularity", but all steps work the same with the [open source Apptainer](https://apptainer.org).
 
+To execute code in a Singularity container, users have to:
+1. [download](SINGULARITY.md#downloading-the-official-fastsurfer-image-for-singularity) or [create](SINGULARITY.md#creating-your-own-fastsurfer-singularity-image) a Singularity image of FastSurfer. 
+2. [Start the Singularity container from a Singularity image](SINGULARITY.md#starting-fastsurfer-with-from-a-singularity-image) by defining options for the container. It is useful, to think of the image as a "hard drive" and the container as a "simulated computer inside the computer".
+    
+   We refer to these "options for the container" in `<*singularity-flags*>`. They are not options to FastSurfer (referred to as `<*fastsurfer-flags*>`), but to the "simulated computer" and define access to data, hardware (e.g. graphics cards), etc. 
 
-For use on HPCs (or in other cases where Docker is not available or preferred) you can easily create a Singularity image from the Docker image. 
-Singularity uses its own image format, so the Docker images must be converted (we publish our releases as docker images available on [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags)). 
+## Downloading the official FastSurfer image for Singularity
+Singularity uses its own image format, so we need to download and convert the official docker images available from [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags).
 
-## Singularity with the official FastSurfer Image
-To create a Singularity image from the official FastSurfer image hosted on Dockerhub just run:
+To create an official FastSurfer Singularity image, run:
 ```bash
-singularity build /home/user/my_singlarity_images/fastsurfer-latest.sif docker://deepmi/fastsurfer:latest
+# singularity build <filename> <source>
+singularity build $HOME/my_singlarity_images/fastsurfer-{{ FASTSURFER_VERSION }}.sif docker://deepmi/fastsurfer:cuda-v{{ FASTSURFER_VERSION }}
 ```
-Singularity images are files - usually with the extension `.sif`. Here, we save the image in `/home/user/my_singlarity_images`.
-If you want to pick a specific FastSurfer version, you can also change the tag (`latest`) in `deepmi/fastsurfer:latest` to any tag. For example to use the cpu image hosted on [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) use the tag `cpu-latest`.
+Singularity images are files with extension `.sif`. Here, we save the image in `$HOME/my_singlarity_images`.
+If you want to pick a specific FastSurfer version, you can also change `cuda-v{{ FASTSURFER_VERSION }}` in the `<source>`. For example to use the [cpu image](https://hub.docker.com/r/deepmi/fastsurfer/tags?name=cpu) (`cpu-v{{ FASTSURFER_VERSION }}`) or a [specific CUDA version](https://hub.docker.com/r/deepmi/fastsurfer/tags?name=cu1) (check, which version is available the current FastSurfer version, for example `cu118-v2.4.0`).
 
-## Building your own FastSurfer Singularity Image
+## Creating your own FastSurfer Singularity Image
 To build a custom FastSurfer Singularity image, the `Docker/build.py` script supports a flag for direct conversion.
-Simply add `--singularity /home/user/my_singlarity_images/fastsurfer-myimage.sif` to the call, which first builds the image with Docker and then converts the image to Singularity.
+Simply add `--singularity $HOME/my_singlarity_images/fastsurfer-myimage.sif` to the call, which first builds the image with Docker and then converts the image to Singularity.
 
 If you want to manually convert the local Docker image `fastsurfer:myimage`, run:
 
 ```bash
-singularity build /home/user/my_singlarity_images/fastsurfer-myimage.sif docker-daemon://fastsurfer:myimage
+singularity build $HOME/my_singlarity_images/fastsurfer-myimage.sif docker-daemon://fastsurfer:myimage
 ```
 
 For more information on how to create your own Docker images, see our [Docker guide](../../Docker/README.md).
 
-## FastSurfer Singularity Image Usage
+## Starting FastSurfer with from a Singularity image
 
 After building the Singularity image, you need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license (for free) - just as when using Docker. This license needs to be passed to the script via the `--fs_license` flag. This is not necessary if you want to run the segmentation only.
 
 To run FastSurfer on a given subject using the Singularity image with GPU access, execute the following command:
 
+`<*singularity-flags*>` includes flags that set up the singularity container:
+- `--nv`: enable nVidia GPUs in Singularity (otherwise FastSurfer will run on the CPU),
+- `-B <path>`: is used to share data between the host and Singularity (only paths listed here will be available to FastSurfer, see [Singularity documentation](SINGULARITY.md#containerization) for more info).
+  This should specifically include the "Subject Directory". If two paths are given like `-B /my/path/host:/other`, this means `/my/path/host/somefile` will be accessible inside Singularity in directory as `/other/somefile`.  
+
+
+
 ```bash
 singularity exec --nv \
                  --no-home \
-                 -B /home/user/my_mri_data:/data \
-                 -B /home/user/my_fastsurfer_analysis:/output \
-                 -B /home/user/my_fs_license_dir:/fs \
-                  /home/user/fastsurfer-gpu.sif \
+                 -B $HOME/my_mri_data:/data \
+                 -B $HOME/my_fastsurfer_analysis:/output \
+                 -B $HOME/my_fs_license_dir:/fs \
+                  $HOME/fastsurfer-gpu.sif \
                   /fastsurfer/run_fastsurfer.sh \
                  --fs_license /fs/license.txt \
                  --t1 /data/subjectX/orig.mgz \
@@ -60,39 +69,44 @@ singularity exec --nv \
 ```
 ### Singularity Flags
 * `--nv`: This flag is used to access GPU resources. It should be excluded if you intend to use the CPU version of FastSurfer
-* `--no-home`: This flag tells singularity to not mount the home directory inside the singularity image (see [Best Practice](#mounting-home))
+* `-e`: 
+* `--no-mount cwd,home`: This flag tells singularity to not mount the home directory inside the singularity image (see [Best Practice](#mounting-home))
 * `-B`: These commands mount your data, output, and directory with the FreeSurfer license file into the Singularity container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs). 
 
 ### FastSurfer Flags
-* The `--fs_license` points to your FreeSurfer license which needs to be available on your computer in the my_fs_license_dir that was mapped above, if you want to run the full surface analysis. 
-* The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside Docker: /home/user/my_mri_data => /data)
+* The `--fs_license` points to your FreeSurfer license (needs to be shared with the container using `-B`) 
+* The `--t1` points to the t1-weighted MRI image to analyse (needs to be shared with the container using `-B`)
 * The `--sid` is the subject ID name (output folder name)
-* The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
+* The `--sd` points to the output directory (needs to be shared with the container using `-B`)
 * The `--parallel` activates processing left and right hemisphere in parallel
 * The `--3T` switches to the 3T atlas instead of the 1.5T atlas for Talairach registration. 
 
-Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-B` arguments. 
-
-A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory. So in this example output will be written to /home/user/my_fastsurfer_analysis/subjectX/ . Make sure the output directory is empty, to avoid overwriting existing files. 
+A directory with the name as specified in `--sid` (here subjectX) will be created in the output directory. So in this example output will be written to `$HOME/my_fastsurfer_analysis/subjectX/`. FastSurfer may overwrite files in `$HOME/my_fastsurfer_analysis/subjectX/`.
 
 ### Singularity without a GPU
 You can run the Singularity equivalent of CPU-Docker by building a Singularity image from the CPU-Docker image (replace # with the current version number) and excluding the `--nv` argument in your Singularity exec command as following:
 
 ```bash
-cd /home/user/my_singlarity_images
-singularity build fastsurfer-gpu.sif docker://deepmi/fastsurfer:cpu-v#.#.#
+cd $HOME/my_singlarity_images
+singularity build fastsurfer-cpu-{{ FASTSURFER_VERSION }}.sif docker://deepmi/fastsurfer:cpu-v{{ FASTSURFER_VERSION }}
 
-singularity exec --no-home \
-                 -B /home/user/my_mri_data:/data \
-                 -B /home/user/my_fastsurfer_analysis:/output \
-                 -B /home/user/my_fs_license_dir:/fs \
-                  /home/user/fastsurfer-cpu.sif \
-                  /fastsurfer/run_fastsurfer.sh \
-                  --fs_license /fs/license.txt \
-                  --t1 /data/subjectX/orig.mgz \
-                  --sid subjectX --sd /output \
-                  --parallel --3T
+singularity exec --no-mount -e \
+                 -B $HOME/my_mri_data \
+                 -B $HOME/my_fastsurfer_analysis \
+                 -B $HOME/my_fs_license.txt \
+                 $HOME/fastsurfer-cpu-{{ FASTSURFER_VERSION }}.sif \
+                   /fastsurfer/run_fastsurfer.sh \
+                     --fs_license $HOME/my_fs_license.txt \
+                     --t1 $HOME/my_mri_data/subjectX/orig.mgz \
+                     --sid subjectX --sd $HOME/my_fastsurfer_analysis \
+                     --parallel --3T
 ```
+
+## Common problems
+
+1. Slow processing despite GPUs, log says `UserWarning: CUDA initialization: The NVIDIA driver on your system is too old (found version ...)`.
+
+   Your NVIDIA drivers are too old for the CUDA version used in the image you created, try using a different image with a different cuda version, for example for [CUDA 11](https://hub.docker.com/r/deepmi/fastsurfer/tags?name=cu11), or specify a different `--device` option if you built the underlying Docker image yourself.
 
 ## Singularity Best Practice
 

--- a/doc/overview/SINGULARITY.md
+++ b/doc/overview/SINGULARITY.md
@@ -4,7 +4,8 @@
 ## Sandbox
 
 Containerization tools like Singularity (or Apptainer) and Docker provide several advantages.
-
+Most importantly, they allow for exactly same setup across different machines and even data centers and compute clusters. They thus increase reproducibility by reducing software differences between evaluations.
+Additionally, errors and unexpected behavior is easier to track down, since 
 
 ## 
 

--- a/doc/overview/SINGULARITY.md
+++ b/doc/overview/SINGULARITY.md
@@ -21,7 +21,7 @@ To create a Singularity image from the official FastSurfer image hosted on Docke
 ```bash
 singularity build /home/user/my_singlarity_images/fastsurfer-latest.sif docker://deepmi/fastsurfer:latest
 ```
-Singularity images are files - usually with the extension `.sif`. Here, we save the image in `/homer/user/my_singlarity_images`.
+Singularity images are files - usually with the extension `.sif`. Here, we save the image in `/home/user/my_singlarity_images`.
 If you want to pick a specific FastSurfer version, you can also change the tag (`latest`) in `deepmi/fastsurfer:latest` to any tag. For example to use the cpu image hosted on [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) use the tag `cpu-latest`.
 
 ## Building your own FastSurfer Singularity Image

--- a/doc/overview/index.rst
+++ b/doc/overview/index.rst
@@ -8,10 +8,9 @@ User Guide
     QUICKSTART.md
     INSTALL.md
     EXAMPLES.md
-    FLAGS.md
     OUTPUT_FILES.md
     docker
-    singularity
+    SINGULARITY.md
     EDITING.md
     LONG.md
     SECURITY.md

--- a/doc/overview/license.rst
+++ b/doc/overview/license.rst
@@ -2,6 +2,9 @@
 FastSurfer License
 ##################
 
+FastSurfer is licensed under the Apache license (see below).
+FastSurfer uses (and the docker image is distributed with) FreeSurfer, which is licensed under the `FreeSurfer License <https://surfer.nmr.mgh.harvard.edu/fswiki/License>`_. Users need a license key for FreeSurfer, which can be obtained for free on the `FreeSurfer website <https://surfer.nmr.mgh.harvard.edu/registration.html>`_.
+FastSurfer uses several python packages (see the :ref:`requirements.txt`). Please refer to these packages for their respective licenses.
 
 Apache License
 ==============

--- a/doc/overview/license.rst
+++ b/doc/overview/license.rst
@@ -4,7 +4,7 @@ FastSurfer License
 
 FastSurfer is licensed under the Apache license (see below).
 FastSurfer uses (and the docker image is distributed with) FreeSurfer, which is licensed under the `FreeSurfer License <https://surfer.nmr.mgh.harvard.edu/fswiki/License>`_. Users need a license key for FreeSurfer, which can be obtained for free on the `FreeSurfer website <https://surfer.nmr.mgh.harvard.edu/registration.html>`_.
-FastSurfer uses several python packages (see the :ref:`requirements.txt`). Please refer to these packages for their respective licenses.
+FastSurfer uses several python packages (see the :ref:`../../requirements.txt`). Please refer to these packages for their respective licenses.
 
 Apache License
 ==============

--- a/doc/overview/license.rst
+++ b/doc/overview/license.rst
@@ -4,9 +4,36 @@ FastSurfer License
 
 FastSurfer is licensed under the Apache license (see below).
 FastSurfer uses (and the docker image is distributed with) FreeSurfer, which is licensed under the `FreeSurfer License <https://surfer.nmr.mgh.harvard.edu/fswiki/License>`_. Users need a license key for FreeSurfer, which can be obtained for free on the `FreeSurfer website <https://surfer.nmr.mgh.harvard.edu/registration.html>`_.
-FastSurfer uses several python packages (see the :ref:`../../requirements.txt`). Please refer to these packages for their respective licenses.
+FastSurfer uses several python packages. Please refer to these packages for their respective licenses.
 
 Apache License
 ==============
 
 .. literalinclude:: ../../LICENSE
+
+Other Packages and Tools distributed or used with FastSurfer
+============================================================
+
+* [FreeSurfer](https://surfer.nmr.mgh.harvard.edu/)
+* [h5py](https://www.h5py.org)
+* [Jinja2](https://jinja.palletsprojects.com/en/stable/)
+* [lapy](https://deep-mi.org/LaPy)
+* [matplotlib](https://matplotlib.org/)
+* [nibabel](https://nipy.org/nibabel/)
+* [numpy](https://numpy.org/)
+* [pandas](https://pandas.pydata.org/)
+* [pillow](https://python-pillow.github.io/)
+* [plotly](https://plotly.com/python/)
+* [PyYAML](https://pyyaml.org/)
+* [requests](https://requests.readthedocs.io/en/latest/)
+* [scikit-image](https://scikit-image.org)
+* [scikit-learn](https://scikit-learn.org)
+* [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse)
+* [scipy](https://scipy.org)
+* [SimpleITK](https://simpleitk.org/)
+* [tensorboard](https://www.tensorflow.org/tensorboard)
+* [torch](https://pytorch.org)
+* [torchio](https://torchio.org)
+* [torchvision](https://pytorch.org/vision)
+* [tqdm](https://tqdm.github.io/)
+* [yacs](https://github.com/rbgirshick/yacs)

--- a/doc/overview/singularity.rst
+++ b/doc/overview/singularity.rst
@@ -1,8 +1,0 @@
-Singularity Support
--------------------
-
-.. include:: ../../Singularity/README.md
-    :parser: fix_links.parser
-    :relative-docs: .
-    :relative-images:
-    :start-line: 1

--- a/doc/scripts/RUN_FASTSURFER.md
+++ b/doc/scripts/RUN_FASTSURFER.md
@@ -1,10 +1,14 @@
-# FastSurfer Flags
-Next, you will learn hot wo specify the `*fastsurfer-flags*` by replacing `*fastsurfer-flags*` with your specific options.
+run_fastsurfer.sh
+=================
 
-The `*fastsurfer-flags*` will usually at least include the subject directory (`--sd`; Note, this will be the mounted path - `/output` - for containers), the subject name/id (`--sid`) and the path to the input image (`--t1`). For example:
+Next, you will learn hot wo specify the `*fastsurfer-flags*` by replacing `*fastsurfer-flags*` with your specific options.
+`run_fastsurfer.sh` is the central command of FastSurfer. In general, `run_fastsurfer.sh` is called once for each T1w MRI image that is to be processed and each call will result in one "Subject Folder" with segmentation maps, surfaces and statistics tables. If you want to process multiple images, you can either loop through the images yourself or use [brun_fastsurfer.sh](BATCH.md) or [srun_fastsurfer.sh](SLURM.md), which are multi-subject extensions to `run_fastsurfer.sh`.
+
+On this page, we explain FastSurfer's options, usually referred to as `<*fastsurfer-flags*>` in this documentation. 
+The `<*fastsurfer-flags*>` will usually at least include the subject directory (`--sd`), the subject name/id (`--sid`) and the path to the input image (`--t1`). For example:
 
 ```bash
-... --sd /output --sid test_subject --t1 /data/test_subject_t1.nii.gz --3T
+$FASTSURFER_HOME/run_fastsurfer.sh --sd $HOME/fastsurfer-data --sid test_subject --t1 $HOME/mri-data/test_subject_t1.nii.gz --3T
 ```
 Additionally, you can use `--seg_only` or `--surf_only` to only run a part of the pipeline or `--no_biasfield`, `--no_cereb` and `--no_asegdkt` to switch off individual segmentation modules.
 Here, we have also added the `--3T` flag, which tells FastSurfer to register against the 3T atlas which is only relevant for the ICV estimation (eTIV).
@@ -53,3 +57,11 @@ In the following, we give an overview of the most important options. You can vie
 * `--py`: Command for python, used in both pipelines. Default: python3.10
 * `--conformed_name`: Name of the file in which the conformed input image will be saved. Default location: \$SUBJECTS_DIR/\$sid/mri/orig.mgz
 * `-h`, `--help`: Prints help text
+
+Usage
+-----
+This is the full output of `./run_fastsurfer.sh --help`.
+
+```{command-output} ./run_fastsurfer.sh --help
+:cwd: /../
+```

--- a/doc/scripts/index.rst
+++ b/doc/scripts/index.rst
@@ -4,6 +4,7 @@ Scripts
 .. toctree::
     :maxdepth: 2
 
+    RUN_FASTSURFER.md
     BATCH.md
     SLURM.md
     advanced

--- a/recon_surf/README.md
+++ b/recon_surf/README.md
@@ -92,7 +92,7 @@ Check [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) to find out t
 ### Singularity Flags: 
 * The `-B` commands mount your output, and directory with the FreeSurfer license file into the Singularity container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs_license). 
 
-* The `--no-home` command disables the automatic mount of the users home directory (see [Best Practice](../Singularity/README.md#mounting-home))
+* The `--no-home` command disables the automatic mount of the users home directory (see [Best Practice](../doc/overview/README.md#mounting-home))
 
 The `--t1` and `--asegdkt_segfile` flags point to the already existing conformed T1 input and segmentation from the segmentation module. Also other files from that pipeline
 will be reused (e.g. the `mask.mgz`, `orig_nu.mgz`). The subject directory will then be populated with the FreeSurfer file structure, including surfaces, statistics 

--- a/recon_surf/README.md
+++ b/recon_surf/README.md
@@ -41,7 +41,9 @@ List them by running the following command:
 * `--no_surfreg`: Skip surface registration with FreeSurfer (if only stats are needed)
 * `--fs_license`: Path to FreeSurfer license key file. Register at https://surfer.nmr.mgh.harvard.edu/registration.html for free to obtain it if you do not have FreeSurfer installed already
 
-For more details see `--help`.
+For more details on arguments see `--help`.
+
+`recon-surf.sh` also supports [processing with edits](../doc/overview/EDITING.md).
 
 ### Example 1: Surface module inside Docker
 
@@ -49,23 +51,20 @@ Docker can be used to simplify the installation (no FreeSurfer on system require
 Given you already ran the segmentation pipeline, and want to just run the surface pipeline on top of it 
 (i.e. on a different cluster), the following command can be used:
 ```bash
-# 1. Pull the docker image (if it does not exist locally)
-docker pull deepmi/fastsurfer:cpu-v?.?.?
-
-# 2. Run command
-docker run -v /home/user/my_fastsurfer_analysis:/output \
-           -v /home/user/my_fs_license_dir:/fs_license \
-           --rm --user $(id -u):$(id -g) deepmi/fastsurfer:cpu-v?.?.? \
-           --fs_license /fs_license/license.txt \
-           --sid subjectX --sd /output --3T --surf_only
+# Run command
+docker run -v $HOME/my_fastsurfer_analysis:$HOME/my_fastsurfer_analysis \
+           -v $HOME/my_fs_license.txt:$HOME/my_fs_license.txt \
+           --rm --user $(id -u):$(id -g) deepmi/fastsurfer:cpu-v{{ FASTSURFER_VERSION }} \
+           --fs_license $HOME/my_fs_license.txt \
+           --sid subjectX --sd $HOME/my_fastsurfer_analysis --3T --surf_only
 ```
-Check [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) to find out the latest release version and replace the "?". 
+Note: Go to [deepmi on Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) to find the latest release version (automatically detected as `deepmi/fastsurfer:cpu-v{{ FASTSURFER_VERSION }}`). 
 
 Docker Flags: 
 * The `-v` commands mount your output, and directory with the FreeSurfer license file into the Docker container. Inside the container these are visible under the name following the colon (in this case /output and /fs_license). 
 
 This essentially calls the run_fastsurfer.sh script as entry point and starts only the surface module. It assumes that this case `subjectX` exists already and that the output files of the segmentation module are 
-available in the subjectX/mri directory (e.g. `/home/user/my_fastsurfeer_analysis/subjectX/mri/aparc.DKTatlas+aseg.deep.mgz`, `mask.mgz`, `orig.mgz` etc.). The directory will then be populated with the FreeSurfer file structure, including surfaces, statistics and labels file (equivalent to a FreeSurfer recon-all run). It is possible to modify the entry point during the docker call and directly run recon-surf.sh, as we will demonstrate with the Singularity example next.
+available in the subjectX/mri directory (e.g. `$HOME/my_fastsurfeer_analysis/subjectX/mri/aparc.DKTatlas+aseg.deep.mgz`, `mask.mgz`, `orig.mgz` etc.). The directory will then be populated with the FreeSurfer file structure, including surfaces, statistics and labels file (equivalent to a FreeSurfer recon-all run). It is possible to modify the entry point during the docker call and directly run recon-surf.sh, as we will demonstrate with the Singularity example next.
 
 ## Example 2: recon-surf inside Singularity
 Singularity can be used instead of Docker to run the full pipeline or individual modules. In this example we change the entrypoint to `recon-surf.sh` instead of the standard
@@ -73,26 +72,26 @@ Singularity can be used instead of Docker to run the full pipeline or individual
 Given you already ran the segmentation pipeline, and want to just run 
 the surface pipeline on top of it (i.e. on a different cluster), the following command can be used:
 ```bash
-# 1. Build the singularity image (if it does not exist)
-singularity build fastsurfer-cpu-v?.?.?.sif docker://deepmi/fastsurfer:cpu-v?.?.?
+# 1. Build the singularity image (only if it does not exist)
+singularity build fastsurfer-cpu-v{{ FASTSURFER_VERSION }}.sif docker://deepmi/fastsurfer:cpu-v{{ FASTSURFER_VERSION }}
 
 # 2. Run command
 singularity exec --no-home \
-                 -B /home/user/my_fastsurfer_analysis:/output \
-                 -B /home/user/my_fs_license_dir:/fs_license \
-                  ./fastsurfer-cpu-?.?.?.sif \
+                 -B $HOME/my_fastsurfer_analysis \
+                 -B $HOME/my_fs_license.txt \
+                  ./fastsurfer-cpu-{{ FASTSURFER_VERSION }}.sif \
                   /fastsurfer/recon_surf/recon-surf.sh \
-                  --fs_license /fs_license/license.txt \
-                  --sid subjectX --sd /output --3T \
-                  --t1 <path_to>/subjectX/mri/orig.mgz \
-                  --asegdkt_segfile <path_to>/subjectX/mri/aparc.DKTatlas+aseg.deep.mgz
+                  --fs_license $HOME/fs_license/license.txt \
+                  --sid subjectX --sd $HOME/my_fastsurfer_analysis --3T \
+                  --t1 $HOME/my_fastsurfer_analysis/subjectX/mri/orig.mgz \
+                  --asegdkt_segfile $HOME/my_fastsurfer_analysis/subjectX/mri/aparc.DKTatlas+aseg.deep.mgz
 ```
-Check [Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) to find out the latest release version and replace the "?". 
+Note: Go to [deepmi on Dockerhub](https://hub.docker.com/r/deepmi/fastsurfer/tags) to find the latest release version (automatically detected as `docker://deepmi/fastsurfer:cpu-v{{ FASTSURFER_VERSION }}`). 
 
 ### Singularity Flags: 
 * The `-B` commands mount your output, and directory with the FreeSurfer license file into the Singularity container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs_license). 
 
-* The `--no-home` command disables the automatic mount of the users home directory (see [Best Practice](../doc/overview/README.md#mounting-home))
+* The `--no-home` command disables the automatic mount of the users home directory (see [Best Practice](../doc/overview/SINGULARITY.md#mounting-home))
 
 The `--t1` and `--asegdkt_segfile` flags point to the already existing conformed T1 input and segmentation from the segmentation module. Also other files from that pipeline
 will be reused (e.g. the `mask.mgz`, `orig_nu.mgz`). The subject directory will then be populated with the FreeSurfer file structure, including surfaces, statistics 
@@ -100,31 +99,26 @@ and labels file (equivalent to a FreeSurfer recon-all run).
 
 ## Example 3: Native installation - recon-surf on a single subject (subjectX)
 
-Given you want to analyze data for subjectX which is stored on your computer under `/home/user/my_mri_data/subjectX/orig.mgz`, 
+Given you want to analyze data for subjectX which is stored on your computer under `$HOME/my_mri_data/subjectX/orig.mgz`, 
 run the following command from the console (do not forget to source FreeSurfer!):
 
 ```bash
-# Source FreeSurfer
+# Source FreeSurfer, defining FREESURFER_HOME will usually enable aut-detection in native installations
 export FREESURFER_HOME=/path/to/freesurfer
 source $FREESURFER_HOME/SetUpFreeSurfer.sh
 
-# Define data directory
-datadir=/home/user/my_mri_data
-segdir=/home/user/my_segmentation_data
-targetdir=/home/user/my_recon_surf_output  # equivalent to FreeSurfer's SUBJECTS_DIR
-
 # Run recon-surf
 ./recon-surf.sh --sid subjectX \
-                --sd $targetdir \
+                --sd $HOME/my_fastsurfer_analysis \
                 --py python3.10 \
                 --3T \
-                --t1 <path_to>/subjectX/mri/orig.mgz \
-                --asegdkt_segfile <path_to>/subjectX/mri/aparc.DKTatlas+aseg.deep.mgz
+                --t1 $HOME/my_fastsurfer_analysis/subjectX/mri/orig.mgz \
+                --asegdkt_segfile $HOME/my_fastsurfer_analysis/subjectX/mri/aparc.DKTatlas+aseg.deep.mgz
 ```
 
 The `--t1` and `--asegdkt_segfile` flags point to the already existing conformed T1 input and segmentation from the segmentation module. Also other files from that pipeline
-will be reused (e.g. the `mask.mgz`, `orig_nu.mgz`, i.e. under `/home/user/my_fastsurfeer_analysis/subjectX/mri/mask.mgz`). The `subjectX` directory will then be populated with the FreeSurfer file structure, including surfaces, statistics and labels file (equivalent to a FreeSurfer recon-all run). 
-The script will generate a bias-field corrected image at `/home/user/my_fastsurfeer_analysis/subjectX/mri/orig_nu.mgz`, if this did not already exist.
+will be reused (e.g. the `mask.mgz`, `orig_nu.mgz`, i.e. under `$HOME/my_fastsurfeer_analysis/subjectX/mri/mask.mgz`). The `subjectX` directory will then be populated with the FreeSurfer file structure, including surfaces, statistics and labels file (equivalent to a FreeSurfer recon-all run). 
+The script will generate a bias-field corrected image at `$HOME/my_fastsurfeer_analysis/subjectX/mri/orig_nu.mgz`, if this did not already exist.
 
 ### Example 4: recon-surf on multiple subjects
 
@@ -138,16 +132,16 @@ Invoke the following command (make sure you have enough resources to run the giv
 
 ```bash
 singularity exec --no-home \
-            -B /home/user/my_fastsurfer_analysis:/output \
-            -B /home/user/subjects_lists/:/lists \
-            -B /home/user/my_fs_license_dir:/fs_license \
-            ./fastsurfer.sif \
+            -B $HOME/my_fastsurfer_analysis \
+            -B $HOME/subjects_lists/ \
+            -B $HOME/my_fs_license.txt \
+            ./fastsurfer-cpu-{{ FASTSURFER_VERSION }}.sif \
             /fastsurfer/brun_fastsurfer.sh \
             --surf_only \
-            --subjects_list /lists/subjects_list.txt \
+            --subjects_list $HOME/subjects_lists//subjects_list.txt \
             --parallel_subjects \
-            --sd /output \
-            --fs_license /fs_license/license.txt \
+            --sd $HOME/my_fastsurfer_analysis \
+            --fs_license $HOME/my_fs_license.txt \
             --3T
 ```
 
@@ -157,50 +151,3 @@ mask and segmentations (as output by our FastSurfer segmentation networks, i.e. 
 The directory will then be populated with the FreeSurfer file structure, including surfaces, statistics and labels file (equivalent to a FreeSurfer recon-all run). The script will also generate a bias-field corrected image at `$subjects_dir/$subject_id/mri/orig_nu.mgz`, if this did not already exist.   
 
 The logs of individual subject's processing can be found in `$subjects_dir/$subject_id/scripts`. On the standard out (e.g. the console), the output from multiple subjects will be interleaved, but each line prepended by the subject id. 
-
-
-# Manual Edits
-
-## Brainmask Edits
-
-Currently, FastSurfer has only very limited functionality for manual edits due to missing entrypoints into the recon-surf script. Starting with FastSurfer v2 one frequently requested edit type (brainmask editing) is now possible, as the initial mask is created in the first segmentation stage. By running segmentation and surface processing in two steps, the mask can be edited in-between.
-
-For a **Docker setup** one can:
-
-1. Run segmentation only:
-    ```bash
-    docker run --gpus=all --rm --name $CONTAINER_NAME \
-                          -v $PATH_TO_IMAGE_DIR:$IMAGE_DIR \
-                          -v $PATH_TO_OUTPUT_DIR:$OUTPUT_DIR \
-                          --user $UID:$GID deepmi/fastsurfer:gpu-v?.?.? \
-                          --t1 $IMAGE_DIR/input.mgz \
-                          --sd $OUTPUT_DIR \
-                          --sid $SUBJECT_ID \
-                          --seg_only
-    ```
-2. Modify the ```$PATH_TO_OUTPUT_DIR/$SUBJECT_ID/mri/mask.mgz``` file as required.
-3. Run the following Docker command to run the surface processing pipeline (remove `--3T` if you are working with 1.5T data):
-    ```bash
-    docker run --rm --name $CONTAINER_NAME \
-               -v $PATH_TO_OUTPUT_DIR:$OUTPUT_DIR \
-               -v $PATH_TO_FS_LICENSE_DIR:$FS_LICENSE_DIR \
-               --user $UID:$GID deepmi/fastsurfer:gpu-v?.?.? \
-               --sid $SUBJECT_ID  \
-               --sd $OUTPUT_DIR/$SUBJECT_ID \
-               --surf_only --3T \
-               --fs_license $FS_LICENSE_DIR/license_file
-    ```
-
-For a **local install** you can similarly:
-
-1. Go to the FastSurfer directory, source FreeSurfer and run the segmentation step:
-    ```bash
-    cd $FASTSURFER_HOME
-    source $FREESURFER_HOME/SetUpFreeSurfer.sh
-    ./run_fastsurfer.sh --t1 $IMAGE_DIR/input.mgz --sd $OUTPUT_DIR --sid $SUBJECT_ID --seg_only
-    ```
-2. Modify the ```$OUTPUT_DIR/$SUBJECT_ID/mri/mask.mgz``` file.
-3. Run the surface pipeline (remove `--3T` if you are working with 1.5T data):
-    ```bash
-    ./run_fastsurfer.sh --sd $OUTPUT_DIR --sid $SUBJECT_ID --fs_license $FS_LICENSE_DIR/license_file --surf_only --3T
-    ```

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -129,10 +129,10 @@ FLAGS:
                             (smallest per-direction voxel size) in the T1w
                             image:
                               If the minimal voxel size is bigger than 0.98mm,
-                                the image is conformed to 1mm isometric.
+                                the image is conformed to 1mm isotropic.
                               If the minimal voxel size is smaller or equal to
                                 0.98mm, the T1w image will be conformed to
-                                isometric voxels of that voxel size.
+                                isotropic voxels of that voxel size.
                             The voxel size (whether set manually or derived)
                             determines whether the surfaces are processed with
                             highres options (below 1mm) or not.

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -86,14 +86,14 @@ Data- and subject-related options:
   Note: files will be copied here only after all jobs have finished, so most IO happens on
   a work directory, which can use IO-optimized cluster storage (see --work).
 --work: directory with fast filesystem on cluster
-  (default: \$HPCWORK/fastsurfer-processing/$(date +%Y%m%d-%H%M%S))
+  (default: \$HPCWORK/fastsurfer-processing/<date as YYMMDD-HHMMSS>)
   NOTE: THIS SCRIPT considers this directory to be owned by this script and job!
   No modifications should be made to the directory after the job is started until it is
   finished (if the job fails, cleanup of this directory may be necessary) and it should be
   empty!
 --data: (root) directory to search in for t1 files (default: current work directory).
 --pattern: glob string to find image files in 'data directory' (default: *.{nii,nii.gz,mgz}),
-   for example --data /data/ --pattern \*/\*/mri/t1.nii.gz
+   for example '--data /data/ --pattern "*/*/mri/t1.nii.gz"'
    will find all images of format /data/<somefolder>/<otherfolder>/mri/t1.nii.gz
 --subject_list: alternative way to define cases to process, files are of format:
   subject_id1=/path/to/t1.mgz

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -418,13 +418,13 @@ check_fs_license "$fs_license"
 check_seg_surf_only "$seg_only" "$surf_only"
 check_out_dir "$out_dir"
 
-if [[ "$cpu_only" == "true" ]] && [[ "$timelimit_seg" -lt 6 ]]
+if [[ "$cpu_only" == "true" ]] && [[ "$timelimit_seg" -lt 11 ]]
 then
   log "WARNING!!!"
   log "------------------------------------------------------------------------"
   log "You specified the segmentation shall be performed on the cpu, but the"
-  log "time limit per segmentation is less than 6 minutes (default is optimized "
-  log "for GPU acceleration @ 5 minutes). This is very likely insufficient!"
+  log "time limit per segmentation is less than 11 minutes (default is optimized "
+  log "for GPU acceleration @ 10 minutes). This is very likely insufficient!"
   log "------------------------------------------------------------------------"
 fi
 


### PR DESCRIPTION
FastSurfer has gained several new features since the last release but some features still need good or cleaned documentation.

This specifically includes 
- the `--tal_reg` flag to `run_fastsurfer.sh`
- hypothal options in `doc/overview/FLAGS.md`