### PR TITLE
Fix the run time calculation (rounded to integer hours in log file)

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1077,8 +1077,7 @@ fi
 # Collect info
 EndTime=$(date)
 tSecEnd=$(date '+%s')
-tRunHours=$(($((tSecEnd - tSecStart))/3600))
-tRunHours=$(printf %6.3f "$tRunHours")
+tRunHours=$(printf %6.3f "$(bc <<< "($tSecEnd - $tSecStart) / 3600")")
 
 {
   echo ""


### PR DESCRIPTION
bash arithmetic cannot do floating point numbers, and therefore, tRUNHours got rounded to integer.