### PR TITLE
Support for edits

### DIFF
--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -1,125 +1,204 @@
-
 # Manual Edits
 
-## Pipeline
+We have noticed that FastSurfer results and neural net segmentations are often very robust and require few manual edits. 
+Therefore, and in contrast to FreeSurfer, much less manual editing is usually necessary. 
 
-FreeSurfer allows the user to perform manual edits at various places in their pipeline.
-A few of these can currently also be done in FastSurfer and we plan to add more in the future. 
-However, we have noticed that much less editing is necessary as the neural net segmentation is
-very robust. If users want to perform edits, it is important to understand that the order of
-processing steps is different in FastSurfer:
+However, FastSurfer allows manual edits in various stages of the pipeline. These editing options includes options that are inherited from FreeSurfer as well as some FastSurfer-specific editing options.
 
-1. We perform the segmentation in the *asegdkt module*. This step produces the segmentation file:
- - ```aparc.DKTatlas+aseg.deep.mgz```
-2. Within the *asegdkt module* this segmentation is then also reduced to the aseg without CC and a brainmask:
- - ```aseg.auto_noCCseg.mgz```
- - ```mask.mgz```
-3. Finally the *asegdkt module* computes a bias field corrected version of the conformed input image (needed to compute partial volume estimates for the stats file):
- - ```orig_nu.mgz```
-4. After potentially other segmentation modules, the *surface module* (*recon-surf*) is run, which uses the above files as input.
+The FastSurfer team plans to add more editing options, if they are feasible and there is interest in the community.
+We also invite users to [contribute](CONTRIBUTING.md) such changes and datasets of paired MRI images and edited files to improve FastSurfer's neural networks.  
+
+## What can be edited?
+
+Most edits primarily affect FastSurfer's surface pipeline and edits of the segmentation pipeline are both easier to understand and more limited in scope.
+
+To understand how edits affect different results and how perform edits, it is important to understand the order of processing steps in FastSurfer. 
+This also explains which edits affect which results.
+
+## Pipeline overview
+
+The FastSurfer pipeline comprises segmentation modules and the surface module.
+
+The relevant modules are:
+1. The *asegdkt module* outputs:
+   - as the primary output: the whole brain segmentation (default name: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`)
+   - as secondary outputs from the whole brain segmentation: 
+     - the aseg without CC segmentation (`<subject_dir>/mri/aseg.auto_noCCseg.mgz`) and 
+     - the brainmask (`<subject_dir>/mri/mask.mgz`).
+2. The *biasfield module* computes based on the white matter segmentation (from aseg):
+   - a bias field corrected version of the conformed input image (`<subject_dir>/mri/orig_nu.mgz`) and
+   - optionally may also perform a talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`).
+3. Other segmentation modules (e.g. the hypothalamus segmentation) use the biasfield corrected image as input.  
+4. The *surface module* (*recon-surf*) generates surfaces and stats files based on all these outputs. This surface module includes:
+   1. a talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`), if not already performed before,
+   2. the segment (`<subject_dir>/mri/wm.mgz`) and fill (`<subject_dir>/mri/filled.mgz`) white matter to initialize surfaces and
+   3. inflation to pial surfaces (`<subject_dir>/mri/brain.finalsurfs.mgz`).
 
 ## Possible Edits
 
-Currently there is no way to interact with the surface module (stopping and resuming it).
-Therefore, some typical FreeSurfer edits (such as brain finalsurfs) are not available.
-Other edits (e.g. placement of WM control points) are not meaningful, as the segmentation is done differently with our neural network in the *asegdkt module*.
+As FastSurfer's surface pipeline is derived from FreeSurfer, the edit options and inconsistent naming schemes are inherited from FreeSurfer. FastSurfer supports the following edits: 
+1. asegdkt_segfile: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` via `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`
+2. the talairach registration: `<subject_dir>/mri/transforms/talairach.xfm` (overwrites automatic results from `<subject_dir>/mri/transforms/talairach.auto.xfm`)
+3. white matter segmentation: `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz`
+4. pial placement: `<subject_dir>/mri/brain.finalsurfs.mgz` via `<subject_dir>/mri/brain.finalsurfs.manedit.mgz`
 
-Therefore, currently three types of edits are possible:
+## General process
+Edits in this list require an update of the subject directory and "re-processing" with the `--edits` flag of `run_fastsurfer.sh`.
 
-## 1. T1 Pre-Processing: 
-Instead of using the original scan as input, you can perform a bias field correction as a pre-processing step. This can also be achieved by running the *asegdkt module* twice (using different subject ids). The second time you input the bias field corrected image ```orig_nu.mgz```
-that was provided from the first run. This can help brighten up some regions and improve segmentation quality for some difficult cases.
+For example (including setup for native processing, see [Examples](EXAMPLES.md) for other processing options):
 
-- Step 1: In first iteration of field correction method run full pipeline as follows: 
-   ```bash
-   # Source FreeSurfer
-   export FREESURFER_HOME=/path/to/freesurfer
-   source $FREESURFER_HOME/SetUpFreeSurfer.sh
+```bash
+# Setup FASTSURFER and FREESURFER
+export FASTSURFER_HOME=/path/to/fastsurfer
+export FREESURFER_HOME=/path/to/freesurfer
+source $FREESURFER_HOME/SetUpFreeSurfer.sh
 
-   # Define data directory
-   datadir=/home/user/my_mri_data
-   fastsurferdir=/home/user/my_fastsurfer_analysis
+# Define data directory
+export SUBJECTS_DIR=/home/user/my_fastsurfer_analysis
 
-   # Run FastSurfer
-   ./run_fastsurfer.sh --t1 $datadir/subjectX/t1-weighted-nii.gz \
-                    --sid subjectX --sd $fastsurferdir \
-                    --parallel --threads 4 --3T
+# Run FastSurfer
+$FASTSURFER_HOME/run_fastsurfer.sh \
+    --sd $SUBJECTS_DIR --sid case_with_edits \
+    --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
+    --fs_license $FREESURFER_HOME/.license \
+    --edits # more flags as you needed, e.g. --parallel --3T --threads 4
+```
+
+Note, a rerun of the segmentation pipeline should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
+
+Skip the segmentation step with
+```bash
+# Setup FASTSURFER and FREESURFER ... (see above)
+
+# Run FastSurfer
+$FASTSURFER_HOME/run_fastsurfer.sh \
+    --sd $SUBJECTS_DIR --sid case_with_edits \
+    --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
+    --fs_license $FREESURFER_HOME/.license \
+    --edits --surf_only # more flags as you needed, e.g. --parallel --3T --threads 4
+```
+
+The first edit is "outside" of the FastSurfer pipeline.
+
+## Bias field correction
+
+### When to use 
+asegdkt module failed or produced unreliable segmentation maps, especially if bias fields are very strong as for example for 7T images. 
+This can be detected by inspecting `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`, `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
+
+### What to do 
+Perform bias field correction prior to segmentation (FastSurfer). Sometimes, even FastSurfer's own bias field correction can help, which can be found in `<subject_dir>/mri/orig_nu.mgz`.
+Alternatively, external bias field correction tools may help (e.g. bias_correct from SPM).
+Run FastSurfer as a new run on this new input file.
+
+For example:
+- Step 1: FastSurfer for bias field correction (not needed if you already processed with FastSurfer a first time): 
+  ```bash
+  # Setup FASTSURFER and FREESURFER ... (see above)
+  
+  # Run FastSurfer
+  $FASTSURFER_HOME/run_fastsurfer.sh \
+      --sd $SUBJECTS_DIR --sid case_bias_only \
+      --t1 /path/to/the/original/T1.mgz \
+      --seg_only --no_hypothal --no_cereb --threads 16
    ```
