### PR TITLE
remove root check and allow_root flag in all sub-programs

### DIFF
--- a/CerebNet/run_prediction.py
+++ b/CerebNet/run_prediction.py
@@ -81,7 +81,7 @@ def setup_options():
     advanced = parser.add_argument_group(title="Advanced options")
     parser_defaults.add_arguments(
         advanced,
-        ["device", "viewagg_device", "threads", "batch_size", "async_io", "allow_root"],
+        ["device", "viewagg_device", "threads", "batch_size", "async_io"],
     )
 
     files: dict[Plane, str | Path] = {k: "default" for k in PLANES}
@@ -131,9 +131,6 @@ def main(args: argparse.Namespace) -> int | str:
     cfg = get_config(args)
     cfg.TEST.ENABLE = True
     cfg.TRAIN.ENABLE = False
-
-    # Warning if run as root user
-    getattr(args, "allow_root", False) or assert_no_root()
 
     # Set up logging
     from FastSurferCNN.utils.logging import setup_logging

--- a/FastSurferCNN/mri_segstats.py
+++ b/FastSurferCNN/mri_segstats.py
@@ -508,7 +508,6 @@ def format_cmdline_args(args: object) -> list[str]:
         if (value := getattr(args, name, None)) is not None:
             arglist.extend([flag, str(value)])
 
-    _append_storetrue("allow_root")
     _append_storetrue("legacy_freesurfer")
     _extend_arg("segfile")
     _extend_arg("normfile")

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -594,7 +594,6 @@ def make_parser():
             "batch_size",
             "async_io",
             "threads",
-            "allow_root",
         ],
     )
     return parser
@@ -612,7 +611,6 @@ def main(
         cfg_cor: Path,
         qc_log: str = "",
         log_name: str = "",
-        allow_root: bool = False,
         conf_name: str = "mri/orig.mgz",
         in_dir: Optional[Path] = None,
         sid: Optional[str] = None,
@@ -631,8 +629,6 @@ def main(
         conform_to_1mm_threshold: float = 0.95,
         **kwargs,
 ) -> Literal[0] | str:
-    # Warning if run as root user
-    allow_root or assert_no_root()
 
     if len(kwargs) > 0:
         LOGGER.warning(f"Unknown arguments {list(kwargs.keys())} in {__file__}:main.")

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -322,7 +322,7 @@ def make_arguments(helpformatter: bool = False) -> argparse.ArgumentParser:
         help="Keep ids for the table that do not exist in the segmentation "
              "(default: drop).",
     )
