### PR TITLE
Fixes a bug in srun_fastsurfer that processed the partition argument wrong

### DIFF
--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -372,8 +372,8 @@ debug "SLURM options:"
 debug "submit jobs and perform operations: $submit_jobs"
 debug "perform the cleanup step: $do_cleanup"
 debug "seg/surf running on slurm partition:" \
-  "$(first_non_empty_arg "$partition_seg" "$partition")" "/" \
-  "$(first_non_empty_arg "$partition_surf" "$partition")"
+  "$(first_non_empty_arg "$partition_seg" "$partition" "<default partition>")" "/" \
+  "$(first_non_empty_arg "$partition_surf" "$partition" "<default partition>")"
 debug "num_cpus_per_task/max. num_cases_per_task: $num_cpus_per_task/$num_cases_per_task"
 debug "segmentation on cpu only: $cpu_only"
 debug "Data options:"
@@ -572,8 +572,8 @@ then
     seg_cmd_file=$(mktemp)
   fi  # END OF NEW
 
-  slurm_part_=$(first_non_empty_partition "$partition_seg" "$partition")
-  if [[ -z "$slurm_part_" ]] ; then slurm_partition=() ; else slurm_partition=("$slurm_part_") ; fi
+  slurm_part_=$(first_non_empty_arg "$partition_seg" "$partition")
+  if [[ -z "$slurm_part_" ]] ; then slurm_partition=() ; else slurm_partition=(-p "$slurm_part_") ; fi
   {
     echo "#!/bin/bash"
     echo "module load singularity"
@@ -669,8 +669,8 @@ then
   if [[ "$mem_surf" -gt "$((mem_per_core * cores_per_task))" ]]; then
     mem_per_core=$((mem_per_core+1))
   fi
-  slurm_part_=$(first_non_empty_partition "$partition_surf" "$partition")
-  if [[ -z "$slurm_part_" ]] ; then slurm_partition=() ; else slurm_partition=("$slurm_part_") ; fi
+  slurm_part_=$(first_non_empty_arg "$partition_surf" "$partition")
+  if [[ -z "$slurm_part_" ]] ; then slurm_partition=() ; else slurm_partition=(-p "$slurm_part_") ; fi
   {
     echo "#!/bin/bash"
     echo "module load singularity"

--- a/stools.sh
+++ b/stools.sh
@@ -388,27 +388,10 @@ function make_copy_job ()
   fi
 }
 
-function first_non_empty_partition ()
-{
-  for i in "$@"
-  do
-    if [[ -n "$i" ]]
-    then
-      echo "-p $i"
-      break
-    fi
-  done
-}
 function first_non_empty_arg ()
 {
-  for i in "$@"
-  do
-    if [[ -n "$i" ]]
-    then
-      echo "$i"
-      break
-    fi
-  done
+  # returns the first argument to the function that was not empty
+  for i in "$@" ; do if [[ -n "$i" ]] ; then echo "$i" ; break ; fi ; done
 }
 function print_status ()
 {


### PR DESCRIPTION
Partition was read, but passed to `sbatch` as "-p <partition>" instead of as "-p" "<partition>"

This PR addresses a BUG reported in #580.

srun_fastsurfer.sh
- Fix the variable assignments of slurm_partition
- Use first_non_empty instead of first_non_empty_partition

stools.sh
- Remove the first_non_empty_partition function.