-- Step 2: Run pipeline again for the second time, however this time input the bias field corrected image i.e ```orig_nu.mgz``` instead of original input image which was produced in first iteration. The file ```orig_nu.mgz``` can be found in output directory in mri subfolder. The output produced from the second iteration can be saved in a different output directory for comparative analysis with the output produced in first iteration.
-   ```bash
-    # Run FastSurfer
-   ./run_fastsurfer.sh --t1 $datadir/subjectX/t1-weighted-nii.gz \
-                    --sid subjectX --sd $fastsurferdir \
-                    --parallel --threads 4 --3T
+- Step 2: Run FastSurfer again, but on the however this time input the bias field corrected image i.e ```orig_nu.mgz``` instead of original input image which was produced in first iteration. The file ```orig_nu.mgz``` can be found in output directory in mri subfolder. The output produced from the second iteration can be saved in a different output directory for comparative analysis with the output produced in first iteration.
+  ```bash
+  # Setup FASTSURFER and FREESURFER ... (see above)
+
+  # Run FastSurfer
+  $FASTSURFER_HOME/run_fastsurfer.sh \
+      --sd $SUBJECTS_DIR --sid case_bias_corrected \
+      --t1 $SUBJECTS_DIR/case_bias_only/mri/orig_nu.mgz \
+      --fs_license $FREESURFER_HOME/.license # more flags as you needed, e.g. --parallel --3T --threads 4
    ```
+- Step 3: Compare and check if bias field correction fixed the issues:
+  ```bash
+  freeview $SUBJECTS_DIR/case_bias_only/mri/orig_nu.mgz $SUBJECTS_DIR/case_bias_corrected/mri/aparc.DKTatlas+aseg.deep.mgz $SUBJECTS_DIR/case_bias_only/mri/orig_nu.mgz $SUBJECTS_DIR/case_bias_corrected/mri/aparc.DKTatlas+aseg.deep.mgz
+  ```
 
-- Step 3: Run freeview or visualization 
-   ```bash 
-   freeview /path/to/output_directory/orig_nu.mgz
-   ``` 
-   Note: ```orig_nu.mgz``` file is not a segmented file, for segmentation load ```aparc.DKTatlas+aseg.deep.edited.mgz``` in freeview.
+## asegdkt_segfile
 
+### When to use 
+(Minor) Segmentation errors such as over- and under-segmentation. Of the gray and white matter, but also subcortical structures.
+In particular, over- and under-segmentation of the brainmask, gray matter over segmentation into the dura, white matter undersegmentation in the cortex (causing missed gyri or cortical thickness overestimation).
+In specific, such errors are detected in `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`, `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
-## 2. Segmentation Edits
+### What to do
+1. Copy `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` to `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`.
+2. Open and edit `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz` fixing any errors.
+3. [Re-run FastSurfer](#general-process) to update `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
-You can manually edit ```aparc.DKTatlas+aseg.deep.mgz```. This is similar to aseg edits in FreeSurfer. You can fill-in undersegmented regions (with the correct segmentation ID). To re-create the aseg and mask run the following command before continuing with other modules:
+<details><summary>Similar FreeSurfer edits</summary>
 
-- Step 1: Assuming that you have run the full fastsurfer pipeline once as described in method_1 and successfully produced segmentations and surfaces
-- Step 2: Execute this command where reduce_to_aseg.py is located
-   ```bash
-   python3 reduce_to_aseg.py -i sid/mri/aparc.DKTatlas+aseg.deep.edited.mgz \ 
-                             -o sid/mri/aseg.auto_noCCseg.mgz \
-                             --outmask sid/mri/mask.mgz \
-                             --fixwm
-   ```
-   Assuming you have edited ```aparc.DKTatlas+aseg.deep.edited.mgz``` in freeview, step_2 will produce two files i.e ```aseg.auto_noCCseg.mgz``` and ```mask.mgz ``` in the specified output folder. The output files can be loaded in freeview as a load volume. Edit-->load volume
+1. Skull stripping: Edit `<subject_dir>/mri/brainmask.mgz` (delta to `brainmask.auto.mgz`)
+2. Brain extraction: Edit `<subject_dir>/mri/brain.mgz` (delta to `brain.auto.mgz`)
+3. Subcortical segmentation: `<subject_dir>/mri/aseg.presurf.mgz` (delta to `aseg.presurf.auto.mgz`)
+4. CRS seeds: PONS, CC, LH, RH => seed files (`$subjdir/scripts/seed-(pons|cc|lh|rh|ws).crs.man.dat`)
+5. watershed seed: seed file (`$subjdir/scripts/seed-ws.crs.man.dat`)
 
-- Step 3: For this step you would have to copy segmentation files produced in step_1, edited file ```aparc.DKTatlas+aseg.deep.edited.mgz``` and re-created file produced in step_2 in new output directory beforehand. 
+</details>
 
-   In this step you can then run surface module as follows:
-   ```bash
-   # Source FreeSurfer
-   export FREESURFER_HOME=/path/to/freesurfer
-   source $FREESURFER_HOME/SetUpFreeSurfer.sh
+## Talairach registration
 
-   # Define data directory
-   datadir=/home/user/my_mri_data
-   fastsurferdir=/home/user/my_fastsurfer_analysis
+### When to use 
+The estimated total intracranial volume is wrong.
 
-   # Run FastSurfer
-   ./run_fastsurfer.sh --t1 $datadir/subjectX/t1-weighted-nii.gz \
-                     --sid subjectX --sd $fastsurferdir \
-                     --parallel --threads 4 \
-                     --surf_only
-   ```
-   Note: ```t1-weighted-nii.gz``` would be the original input mri image.
-   
-   Do not forget to give fullpath to the input and output folder unless specified in variables.
+### What to do 
+1. Copy and edit `<subject_dir>/mri/transforms/talairach.xfm` replacing the old file.
+2. [Re-run FastSurfer](#general-process) to update the eTIV value in all stats files.
 
-## 3. Brainmask Edits: 
-When surfaces go out too far, e.g. they grab dura, you can tighten the mask directly, just edit ```mask.mgz```and start the *surface module*. 
+See also: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/Talairach
 
-- Step 1: Assuming that you have run the full fastsurfer pipeline once as described in method_1 and successfully produced segmentations and surfaces
-- Step 2: Edit ```mask.mgz``` file in freeview
-- Step 3: Run the pipeline again in order to get the surfaces but before running the pipeline again do not forget to copy all the segmented files in to new input and output directory. 
-   Note: The files in output folder should be pasted in the subjectX folder, the name of subjectX should be the same as it was used in step_1 otherwise it would raise an error of missing files even though the segmentation files exists in output folder.
-   ```bash
-   # Source FreeSurfer
-   export FREESURFER_HOME=/path/to/freesurfer
-   source $FREESURFER_HOME/SetUpFreeSurfer.sh
+<details><summary>Similar FreeSurfer edits</summary>
 
-   # Define data directory
-   datadir=/home/user/my_mri_data
-   fastsurferdir=/home/user/my_fastsurfer_analysis
+Talairach registration
 
-   # Run FastSurfer
-   ./run_fastsurfer.sh --t1 $datadir/subjectX/t1-weighted-nii.gz \
-                     --sid subjectX --sd $fastsurferdir \
-                     --parallel --threads 4 \
-                     --surf_only
-   ```
+</details>
 
-   Note: ```t1-weighted-nii.gz``` would be the original input mri image.
+## White matter segmentation
 
-   We hope that this will help with (some of) your editing needs. If more edits become available we will update this file. 
-   Thanks for using FastSurfer. 
+### When to use
+Over- and/or under-segmentation of the white matter: voxels that should be white matter are excluded, or those that should not are included.
+
+### What to do
+Often, these errors should be fixed in [#asegdkt_segfile] `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz` can be edited to fix the initial white matter surface.
+
+The manual label 255 indicates a voxel should be included in the white matter and a voxel labeled 1 should not.
+
+See also: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/WhiteMatterEdits_freeview
+
+<details><summary>Similar FreeSurfer edits</summary>
+
+1. WM control points `$ControlPointsFile`: `<subject_dir>/tmp/control.dat`
+2. in-file edits of the white matter segmentation: `<subject_dir>/mri/wm.mgz` (delta to `wm.auto.mgz`)
+3. in-file edits of the filled Fill white matter segmentation: `<subject_dir>/mri/filled.mgz` (delta to `filled.auto.mgz`)
+
+</details>
+
+## Pial surface placement
+
+### When to use
+Over- and/or under-segmentation of the cortical gray matter: voxels that should be gray matter are excluded, or those that should not are included.
+
+### What to do
+Often, these errors should be fixed in [#asegdkt_segfile] `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (overwriting values in `<subject_dir>/mri/brain.finalsurfs.mgz`) can be edited to fix the pial surface.
+The manual label 255 indicates a voxel should be included in the gray matter and a voxel labeled 1 should not.
+
+See also: https://surfer.nmr.mgh.harvard.edu/fswiki/Edits#brain.finalsurfs.mgz
+
+<details><summary>Similar FreeSurfer edits</summary>
+
+pial placement correction: `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (delta to `brain.finalsurfs.mgz`)
+
+</details>
+
+## Side effects of edits
+
+Technically, all edits are changes to the processing pipeline and may cause systematic effects in the analysis.
+Computational edits (e.g. [bias field correction](#bias-field-correction)) should be integrated systematically.
+Other effects are impossible to avoid (edit carefully), often very small and hard to account for. 
+It is recommended to analyze whether files with edits distort results in a specific direction, i.e. how do effect sizes change if manually edited cases are excluded?
+
+We hope that this will help with (some of) your editing needs. 
+Thanks for using FastSurfer. 

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -1,46 +1,46 @@
 # Manual Edits
 
-We have noticed that FastSurfer results and neural net segmentations are often very robust and require few manual edits. 
-Therefore, and in contrast to FreeSurfer, much less manual editing is usually necessary. 
+We have noticed that FastSurfer segmentations and surface results are very robust and rarely require any manual edits. 
+However, for your convenience, we allow manual edits in various stages of the FastSurfer pipeline.
+These editing options include approaches that are inherited from FreeSurfer as well as some FastSurfer-specific editing options.
 
-However, FastSurfer allows manual edits in various stages of the pipeline. These editing options includes options that are inherited from FreeSurfer as well as some FastSurfer-specific editing options.
-
-The FastSurfer team plans to add more editing options, if they are feasible and there is interest in the community.
-We also invite users to [contribute](CONTRIBUTING.md) such changes and datasets of paired MRI images and edited files to improve FastSurfer's neural networks.  
+The provided editing options may be changed or extended in the future, also depending on requests from the community.
+Furthermore, we invite users to [contribute](CONTRIBUTING.md) such changes and/or datasets of paired MRI images and edited files to improve FastSurfer's neural networks.  
 
 ## What can be edited?
 
-Most edits primarily affect FastSurfer's surface pipeline and edits of the segmentation pipeline are both easier to understand and more limited in scope.
-
-To understand how edits affect different results and how perform edits, it is important to understand the order of processing steps in FastSurfer. 
-This also explains which edits affect which results.
+Edits primarily affect FastSurfer's surface pipeline but some edits exist also during the segmentation steps.
+To understand how edits affect different results and how to perform them, it is important to understand the order of processing steps in FastSurfer. 
 
 ## Pipeline overview
 
 The FastSurfer pipeline comprises segmentation modules and the surface module.
 
-The relevant modules are:
-1. The *asegdkt module* outputs:
+The outputs of the relevant modules are:
+1. The *asegdkt module*:
    - as the primary output: the whole brain segmentation (default name: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`)
    - as secondary outputs from the whole brain segmentation: 
      - the aseg without CC segmentation (`<subject_dir>/mri/aseg.auto_noCCseg.mgz`) and 
      - the brainmask (`<subject_dir>/mri/mask.mgz`).
-2. The *biasfield module* computes based on the white matter segmentation (from aseg):
-   - a bias field corrected version of the conformed input image (`<subject_dir>/mri/orig_nu.mgz`) and
-   - optionally may also perform a talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`).
+2. The *biasfield module* uses the white matter segmentation (from aseg) and computes:
+   - a bias field-corrected version of the conformed input image (`<subject_dir>/mri/orig_nu.mgz`) and
+   - optionally may also perform a Talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`).
 3. Other segmentation modules (e.g. the hypothalamus segmentation) use the biasfield corrected image as input.  
-4. The *surface module* (*recon-surf*) generates surfaces and stats files based on all these outputs. This surface module includes:
-   1. a talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`), if not already performed before,
-   2. the segment (`<subject_dir>/mri/wm.mgz`) and fill (`<subject_dir>/mri/filled.mgz`) white matter to initialize surfaces and
-   3. inflation to pial surfaces (`<subject_dir>/mri/brain.finalsurfs.mgz`).
+4. The *surface module* (*recon-surf*) generates surfaces and stats files based on outputs from the *asegdkt module*, including:
+   1. a Talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`), if not already performed before,
+   2. the WM segmentation (`<subject_dir>/mri/wm.mgz`) and filled version (`<subject_dir>/mri/filled.mgz`) to initialize surfaces and
+   3. a brainmask (`<subject_dir>/mri/brain.finalsurfs.mgz`) to guide the positioning of the pial surfaces.
 
 ## Possible Edits
 
-As FastSurfer's surface pipeline is derived from FreeSurfer, the edit options and inconsistent naming schemes are inherited from FreeSurfer. FastSurfer supports the following edits: 
-1. asegdkt_segfile: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` via `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`
-2. the talairach registration: `<subject_dir>/mri/transforms/talairach.xfm` (overwrites automatic results from `<subject_dir>/mri/transforms/talairach.auto.xfm`)
-3. white matter segmentation: `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz`
-4. pial placement: `<subject_dir>/mri/brain.finalsurfs.mgz` via `<subject_dir>/mri/brain.finalsurfs.manedit.mgz`
+FastSurfer supports the following edits: 
+1. Bias field corrected inputs (for improved image quality, not really an edit)
+2. asegdkt_segfile: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` via `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`
+3. Talairach registration: `<subject_dir>/mri/transforms/talairach.xfm` (overwrites automatic results from `<subject_dir>/mri/transforms/talairach.auto.xfm`)
+4. White matter segmentation: `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz`
+5. Pial placement: `<subject_dir>/mri/brain.finalsurfs.mgz` via `<subject_dir>/mri/brain.finalsurfs.manedit.mgz`
+
+Note, as FastSurfer's surface pipeline is derived from FreeSurfer, some edit options and corresponding naming schemes are inherited from FreeSurfer.
 
 ## General process
 Edits in this list require an update of the subject directory and "re-processing" with the `--edits` flag of `run_fastsurfer.sh`.
@@ -64,9 +64,8 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
     --edits # more flags as you needed, e.g. --parallel --3T --threads 4
 ```
 
-Note, a rerun of the segmentation pipeline should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
-
-Skip the segmentation step with
+Note, a rerun of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
+There, we can usually skip the segmentation step with
 ```bash
 # Setup FASTSURFER and FREESURFER ... (see above)
 
@@ -78,21 +77,21 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
     --edits --surf_only # more flags as you needed, e.g. --parallel --3T --threads 4
 ```
 
-The first edit is "outside" of the FastSurfer pipeline.
-
 ## Bias field correction
 
+This edit is "outside" of the FastSurfer pipeline and not really an edit.
+
 ### When to use 
-asegdkt module failed or produced unreliable segmentation maps, especially if bias fields are very strong as for example for 7T images. 
+The *asegdkt module* failed or produced unreliable segmentation maps, especially if bias fields are very strong as for example for 7T images. 
 This can be detected by inspecting `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`, `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
 ### What to do 
-Perform bias field correction prior to segmentation (FastSurfer). Sometimes, even FastSurfer's own bias field correction can help, which can be found in `<subject_dir>/mri/orig_nu.mgz`.
-Alternatively, external bias field correction tools may help (e.g. bias_correct from SPM).
+Perform bias field correction prior to segmentation (FastSurfer) and provide the bias corrected image as input. Sometimes, even FastSurfer's own bias field correction can help, which can be found in `<subject_dir>/mri/orig_nu.mgz`.
+Alternatively, external bias field correction tools may help (e.g. *bias_correct* from SPM).
 Run FastSurfer as a new run on this new input file.
 
 For example:
-- Step 1: FastSurfer for bias field correction (not needed if you already processed with FastSurfer a first time): 
+- Step 1: Run FastSurfer to obrtain a bias field corrected image (not needed if you already processed with FastSurfer a first time): 
   ```bash
   # Setup FASTSURFER and FREESURFER ... (see above)
   
@@ -102,7 +101,7 @@ For example:
       --t1 /path/to/the/original/T1.mgz \
       --seg_only --no_hypothal --no_cereb --threads 16
    ```
-- Step 2: Run FastSurfer again, but on the however this time input the bias field corrected image i.e ```orig_nu.mgz``` instead of original input image which was produced in first iteration. The file ```orig_nu.mgz``` can be found in output directory in mri subfolder. The output produced from the second iteration can be saved in a different output directory for comparative analysis with the output produced in first iteration.
+- Step 2: Run FastSurfer again, but this time input the bias field corrected image i.e ```orig_nu.mgz``` instead of original input image. The file ```orig_nu.mgz``` can be found in the output directory under the *mri* subfolder. The output produced from the second iteration should be saved in a different output directory for comparative analysis with the output produced in first iteration.
   ```bash
   # Setup FASTSURFER and FREESURFER ... (see above)
 
@@ -120,9 +119,9 @@ For example:
 ## asegdkt_segfile
 
 ### When to use 
-(Minor) Segmentation errors such as over- and under-segmentation. Of the gray and white matter, but also subcortical structures.
+(Minor) Segmentation errors such as over- and under-segmentation, of the gray and white matter, but also subcortical structures.
 In particular, over- and under-segmentation of the brainmask, gray matter over segmentation into the dura, white matter undersegmentation in the cortex (causing missed gyri or cortical thickness overestimation).
-In specific, such errors are detected in `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`, `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
+In specific, such errors are inspected in `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`, `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
 ### What to do
 1. Copy `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` to `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`.
@@ -131,6 +130,7 @@ In specific, such errors are detected in `<subject_dir>/mri/aparc.DKTatlas+aseg.
 
 <details><summary>Similar FreeSurfer edits</summary>
 
+These are some edits that are possible in FreeSurfer and would be fixed by our asegdkt_segfile edits above:
 1. Skull stripping: Edit `<subject_dir>/mri/brainmask.mgz` (delta to `brainmask.auto.mgz`)
 2. Brain extraction: Edit `<subject_dir>/mri/brain.mgz` (delta to `brain.auto.mgz`)
 3. Subcortical segmentation: `<subject_dir>/mri/aseg.presurf.mgz` (delta to `aseg.presurf.auto.mgz`)
@@ -142,7 +142,7 @@ In specific, such errors are detected in `<subject_dir>/mri/aparc.DKTatlas+aseg.
 ## Talairach registration
 
 ### When to use 
-The estimated total intracranial volume is wrong.
+The estimated total intracranial volume is inaccurate.
 
 ### What to do 
 1. Copy and edit `<subject_dir>/mri/transforms/talairach.xfm` replacing the old file.

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -74,7 +74,7 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
 ```
 
 Note, a re-run of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
-There, we can usually skip the segmentation step with
+Therefore, in most cases, we can skip the segmentation step with
 ```bash
 # Setup FASTSURFER and FREESURFER ... (see above)
 
@@ -168,13 +168,11 @@ See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/WhiteMatterEdits
 ### When to use
 Over- and/or under-segmentation of the cortical gray matter: voxels that should be gray matter are excluded, or those that should not are included.
 
-This explicitly 
 
 ### What to do
 Often, these errors should be fixed in [asegdkt_segfile](#asegdkt_segfile) `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not successful:
 1. Open end edit `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (overwriting values in `<subject_dir>/mri/brain.finalsurfs.mgz`).
 2. [Re-run FastSurfer](#general-process) to fix the pial surface. 
-3. 
 The manual label 255 indicates a voxel should be included in the gray matter and a voxel labeled 1 should not.
 
 See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/Edits#brain.finalsurfs.mgz>

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -17,16 +17,16 @@ To understand how edits affect different results and how to perform them, it is 
 The FastSurfer pipeline comprises segmentation modules and the surface module.
 
 The outputs of the relevant modules are:
-1. The *asegdkt module*:
+1. The **asegdkt module**:
    - as the primary output: the whole brain segmentation (default name: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`)
    - as secondary outputs from the whole brain segmentation: 
      - the aseg without CC segmentation (`<subject_dir>/mri/aseg.auto_noCCseg.mgz`) and 
      - the brainmask (`<subject_dir>/mri/mask.mgz`).