-    advanced = add_arguments(advanced, ["device", "sid", "sd", "allow_root"])
+    advanced = add_arguments(advanced, ["device", "sid", "sd"])
     advanced.add_argument(
         "--lut",
         type=Path,
@@ -760,7 +760,6 @@ def main(args: argparse.Namespace) -> Literal[0] | str:
     from FastSurferCNN.data_loader.data_utils import read_classes_from_lut
 
     start = perf_counter_ns()
-    getattr(args, "allow_root", False) or assert_no_root()
 
     subjects_dir = getattr(args, "out_dir", None)
     if subjects_dir is not None:

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -136,7 +136,7 @@ def option_parse() -> argparse.ArgumentParser:
     advanced = parser.add_argument_group(title="Advanced options")
     parser_defaults.add_arguments(
         advanced,
-        ["device", "viewagg_device", "threads", "batch_size", "async_io", "allow_root"],
+        ["device", "viewagg_device", "threads", "batch_size", "async_io"],
     )
 
     files: dict[Plane, str | Path] = {k: "default" for k in PLANES}
@@ -174,7 +174,6 @@ def main(
         cfg_sag: Path,
         hypo_segfile: str = HYPVINN_SEG_NAME,
         hypo_maskfile: str = HYPVINN_MASK_NAME,
-        allow_root: bool = False,
         qc_snapshots: bool = False,
         reg_mode: Literal["coreg", "robust", "none"] = "coreg",
         threads: int = -1,
@@ -212,8 +211,6 @@ def main(
         The name of the hypothalamus segmentation file. Default is {HYPVINN_SEG_NAME}.
     hypo_maskfile : str, default="{HYPVINN_MASK_NAME}"
         The name of the hypothalamus mask file. Default is {HYPVINN_MASK_NAME}.
-    allow_root : bool, default=False
-        Whether to allow running as root user. Default is False.
     qc_snapshots : bool, optional
         Whether to create QC snapshots. Default is False.
     reg_mode : "coreg", "robust", "none", default="coreg"
@@ -248,8 +245,6 @@ def main(
     t2_path = t2
     subject_name = sid
     subject_dir = out_dir / sid
-    # Warning if run as root user
-    allow_root or assert_no_root()
     start = time()
     try:
         # Set up logging

--- a/HypVINN/utils/stats_utils.py
+++ b/HypVINN/utils/stats_utils.py
@@ -56,7 +56,7 @@ def compute_stats(
     args = namedtuple(
         "ArgNamespace",
         ["normfile", "i", "o", "excludedid", "ids", "merged_labels",
-         "robust", "threads", "patch_size", "device", "lut", "allow_root"])
+         "robust", "threads", "patch_size", "device", "lut"])
 
     labels = [v for v in FS_CLASS_NAMES.values() if v != 0]
 
@@ -71,7 +71,4 @@ def compute_stats(
     args.patch_size = 32
     args.device = "auto"
     args.lut = FASTSURFER_ROOT / "FastSurferCNN/config/FreeSurferColorLUT.txt"
-    # We check for this in the parent code
-    # TODO: it would be better to populate this properly
-    args.allow_root = True
     return main(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'fastsurfer'
-version = '2.3.0'
+version = '2.3.1'
 description = 'A fast and accurate deep-learning based neuroimaging pipeline'
 readme = 'README.md'
 license = {file = 'LICENSE'}

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -28,7 +28,6 @@ fssurfreg=1           # run FS surface registration to fsaverage, if 0 omit this
 python="python3.10"   # python version
 DoParallel=0          # if 1, run hemispheres in parallel
 threads="1"           # number of threads to use for running FastSurfer
-allow_root=""         # flag for allowing execution as root user
 atlas3T="false"       # flag to use/do not use the 3t atlas for talairach registration/etiv
 segstats_legacy="false" # flag to enable segstats legacy mode
 
@@ -117,7 +116,6 @@ Dev Flags:
                             cross-subject correspondence). Not recommended, but
                             speeds up processing if you just need the stats and
                             don't want to do thickness analysis on the cortex.
-  --allow_root            Allow execution as root user
 
 REFERENCES:
 
@@ -190,7 +188,6 @@ case $key in
     ;;
   --ignore_fs_version) check_version=0 ;;
   --no_fs_t1 ) get_t1=0 ;;
-  --allow_root) allow_root="--allow_root" ;;
   -h|--help) usage ; exit ;;
   # unknown option
   *) echo "ERROR: Flag $key unrecognized." ; exit 1 ;;
@@ -204,18 +201,6 @@ echo "sid $subject"
 echo "T1  $t1"
 echo "asegdkt_segfile $asegdkt_segfile"
 echo ""
-
-
-# Warning if run as root user
-if [ -z "$allow_root" ] && [ "$(id -u)" == "0" ]
-then
-  echo "You are trying to run '$0' as root. We advice to avoid running FastSurfer as root, "
-  echo "because it will lead to files and folders created as root."
-  echo "If you are running FastSurfer in a docker container, you can specify the user with "
-  echo "'-u \$(id -u):\$(id -g)' (see https://docs.docker.com/engine/reference/run/#user)."
-  echo "If you want to force running as root, you may pass --allow_root to recon-surf.sh."
-  exit 1;
-fi
 
 if [ -z "$SUBJECTS_DIR" ]
 then

--- a/recon_surf/recon-surfreg.sh
+++ b/recon_surf/recon-surfreg.sh
@@ -22,7 +22,6 @@ subject=""; # Subject name
 python="python3.10" # python version
 DoParallel=0 # if 1, run hemispheres in parallel
 threads="1" # number of threads to use for running FastSurfer
-allow_root=""         # flag for allowing execution as root user
 
 # Dev flags default
 check_version=1.      # Check for supported FreeSurfer version (terminate if not detected)
@@ -77,7 +76,6 @@ Dev Flags:
   --ignore_fs_version     Switch on to avoid check for FreeSurfer version.
                             Program will otherwise terminate if $FS_VERSION_SUPPORT is
                             not sourced. Can be used for testing dev versions.
-  --allow_root            Allow execution as root user
 
 REFERENCES:
 
@@ -243,18 +241,6 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 echo
 echo sid $subject
 echo
