### PR TITLE
Extend PATH to include FastSurfer

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -195,7 +195,8 @@ RUN if [[ "$DEVICE" == "cu118" ]] ; then cd /venv/python3.10/site-packages/torch
 # Copy fastsurfer over from the build context and add PYTHONPATH
 COPY . /fastsurfer/
 ENV PYTHONPATH=/fastsurfer:/opt/freesurfer/python/packages \
-    FASTSURFER_HOME=/fastsurfer
+    FASTSURFER_HOME=/fastsurfer \
+    PATH=/fastsurfer:$PATH
 
 # Download all remote network checkpoints already, compile all FastSurfer scripts into
 # bytecode and update the build file with checkpoints md5sums and pip packages.


### PR DESCRIPTION
Currently, the fastsurfer folder (/fastsurfer) is not part of PATH. Adding this will make singularity and docker commands potentially easier:

```bash
singularity exec [options] run_fastsurfer.sh [options]
```

instead of

```bash
singularity exec [options] /fastsurfer/run_fastsurfer.sh [options]
```