-2. The *biasfield module* uses the white matter segmentation (from aseg) and computes:
+2. The **biasfield module** uses the white matter segmentation (from aseg) and computes:
    - a bias field-corrected version of the conformed input image (`<subject_dir>/mri/orig_nu.mgz`) and
    - optionally may also perform a Talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`).
 3. Other segmentation modules (e.g. the hypothalamus segmentation) use the biasfield corrected image as input.  
-4. The *surface module* (*recon-surf*) generates surfaces and stats files based on outputs from the *asegdkt module*, including:
+4. The **surface module** (**recon-surf**) generates surfaces and stats files based on outputs from the **asegdkt module**, including:
    1. a Talairach registration (`<subject_dir>/mri/transforms/talairach.(xfm|lta)`), if not already performed before,
    2. the WM segmentation (`<subject_dir>/mri/wm.mgz`) and filled version (`<subject_dir>/mri/filled.mgz`) to initialize surfaces and
    3. a brainmask (`<subject_dir>/mri/brain.finalsurfs.mgz`) to guide the positioning of the pial surfaces.
@@ -34,11 +34,11 @@ The outputs of the relevant modules are:
 ## Possible Edits
 
 FastSurfer supports the following edits: 
-1. Bias field corrected inputs (for improved image quality, not really an edit)
-2. asegdkt_segfile: `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` via `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`
-3. Talairach registration: `<subject_dir>/mri/transforms/talairach.xfm` (overwrites automatic results from `<subject_dir>/mri/transforms/talairach.auto.xfm`)
-4. White matter segmentation: `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz`
-5. Pial placement: `<subject_dir>/mri/brain.finalsurfs.mgz` via `<subject_dir>/mri/brain.finalsurfs.manedit.mgz`
+1. [Bias field corrected inputs](#bias-field-correction) (for improved image quality, not really an edit)
+2. [asegdkt_segfile](#asegdkt_segfile): `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` via `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`
+3. [Talairach registration](#talairach-registration): `<subject_dir>/mri/transforms/talairach.xfm` (overwrites automatic results from `<subject_dir>/mri/transforms/talairach.auto.xfm`)
+4. [White matter segmentation](#white-matter-segmentation): `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz`
+5. [Pial placement](#pial-surface-placement): `<subject_dir>/mri/brain.finalsurfs.mgz` via `<subject_dir>/mri/brain.finalsurfs.manedit.mgz`
 
 Note, as FastSurfer's surface pipeline is derived from FreeSurfer, some edit options and corresponding naming schemes are inherited from FreeSurfer.
 
@@ -61,10 +61,10 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
     --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
     --fs_license $FREESURFER_HOME/.license \
-    --edits # more flags as you needed, e.g. --parallel --3T --threads 4
+    --edits # more flags as needed, e.g. --parallel --3T --threads 4
 ```
 