-
-
-# Warning if run as root user
-if [ -z "$allow_root" ] && [ "$(id -u)" == "0" ]
-  then
-    echo "You are trying to run '$0' as root. We advice to avoid running FastSurfer as root, "
-    echo "because it will lead to files and folders created as root."
-    echo "If you are running FastSurfer in a docker container, you can specify the user with "
-    echo "'-u \$(id -u):\$(id -g)' (see https://docs.docker.com/engine/reference/run/#user)."
-    echo "If you want to force running as root, you may pass --allow_root to recon-surf.sh."
-    exit 1;
-fi
 
 if [ "$subject" == "subject" ]
 then

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -761,7 +761,7 @@ then
          --asegdkt_segfile "$asegdkt_segfile" --conformed_name "$conformed_name"
          --brainmask_name "$mask_name" --aseg_name "$aseg_segfile" --sid "$subject"
          --seg_log "$seg_log" --vox_size "$vox_size" --batch_size "$batch_size"
-         --viewagg_device "$viewagg" --device "$device" "${allow_root[@]}")
+         --viewagg_device "$viewagg" --device "$device")
     # specify the subject dir $sd, if asegdkt_segfile explicitly starts with it
     if [[ "$sd" == "${asegdkt_segfile:0:${#sd}}" ]]; then cmd=("${cmd[@]}" --sd "$sd"); fi
     echo_quoted "${cmd[@]}" | tee -a "$seg_log"
@@ -829,7 +829,7 @@ then
     then
       cmd=($python "${fastsurfercnndir}/segstats.py" --segfile "$asegdkt_segfile"
            --segstatsfile "$asegdkt_statsfile" --normfile "$norm_name"
-           --threads "$threads" "${allow_root[@]}" --empty --excludeid 0
+           --threads "$threads" --empty --excludeid 0
            --sd "${sd}" --sid "${subject}"
            --ids 2 4 5 7 8 10 11 12 13 14 15 16 17 18 24 26 28 31 41 43 44 46 47
                  49 50 51 52 53 54 58 60 63 77 251 252 253 254 255 1002 1003 1005
@@ -907,7 +907,7 @@ then
          --asegdkt_segfile "$asegdkt_segfile" --conformed_name "$conformed_name"
          --cereb_segfile "$cereb_segfile" --seg_log "$seg_log" --async_io
          --batch_size "$batch_size" --viewagg_device "$viewagg" --device "$device"
-         --threads "$threads" "${cereb_flags[@]}" "${allow_root[@]}")
+         --threads "$threads" "${cereb_flags[@]}")
     # specify the subject dir $sd, if asegdkt_segfile explicitly starts with it
     if [[ "$sd" == "${cereb_segfile:0:${#sd}}" ]] ; then cmd=("${cmd[@]}" --sd "$sd"); fi
     echo_quoted "${cmd[@]}" | tee -a "$seg_log"
@@ -923,7 +923,7 @@ then
   then
         # currently, the order of the T2 preprocessing only is registration to T1w
     cmd=($python "$hypvinndir/run_prediction.py" --sd "${sd}" --sid "${subject}"
-         "${hypvinn_flags[@]}" "${allow_root[@]}" --threads "$threads" --async_io
+         "${hypvinn_flags[@]}" --threads "$threads" --async_io
          --batch_size "$batch_size" --seg_log "$seg_log" --device "$device"
          --viewagg_device "$viewagg" --t1)
     if [[ "$run_biasfield" == "1" ]]
@@ -957,7 +957,7 @@ then
   pushd "$reconsurfdir" > /dev/null || exit 1
   cmd=("./recon-surf.sh" --sid "$subject" --sd "$sd" --t1 "$conformed_name"
        --asegdkt_segfile "$asegdkt_segfile" --threads "$threads" --py "$python"
-       "${surf_flags[@]}" "${allow_root[@]}")
+       "${surf_flags[@]}")
   echo_quoted "${cmd[@]}" | tee -a "$seg_log"
   "${cmd[@]}"
   if [[ "${PIPESTATUS[0]}" -ne 0 ]] ; then exit 1 ; fi


### PR DESCRIPTION
Currently we are doing checks for running as root in many places, requiring the ```--allow_root``` flag to be passed everywhere. 
This flag however was not always passed through, e.g. see #597 causing ```recon-surf.sh``` to error and stop. 

The two options to fix this are i) forward ```--allow_root``` everywhere or ii) avoid checking this in so many places and reduce it to the top level entry scripts (currently run_fastsurfer.sh ). 

I took the second approach to simplify things and avoid future such bugs. 

This needs to be tested when running as root and passing the ```--allow_root```flag. Maybe also test as non-root, just in case. 