### PR TITLE
Added explicit creation of nonroot user to Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -221,6 +221,7 @@ RUN cd /fastsurfer ; python3 FastSurferCNN/download_checkpoints.py --all && \
 
 # Set FastSurfer workdir and entrypoint
 #  the script entrypoint ensures that our conda env is active
+RUN useradd -m -s /bin/bash -u 1000 -g 1000 nonroot
 USER nonroot
 WORKDIR "/fastsurfer"
 ENTRYPOINT ["/fastsurfer/Docker/entrypoint.sh","/fastsurfer/run_fastsurfer.sh"]


### PR DESCRIPTION
Added explicit creation of non-root to the dockerfile. In some situations (e.g., containerd on Kubernetes) the home directory for the user (/home/nonroot) isn't necessarily created when the image is loaded. In this case, things get tricky because the nonroot user doesn't seem to have write access to any other paths. Also, explicitly coding in the useradd seems to be best practice (though this is obviously less relevant).