-Note, a rerun of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
+Note, a re-run of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
 There, we can usually skip the segmentation step with
 ```bash
 # Setup FASTSURFER and FREESURFER ... (see above)
@@ -74,7 +74,7 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
     --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
     --fs_license $FREESURFER_HOME/.license \
-    --edits --surf_only # more flags as you needed, e.g. --parallel --3T --threads 4
+    --edits --surf_only # more flags as needed, e.g. --parallel --3T --threads 4
 ```
 
 ## Bias field correction
@@ -91,7 +91,7 @@ Alternatively, external bias field correction tools may help (e.g. *bias_correct
 Run FastSurfer as a new run on this new input file.
 
 For example:
-- Step 1: Run FastSurfer to obrtain a bias field corrected image (not needed if you already processed with FastSurfer a first time): 
+- Step 1: Run FastSurfer to obtain a bias field corrected image (not needed if you already processed with FastSurfer a first time): 
   ```bash
   # Setup FASTSURFER and FREESURFER ... (see above)
   
@@ -101,7 +101,7 @@ For example:
       --t1 /path/to/the/original/T1.mgz \
       --seg_only --no_hypothal --no_cereb --threads 16
    ```
-- Step 2: Run FastSurfer again, but this time input the bias field corrected image i.e ```orig_nu.mgz``` instead of original input image. The file ```orig_nu.mgz``` can be found in the output directory under the *mri* subfolder. The output produced from the second iteration should be saved in a different output directory for comparative analysis with the output produced in first iteration.
+- Step 2: Run FastSurfer again, but this time input the bias field corrected image (i.e. ```orig_nu.mgz```) instead of original input image. The file ```orig_nu.mgz``` can be found in the output directory under the *mri* subfolder. The output produced from the second iteration should be saved in a different output directory for comparative analysis with the output produced in first iteration.
   ```bash
   # Setup FASTSURFER and FREESURFER ... (see above)
 
@@ -109,7 +109,7 @@ For example:
   $FASTSURFER_HOME/run_fastsurfer.sh \
       --sd $SUBJECTS_DIR --sid case_bias_corrected \
       --t1 $SUBJECTS_DIR/case_bias_only/mri/orig_nu.mgz \
-      --fs_license $FREESURFER_HOME/.license # more flags as you needed, e.g. --parallel --3T --threads 4
+      --fs_license $FREESURFER_HOME/.license # more flags as needed, e.g. --parallel --3T --threads 4
    ```
 - Step 3: Compare and check if bias field correction fixed the issues:
   ```bash
@@ -128,17 +128,6 @@ In specific, such errors are inspected in `<subject_dir>/mri/aparc.DKTatlas+aseg
 2. Open and edit `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz` fixing any errors.
 3. [Re-run FastSurfer](#general-process) to update `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
-<details><summary>Similar FreeSurfer edits</summary>
-
-These are some edits that are possible in FreeSurfer and would be fixed by our asegdkt_segfile edits above:
-1. Skull stripping: Edit `<subject_dir>/mri/brainmask.mgz` (delta to `brainmask.auto.mgz`)
-2. Brain extraction: Edit `<subject_dir>/mri/brain.mgz` (delta to `brain.auto.mgz`)
-3. Subcortical segmentation: `<subject_dir>/mri/aseg.presurf.mgz` (delta to `aseg.presurf.auto.mgz`)
-4. CRS seeds: PONS, CC, LH, RH => seed files (`$subjdir/scripts/seed-(pons|cc|lh|rh|ws).crs.man.dat`)
-5. watershed seed: seed file (`$subjdir/scripts/seed-ws.crs.man.dat`)
-
-</details>
-
 ## Talairach registration
 
 ### When to use 
@@ -148,13 +137,7 @@ The estimated total intracranial volume is inaccurate.
 1. Copy and edit `<subject_dir>/mri/transforms/talairach.xfm` replacing the old file.
 2. [Re-run FastSurfer](#general-process) to update the eTIV value in all stats files.
 
-See also: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/Talairach
-
-<details><summary>Similar FreeSurfer edits</summary>
-
-Talairach registration
-
-</details>
+See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/Talairach>
 
 ## White matter segmentation
 
@@ -166,39 +149,50 @@ Often, these errors should be fixed in [#asegdkt_segfile] `<subject_dir>/mri/apa
 
 The manual label 255 indicates a voxel should be included in the white matter and a voxel labeled 1 should not.
 
-See also: https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/WhiteMatterEdits_freeview
-
-<details><summary>Similar FreeSurfer edits</summary>
-
-1. WM control points `$ControlPointsFile`: `<subject_dir>/tmp/control.dat`
-2. in-file edits of the white matter segmentation: `<subject_dir>/mri/wm.mgz` (delta to `wm.auto.mgz`)
-3. in-file edits of the filled Fill white matter segmentation: `<subject_dir>/mri/filled.mgz` (delta to `filled.auto.mgz`)
-
-</details>
+See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/WhiteMatterEdits_freeview>
 
 ## Pial surface placement
 
 ### When to use
 Over- and/or under-segmentation of the cortical gray matter: voxels that should be gray matter are excluded, or those that should not are included.
 
+This explicitly 
+
 ### What to do
-Often, these errors should be fixed in [#asegdkt_segfile] `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (overwriting values in `<subject_dir>/mri/brain.finalsurfs.mgz`) can be edited to fix the pial surface.
+Often, these errors should be fixed in <#asegdkt_segfile> `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (overwriting values in `<subject_dir>/mri/brain.finalsurfs.mgz`) can be edited to fix the pial surface.
 The manual label 255 indicates a voxel should be included in the gray matter and a voxel labeled 1 should not.
 
-See also: https://surfer.nmr.mgh.harvard.edu/fswiki/Edits#brain.finalsurfs.mgz
-
-<details><summary>Similar FreeSurfer edits</summary>
-
-pial placement correction: `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (delta to `brain.finalsurfs.mgz`)
-
-</details>
+See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/Edits#brain.finalsurfs.mgz>
 
 ## Side effects of edits
 
 Technically, all edits are changes to the processing pipeline and may cause systematic effects in the analysis.
-Computational edits (e.g. [bias field correction](#bias-field-correction)) should be integrated systematically.
+Computational edits (e.g. [Bias Field Correction](#bias-field-correction)) should be integrated systematically.
 Other effects are impossible to avoid (edit carefully), often very small and hard to account for. 
 It is recommended to analyze whether files with edits distort results in a specific direction, i.e. how do effect sizes change if manually edited cases are excluded?
+
+## Guide for experienced FreeSurfer users
+
+The following list enumerates editing options available in FreeSurfer and how to achieve similar edits in FastSurfer. 
+
+1. Skull stripping by editing `<subject_dir>/mri/brainmask.mgz` (delta to `brainmask.auto.mgz`) -> [asegdkt_segfile](#asegdkt_segfile)
+2. Talairach registration by editing `<subject_dir>/mri/transforms/talairach.xfm` (delta to `transforms/talairach.xfm`) -> [Talairach Registration](#talairach-registration)
+3. Brain extraction by editing `<subject_dir>/mri/brain.mgz` (delta to `brain.auto.mgz`) -> [asegdkt_segfile](#asegdkt_segfile)
+4. Subcortical segmentation: `<subject_dir>/mri/aseg.presurf.mgz` (delta to `aseg.presurf.auto.mgz`) -> [asegdkt_segfile](#asegdkt_segfile)
+5. CRS seeds: PONS, CC, LH, RH, watershed => seed files (`<subject_dir>/scripts/seed-(pons|cc|lh|rh|ws).crs.man.dat`) -> [asegdkt_segfile](#asegdkt_segfile)
+6. WM control points: `<subject_dir>/tmp/control.dat` -> [asegdkt_segfile](#asegdkt_segfile)
+7. In-file edits of the white matter segmentation: `<subject_dir>/mri/wm.mgz` (delta to `wm.auto.mgz`) -> [asegdkt_segfile](#asegdkt_segfile) or [White Matter Segmentation (wm.mgz)](#white-matter-segmentation)
+8. In-file edits of the filled Fill white matter segmentation: `<subject_dir>/mri/filled.mgz` (delta to `filled.auto.mgz`) -> [asegdkt_segfile](#asegdkt_segfile) or [White Matter Segmentation (filled.mgz)](#white-matter-segmentation)
+9. Pial placement correction: `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (delta to `brain.finalsurfs.mgz`) -> [Pial Surface Placement](#pial-surface-placement)
+
+## What NOT to do
+
+Do not edit the following files. These edits may not work as you expect and are considered **undefined behavior**.
+1. The mask: `<subject_dir>/mri/mask.mgz`
+2. The brainmask: `<subject_dir>/mri/brainmask.mgz`
+3. WM control points: `<subject_dir>/tmp/control.dat`
+4. Seed points: `<subject_dir>/scripts/seed-(pons|cc|lh|rh|ws).crs.man.dat`
+5. The subcortical segmentation: `<subject_dir>/mri/aseg.presurf.mgz`
 
 We hope that this will help with (some of) your editing needs. 
 Thanks for using FastSurfer. 

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -43,7 +43,7 @@ FastSurfer supports the following edits:
 Note, as FastSurfer's surface pipeline is derived from FreeSurfer, some edit options and corresponding naming schemes are inherited from FreeSurfer.
 
 ## General process
-Edits in this list require an update of the subject directory and "re-processing" with the `--edits` flag of `run_fastsurfer.sh`.
+To use the `--edits` flag with `run_fastsurfer.sh`, you must first update the images in the subject directory that require editing, and then reprocess the updated directory using the --edits option.
 
 For example (including setup for native processing, see [Examples](EXAMPLES.md) for other processing options):
 
@@ -124,9 +124,9 @@ In particular, over- and under-segmentation of the brainmask, gray matter over s
 In specific, such errors are inspected in `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz`, `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
 ### What to do
-1. Copy `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` to `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`.
-2. Open and edit `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz` fixing any errors.
-3. [Re-run FastSurfer](#general-process) to update `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
+1.Copy the file `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.mgz` to the same directory with a different name, `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`.
+2. Open and edit `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz` and fix any errors you find.
+3. [Re-run FastSurfer](#general-process) to apply the changes you made and update `<subject_dir>/mri/aseg.auto_noCCseg.mgz` and `<subject_dir>/mri/mask.mgz`.
 
 ## Talairach registration
 
@@ -134,7 +134,7 @@ In specific, such errors are inspected in `<subject_dir>/mri/aparc.DKTatlas+aseg
 The estimated total intracranial volume is inaccurate.
 
 ### What to do 
-1. Copy and edit `<subject_dir>/mri/transforms/talairach.xfm` replacing the old file.
+1. Open and edit `<subject_dir>/mri/transforms/talairach.xfm` and replace the edited version with the old file.
 2. [Re-run FastSurfer](#general-process) to update the eTIV value in all stats files.
 
 See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/Talairach>
@@ -145,7 +145,9 @@ See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/Talairach>
 Over- and/or under-segmentation of the white matter: voxels that should be white matter are excluded, or those that should not are included.
 
 ### What to do
-Often, these errors should be fixed in [#asegdkt_segfile] `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz` can be edited to fix the initial white matter surface.
+Often, these errors should be fixed in [#asegdkt_segfile] `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible: 
+1. Open and edit  `<subject_dir>/mri/wm.mgz` and `<subject_dir>/mri/filled.mgz` and replace the edited version with the old file.
+2. [Re-run FastSurfer](#general-process) to apply the changes .
 
 The manual label 255 indicates a voxel should be included in the white matter and a voxel labeled 1 should not.
 
@@ -159,7 +161,7 @@ Over- and/or under-segmentation of the cortical gray matter: voxels that should 
 This explicitly 
 
 ### What to do
-Often, these errors should be fixed in <#asegdkt_segfile> `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (overwriting values in `<subject_dir>/mri/brain.finalsurfs.mgz`) can be edited to fix the pial surface.
+Often, these errors should be fixed in <#asegdkt_segfile> `<subject_dir>/mri/aparc.DKTatlas+aseg.deep.manedit.mgz`, but if that is not possible, `<subject_dir>/mri/brain.finalsurfs.manedit.mgz` (overwriting values in `<subject_dir>/mri/brain.finalsurfs.mgz`) can be edited and then [Re-run FastSurfer](#general-process) to fix the pial surface. 
 The manual label 255 indicates a voxel should be included in the gray matter and a voxel labeled 1 should not.
 
 See also: <https://surfer.nmr.mgh.harvard.edu/fswiki/Edits#brain.finalsurfs.mgz>

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -192,6 +192,28 @@ function echo_quoted()
   echo ""
 }
 
+function add_file_suffix()
+{
+  # params:
+  # 1: filename
+  # 2: suffix to add
+
+  # example: add_file_suffix /path/to/file.nii.gz suffix -> /path/to/file.suffix.nii.gz
+
+  # file extensions supported:
+  file_extensions=(nii.gz nii mgz stats annot ctab label log txt lta xfm yaml)
+  for extension in "${file_extensions[@]}"
+  do
+    pattern="\.${extension//./\\.}$"
+    if [[ "$1" =~ $pattern ]]
+    then
+      length=$((${#1} - ${#extension}))
+      echo "${1:0:$length}$2.$extension"
+    fi
+  done
+}
+
+
 function check_is_template()
 {
   # params:

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -87,7 +87,7 @@ FLAGS:
                             that segmentations produced otherwise are conformed.
                             Requires an ABSOLUTE Path! Default location:
                             \$SUBJECTS_DIR/\$sid/mri/aparc.DKTatlas+aseg.deep.mgz
-  --mask_name <mask_file> Path to the brainmask file to use. Default location:
+  --mask_name <mask_file> Path to the brain mask file to use. Default location:
                             \$SUBJECTS_DIR/\$sid/mri/mask.mgz
   --edits                 Disable the check for existing recon-surf.sh run, replace
                             <asegdkt_segfile> by its manedit-suffixed version,

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -809,6 +809,7 @@ for hemi in lh rh ; do
 
   # In Long stream we skip topo fix
   if [ "$long" == "0" ] ; then
+    # longitudinal base and cross-sectional
 
     {
       echo "echo \"\""
@@ -829,7 +830,8 @@ for hemi in lh rh ; do
     cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -white-preaparc -no-isrunning $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
-  else # longitudinal
+  else # longitudinal stream
+    # ... we skip topo fix
 
     # in long we don't use orig.premesh (so switch off remesh for autodetgwstat)
     cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -no-remesh -no-isrunning $hiresflag $fsthreads"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -57,6 +57,7 @@ norm_name_t2=""
 seg_log=""
 run_talairach_registration="false"
 atlas3T="false"
+edits="false"
 viewagg="auto"
 device="auto"
 batch_size="1"
@@ -73,6 +74,8 @@ threads="1"
 python="python3.10 -s"
 allow_root=()
 version_and_quit=""
+warn_seg_only=()
+warn_base=()
 base=0                # flag for longitudinal template (base) run
 long=0                # flag for longitudinal time point run
 baseid=""             # baseid for logitudinal time point run
@@ -132,6 +135,12 @@ FLAGS:
                             The voxel size (whether set manually or derived)
                             determines whether the surfaces are processed with
                             highres options (below 1mm) or not.
+  --edits                 Enables manual edits by replacing select intermediate/
+                            result files by manedit substitutes (*.manedit.<ext>).
+                            Segmentation: <asegdkt_segfile> and <mask_name>.
+                            Surface: Disables check for existing recon-surf.sh run;
+                              edits of mri/wm.mgz and brain.finalsurfs.mgz
+                              as well as FreeSurfer-style WM control points.
   --version <info>        Print version information and exit; <info> is optional.
                             <info> may be empty, just prints the version number,
                             +git_branch also prints the current branch, and any
@@ -161,7 +170,8 @@ SEGMENTATION PIPELINE:
                             \$SUBJECTS_DIR/\$sid/mri/orig_nu.mgz
   --tal_reg               Perform the talairach registration for eTIV estimates
                             in --seg_only stream and stats files (is affected by
-                            the --3T flag, see below).
+                            the --3T flag, see below). Manual talairach
+                            registrations are not replaced in --edits mode.
 
   MODULES:
   By default, all modules are run.
@@ -354,8 +364,8 @@ case $key in
   --t1) t1="$1" ; shift ;;
   --t2) t2="$1" ; shift ;;
   --seg_log) seg_log="$1" ; shift ;;
-  --conformed_name) conformed_name="$1" ; shift ;;
-  --norm_name) norm_name="$1" ; shift ;;
+  --conformed_name) conformed_name="$1" ; warn_seg_only+=("$key" "$1") ; shift ;;
+  --norm_name) norm_name="$1" ; warn_seg_only+=("$key" "$1") ; shift ;;
   --norm_name_t2) norm_name_t2="$1" ; shift ;;
   --seg|--asegdkt_segfile|--aparc_aseg_segfile)
     if [[ "$key" != "--asegdkt_segfile" ]]
@@ -368,6 +378,7 @@ case $key in
   --vox_size) vox_size="$1" ; shift ;;
   # --3t: both for surface pipeline and the --tal_reg flag
   --3t) surf_flags+=("--3T") ; atlas3T="true" ;;
