### PR TITLE
Hotfix2.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'fastsurfer'
-version = '2.3.1'
+version = '2.3.2'
 description = 'A fast and accurate deep-learning based neuroimaging pipeline'
 readme = 'README.md'
 license = {file = 'LICENSE'}

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -995,11 +995,12 @@ fi
          measures --file "$statsdir/aseg.stats" --import "all")
   fi
   RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
+
   # -wmparc based on mapped aparc labels (from input asegdkt_segfile) (1min40sec) needs ribbon and we need to point it to aparc.mapped:
   cmd="mri_surf2volseg --o $mdir/wmparc.DKTatlas.mapped.mgz --label-wm --i $mdir/aparc.DKTatlas+aseg.mapped.mgz --threads $threads --lh-annot $ldir/lh.aparc.DKTatlas.mapped.annot 3000 --lh-cortex-mask $ldir/lh.cortex.label --lh-white $sdir/lh.white --lh-pial $sdir/lh.pial --rh-annot $ldir/rh.aparc.DKTatlas.mapped.annot 4000 --rh-cortex-mask $ldir/rh.cortex.label --rh-white $sdir/rh.white --rh-pial $sdir/rh.pial"
   RunIt "$cmd" "$LF"
 
-  # takes a few mins
+  # stats of the wmparc DKTatlas mapped
   #cmd="mri_segstats --seed 1234 --seg $mdir/wmparc.DKTatlas.mapped.mgz --sum $mdir/../stats/wmparc.DKTatlas.mapped.stats --pv $mdir/norm.mgz --excludeid 0 --brainmask $mdir/brainmask.mgz --in $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --subject $subject --surf-wm-vol --ctab $FREESURFER_HOME/WMParcStatsLUT.txt"
   if [[ "$segstats_legacy" == "true" ]] ; then
     cmd=($python "$FASTSURFER_HOME/FastSurferCNN/mri_segstats.py"
@@ -1015,7 +1016,7 @@ fi
          --sid "$subject" --sd "$SUBJECTS_DIR" --pvfile "$mdir/norm.mgz"
          --segfile "$mdir/wmparc.DKTatlas.mapped.mgz" --normfile "$mdir/norm.mgz"
          --lut "$FREESURFER_HOME/WMParcStatsLUT.txt" --threads "$threads"
-         --segstatsfile "$statsdir/wmparc.DKTatlas.mapped.stats" --empty
+         --segstatsfile "$statsdir/wmparc.DKTatlas.mapped.stats"
          --volume_precision 1
          measures --file "$statsdir/brainvol.stats" --import "Mask"
                   "VentricleChoroidVol" "rhCerebralWhiteMatter" "lhCerebralWhiteMatter"

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -913,57 +913,56 @@ fi
 
 # ============================= FASTSURFER - STATS =========================================
 
-  if [ "$fsaparc" == "0" ] ; then
-    # get stats for the aseg (note these are surface fine tuned, that may be good or bad, below we also do the stats for the input aseg (plus some processing)
-    # cmd="recon-all -subject $subject -segstats $hiresflag $fsthreads"
-    if [[ "$segstats_legacy" == "true" ]] ; then
-      cmd=($python "$FASTSURFER_HOME/FastSurferCNN/mri_brainvol_stats.py"
-           --subject "$subject")
-      RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
-
-      cmd=($python "$FASTSURFER_HOME/FastSurferCNN/mri_segstats.py" --seed 1234
-           --seg "$mdir/aseg.mgz" --sum "$statsdir/aseg.stats" --pv "$mdir/norm.mgz"
-           "--in-intensity-name" norm "--in-intensity-units" MR --subject "$subject"
-           --surf-wm-vol --ctab "$FREESURFER_HOME/ASegStatsLUT.txt" --etiv
-           --threads "$threads")
-#      cmd="$python $FASTSURFER_HOME/FastSurferCNN/mri_segstats.py --seed 1234 --seg $mdir/wmparc.mgz --sum $statsdir/wmparc.stats --pv $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --subject $subject --surf-wm-vol --ctab $FREESURFER_HOME/WMParcStatsLUT.txt --etiv"
-    else
-      # calculate brainvol stats and aseg stats with segstats.py
-      cmd=($python "$FASTSURFER_HOME/FastSurferCNN/segstats.py" --sid "$subject"
-           --segfile "$mdir/aseg.mgz" --segstatsfile "$statsdir/aseg.stats"
-           --pvfile "$mdir/norm.mgz" --normfile "$mdir/norm.mgz" --threads "$threads"
-           # --excl-ctxgmwm: exclude Left/Right WM / Cortex despite ASegStatsLUT.txt
-           --excludeid 0 2 3 41 42
-           --lut "$FREESURFER_HOME/ASegStatsLUT.txt" --empty
-           measures --compute "BrainSeg" "BrainSegNotVent" "VentricleChoroidVol"
-                              "lhCortex" "rhCortex" "Cortex" "lhCerebralWhiteMatter"
-                              "rhCerebralWhiteMatter" "CerebralWhiteMatter"
-                              "SubCortGray" "TotalGray" "SupraTentorial"
-                              "SupraTentorialNotVent" "Mask($mdir/mask.mgz)"
-                              "BrainSegVol-to-eTIV" "MaskVol-to-eTIV" "lhSurfaceHoles"
-                              "rhSurfaceHoles" "SurfaceHoles"
-                              "EstimatedTotalIntraCranialVol")
-      RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
-      echo "Extract the brainvol stats section from segstats output." | tee -a "$LF"
-      # ... so stats/brainvol.stats also exists (but it is slightly different
-#      cmd="recon-all -subject $subject -segstats $hiresflag $fsthreads"
-#      RunIt "$cmd" "$LF"
-
-      # this call is only "required" to "compute" brainvol.stats, so --normfile/--pvfile
-      # are not required
-      cmd=($python "$FASTSURFER_HOME/FastSurferCNN/segstats.py" --sid "$subject"
-           --segfile "$mdir/aseg.mgz" --pvfile "$mdir/norm.mgz"
-           --measure_only --threads "$threads" --segstatsfile "$statsdir/brainvol.stats"
-           measures --file "$statsdir/aseg.stats"
-                    --import "BrainSeg" "BrainSegNotVent" "SupraTentorial"
-                             "SupraTentorialNotVent" "SubCortGray" "lhCortex" "rhCortex"
-                             "Cortex" "TotalGray" "lhCerebralWhiteMatter"
-                             "rhCerebralWhiteMatter" "CerebralWhiteMatter" "Mask"
-                    --compute "SupraTentorialNotVentVox" "BrainSegNotVentSurf"
-                              "VentricleChoroidVol")
-    fi
+  # get stats for the aseg (note these are surface fine tuned, that may be good or bad, below we also do the stats for the input aseg (plus some processing)
+  # cmd="recon-all -subject $subject -segstats $hiresflag $fsthreads"
+  if [[ "$segstats_legacy" == "true" ]] ; then
+    cmd=($python "$FASTSURFER_HOME/FastSurferCNN/mri_brainvol_stats.py"
+         --subject "$subject")
     RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
+
+    cmd=($python "$FASTSURFER_HOME/FastSurferCNN/mri_segstats.py" --seed 1234
+         --seg "$mdir/aseg.mgz" --sum "$statsdir/aseg.stats" --pv "$mdir/norm.mgz"
+         "--in-intensity-name" norm "--in-intensity-units" MR --subject "$subject"
+         --surf-wm-vol --ctab "$FREESURFER_HOME/ASegStatsLUT.txt" --etiv
+         --threads "$threads")
+#    cmd="$python $FASTSURFER_HOME/FastSurferCNN/mri_segstats.py --seed 1234 --seg $mdir/wmparc.mgz --sum $statsdir/wmparc.stats --pv $mdir/norm.mgz --in-intensity-name norm --in-intensity-units MR --subject $subject --surf-wm-vol --ctab $FREESURFER_HOME/WMParcStatsLUT.txt --etiv"
+  else
+    # calculate brainvol stats and aseg stats with segstats.py
+    cmd=($python "$FASTSURFER_HOME/FastSurferCNN/segstats.py" --sid "$subject"
+         --segfile "$mdir/aseg.mgz" --segstatsfile "$statsdir/aseg.stats"
+         --pvfile "$mdir/norm.mgz" --normfile "$mdir/norm.mgz" --threads "$threads"
+         # --excl-ctxgmwm: exclude Left/Right WM / Cortex despite ASegStatsLUT.txt
+         --excludeid 0 2 3 41 42
+         --lut "$FREESURFER_HOME/ASegStatsLUT.txt" --empty
+         measures --compute "BrainSeg" "BrainSegNotVent" "VentricleChoroidVol"
+                            "lhCortex" "rhCortex" "Cortex" "lhCerebralWhiteMatter"
+                            "rhCerebralWhiteMatter" "CerebralWhiteMatter"
+                            "SubCortGray" "TotalGray" "SupraTentorial"
+                            "SupraTentorialNotVent" "Mask($mdir/mask.mgz)"
+                            "BrainSegVol-to-eTIV" "MaskVol-to-eTIV" "lhSurfaceHoles"
+                            "rhSurfaceHoles" "SurfaceHoles"
+                            "EstimatedTotalIntraCranialVol")
+    RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
+    echo "Extract the brainvol stats section from segstats output." | tee -a "$LF"
+    # ... so stats/brainvol.stats also exists (but it is slightly different
+#    cmd="recon-all -subject $subject -segstats $hiresflag $fsthreads"
+#    RunIt "$cmd" "$LF"
+
+    # this call is only "required" to "compute" brainvol.stats, so --normfile/--pvfile
+    # are not required
+    cmd=($python "$FASTSURFER_HOME/FastSurferCNN/segstats.py" --sid "$subject"
+         --segfile "$mdir/aseg.mgz" --pvfile "$mdir/norm.mgz"
+         --measure_only --threads "$threads" --segstatsfile "$statsdir/brainvol.stats"
+         measures --file "$statsdir/aseg.stats"
+                  --import "BrainSeg" "BrainSegNotVent" "SupraTentorial"
+                           "SupraTentorialNotVent" "SubCortGray" "lhCortex" "rhCortex"
+                           "Cortex" "TotalGray" "lhCerebralWhiteMatter"
+                           "rhCerebralWhiteMatter" "CerebralWhiteMatter" "Mask"
+                  --compute "SupraTentorialNotVentVox" "BrainSegNotVentSurf"
+                            "VentricleChoroidVol")
   fi
+  RunIt "$(echo_quoted "${cmd[@]}")" "$LF"
+
 
 # ============================= MAPPED-WMPARC =========================================
 {


### PR DESCRIPTION
This fixes two things: 

1. wmparc.DKTaltas.mapped.stats had lots of zero entries, which are now dropped
2. when using the --fsaparc flag, aseg.stats was not created and that lead to errors downstream (when creating stats for wmaparc mapped). 