+  --edits) surf_flags+=("$key") ; edits="true" ;;
   --threads) threads="$1" ; shift ;;
   --py) python="$1" ; shift ;;
   -h|--help) usage ; exit ;;
@@ -429,7 +440,7 @@ case $key in
     ;;
   --asegdkt_statsfile) asegdkt_statsfile="$1" ; shift ;;
   --aseg_segfile) aseg_segfile="$1" ; shift ;;
-  --mask_name) mask_name="$1" ; shift ;;
+  --mask_name) mask_name="$1" ; warn_seg_only+=("$key" "$1") ; warn_base+=("$key" "$1") ; shift ;;
   --merged_segfile) merged_segfile="$1" ; shift ;;
 
   # cereb module options
@@ -546,6 +557,13 @@ then
   exit 1
 fi
 
+if [[ "${#warn_seg_only[@]}" -gt 0 ]] && [[ "$run_surf_pipeline" == "1" ]]
+then
+  echo "WARNING: Specifying '${warn_seg_only[*]}' only affects the segmentation "
+  echo "  pipeline and not the surface pipeline. It can therefore have unexpected consequences"
+  echo "  on surface processing."
+fi
+
 # DEFAULT FILE NAMES
 if [[ -z "$merged_segfile" ]] ; then merged_segfile="${sd}/${subject}/mri/fastsurfer.merged.mgz" ; fi
 if [[ -z "$asegdkt_segfile" ]] ; then asegdkt_segfile="${sd}/${subject}/mri/aparc.DKTatlas+aseg.deep.mgz" ; fi
@@ -644,6 +662,7 @@ then
     echo "ERROR: To run the cerebellum segmentation but no asegdkt, the aseg segmentation must already exist."
     echo "  You passed --no_asegdkt but the asegdkt segmentation ($asegdkt_segfile) could not be found."
     echo "  If the segmentation is not saved in the default location ($asegdkt_segfile_default),"
+    echo "  specify the absolute path and name via --asegdkt_segfile"
     exit 1
   fi
 fi
@@ -703,7 +722,10 @@ then
   fi
   # base can only be run with the template image from base-setup:
   t1="$sd/$subject/mri/orig.mgz"
-
+  if [[ "${#warn_base[@]}" -gt 0 ]] ; then
+    echo "ERROR: Specifying '${warn_base[*]}' is not supported for base (template) creation."
+    exit 1
+  fi
 fi
 
 if [[ "$long" == "1" ]]
@@ -779,6 +801,8 @@ if [[ "$num_files_in_subject_dir" -gt 1 ]] ; then
   } | tee -a "$seg_log"
 fi
 
+asegdkt_segfile_manedit=$(add_file_suffix "$asegdkt_segfile" "manedit")
+
 if [[ "$run_seg_pipeline" == "1" ]]
 then
   # "============= Running FastSurferCNN (Creating Segmentation aparc.DKTatlas.aseg.mgz) ==============="
@@ -804,6 +828,34 @@ then
     then
       echo "ERROR: FastSurfer asegdkt segmentation failed." | tee -a "$seg_log"
       exit 1
+    fi
+    if [[ -e "$asegdkt_segfile_manedit" ]]
+    then
+      if [[ "$edits" == "true" ]]
+      then
+        {
+          echo "INFO: $asegdkt_segfile_manedit (manedit file for <asegdkt_segfile>) detected,"
+          echo "  supersedes $asegdkt_segfile <asegdkt_segfile> for creation of $aseg_segfile"
+          echo "  and $mask_name!"
+        } | tee -a "$seg_log"
+        asegdkt_segfile="$asegdkt_segfile_manedit"
+        cmd=($python "$fastsurfercnndir/reduce_to_aseg.py" -i "$asegdkt_segfile" -o "$aseg_segfile"
+             --outmask "$mask_name" --fixwm)
+        echo_quoted "${cmd[@]}" | tee -a "$seg_log"
+        "${cmd[@]}" | tee -a "$seg_log"
+        exit_code="${PIPESTATUS[0]}"
+        if [[ "${exit_code}" -ne 0 ]]
+        then
+          echo "ERROR: Reduction of asegdkt to aseg failed." | tee -a "$seg_log"
+          exit 1
+        fi
+      else
+        {
+          echo "ERROR: $asegdkt_segfile_manedit (manedit file for <asegdkt_segfile>) detected,"
+          echo "  but edit was not passed. Please delete $asegdkt_segfile_manedit, or add --edits!"
+        } | tee -a "$seg_log"
+        exit 1
+      fi
     fi
   fi
   if [[ -n "$t2" ]]
@@ -844,6 +896,7 @@ then
       cmd=("$reconsurfdir/talairach-reg.sh" "$seg_log"
            --dir "$sd/$subject/mri" --conformed_name "$conformed_name" --norm_name "$norm_name")
       if [[ "$long" == "1" ]] ; then cmd+=(--long "$basedir") ; fi
+      if [[ "$edits" == "1" ]] ; then cmd+=(--edits) ; fi
       if [[ "$atlas3T" == "true" ]] ; then cmd+=(--3T) ; fi
       {
         echo "INFO: Running talairach registration..."
@@ -859,6 +912,8 @@ then
 
     if [[ "$run_asegdkt_module" ]]
     then
+      mask_name_manedit=$(add_file_suffix "$mask_name" "manedit")
+      if [[ -e "$mask_name_manedit" ]] ; then mask_name="$mask_name_manedit" ; fi
       cmd=($python "${fastsurfercnndir}/segstats.py" --segfile "$asegdkt_segfile"
            --segstatsfile "$asegdkt_statsfile" --normfile "$norm_name"
            --threads "$threads" --empty --excludeid 0
@@ -985,6 +1040,10 @@ then
 #      then
 #        ln -s -r "$asegdkt_segfile" "$merged_segfile"
 #    fi
+else # not running segmentation pipeline
+  # Replace asegdkt_segfile and aseg_segfile variables with manedit file here,
+  # if the manedit exists, so recon-surf uses the manedit file.
+  if [[ -e "$asegdkt_segfile_manedit" ]] ; then asegdkt_segfile="$asegdkt_segfile_manedit" ; fi
 fi
 
 if [[ "$run_surf_pipeline" == "1" ]]
@@ -993,7 +1052,7 @@ then
   # use recon-surf to create surface models based on the FastSurferCNN segmentation.
   pushd "$reconsurfdir" > /dev/null || exit 1
   echo "cd $reconsurfdir" | tee -a "$seg_log"
-  cmd=("./recon-surf.sh" --sid "$subject" --sd "$sd" --t1 "$conformed_name"
+  cmd=("./recon-surf.sh" --sid "$subject" --sd "$sd" --t1 "$conformed_name" --mask_name "$mask_name"
        --asegdkt_segfile "$asegdkt_segfile" --threads "$threads" --py "$python"
        "${surf_flags[@]}")
   echo_quoted "${cmd[@]}" | tee -a "$seg_log"


### PR DESCRIPTION
This PR adds support for edits in FastSurfer.

Edits are enabled by the `--edits` flag for `run_fastsurfer.sh`.

Edits supported:
<asegdkt_segfile> via <asegdkt_segfile-w/o-ext>.manedit.<ext>
white matter segmentation (wm.mgz) via wm.manedit.mgz
white matter control points (via the standard FreeSurfer control points file)
talairach registration via mri/mri/transforms/talairach.xfm (overwriting talairach registration via mri/mri/transforms/talairach.xfm)
brain.finalsurfs.mgz via brain.finalsurfs.manedit.mgz


This PR also move the allow_root check into functions.sh and introduces run_it and run_it_cmdf function variants that are more clear wrt. argument splitting (see SC2206, SC2207 and similar).