### PR TITLE
Bug fixes

### DIFF
--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -66,7 +66,8 @@ function usage()
 {
 cat << EOF
 
-Usage: long_fastsurfer.sh --sid <sid> --sd <sdir> --t1 <t1_input> [OPTIONS]
+Usage: long_fastsurfer.sh --tid <tid> --t1s <T1_1> <T1_2> .. \
+                          --tpids <tID1> <tID2> .. [OPTIONS]
 
 long_fastsurfer.sh takes a list of T1 full head image and sequentially creates:
      (i)   a template subject directory 
@@ -82,7 +83,7 @@ FLAGS:
   --tpids <tID1> >tID2> ..  IDs for future time points directories inside
                               \$SUBJECTS_DIR to be created later (during --long)
   --sd  <subjects_dir>      Output directory \$SUBJECTS_DIR (or pass via env var)
-  --parallel_long           (Experimental) Parallelize the long script
+  --parallel_long           (Highly Experimental) Parallelize the long script
   --py <python_cmd>         Command for python, used in both pipelines.
                               Default: "$python"
                               (-s: do no search for packages in home directory)
@@ -96,6 +97,7 @@ REFERENCES:
 
 If you use this for research publications, please cite:
 
+For FastSurfer (both):
 Henschel L, Conjeti S, Estrada S, Diers K, Fischl B, Reuter M, FastSurfer - A
  fast and accurate deep learning based neuroimaging pipeline, NeuroImage 219
  (2020), 117012. https://doi.org/10.1016/j.neuroimage.2020.117012
@@ -104,6 +106,11 @@ Henschel L*, Kuegler D*, Reuter M. (*co-first). FastSurferVINN: Building
  Resolution-Independence into Deep Learning Segmentation Methods - A Solution
  for HighRes Brain MRI. NeuroImage 251 (2022), 118933. 
  http://dx.doi.org/10.1016/j.neuroimage.2022.118933
+
+And for longitudinal processing:
+Reuter M, Schmansky NJ, Rosas HD, Fischl B. Within-subject template estimation
+ for unbiased longitudinal image analysis, NeuroImage 61:4 (2012).
+ https://doi.org/10.1016/j.neuroimage.2012.02.084
 
 For cerebellum sub-segmentation:
 Faber J*, Kuegler D*, Bahrami E*, et al. (*co-first). CerebNet: A fast and
@@ -116,12 +123,6 @@ Estrada S, Kuegler D, Bahrami E, Xu P, Mousa D, Breteler MMB, Aziz NA, Reuter M.
  FastSurfer-HypVINN: Automated sub-segmentation of the hypothalamus and adjacent
  structures on high-resolutional brain MRI. Imaging Neuroscience 2023; 1 1–32.
  https://doi.org/10.1162/imag_a_00034
-
-For longitudinal processing:
-Reuter M, Schmansky NJ, Rosas HD, Fischl B. Within-subject template estimation
- for unbiased longitudinal image analysis, NeuroImage 61:4 (2012).
- https://doi.org/10.1016/j.neuroimage.2012.02.084
-
 
 EOF
 }

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -66,8 +66,7 @@ function usage()
 {
 cat << EOF
 
-Usage: long_fastsurfer.sh --tid <tid> --t1s <T1_1> <T1_2> .. \
-                          --tpids <tID1> <tID2> .. [OPTIONS]
+Usage: long_fastsurfer.sh --tid <tid> --t1s <T1_1> <T1_2> .. --tpids <tID1> <tID2> .. [OPTIONS]
 
 long_fastsurfer.sh takes a list of T1 full head image and sequentially creates:
      (i)   a template subject directory 

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -278,10 +278,20 @@ else
   run_it "$LF" "${cmda[@]}"
 fi
 
-
 ################################### Run Long Seg ##################################
 
 # This can run in parallel with base seg and surf steps above
+for ((i=0;i<${#tpids[@]};++i)); do
+  echo "Long Seg: ${tpids[i]} with T1 ${t1s[i]}"
+  cmd="$FASTSURFER_HOME/run_fastsurfer.sh \
+        --sid ${tpids[i]} --sd $sd \
+        --seg_only --long $tid \
+        ${POSITIONAL_FASTSURFER[*]}"
+  RunIt "$cmd" "$LF"
+done
+
+# skip this for now as brun does not even have the --long flag yet
+if false ; then
 time_points=()
 for ((i=0;i<${#tpids[@]};++i)); do
   time_points+=("${tpids[$i]}=from-base")
@@ -308,9 +318,21 @@ if [[ "$parallel" == "1" ]] ; then
 else
   run_it "$LF" "${cmda[@]}"
 fi
+fi # comment block
 
 ################################### Run Long Surf #################################
 
+for ((i=0;i<${#tpids[@]};++i)); do
+  echo "Long Surf: ${tpids[i]} with T1 ${t1s[i]}"
+  cmd="$FASTSURFER_HOME/run_fastsurfer.sh \
+        --sid ${tpids[i]} --sd $sd \
+        --surf_only --long $tid \
+        ${POSITIONAL_FASTSURFER[*]}"
+  RunIt "$cmd" "$LF"
+done
+
+# skip this for now as brun does not even have the --long flag yet
+if false ; then
 cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --surf_only --long "$tid"
       "${POSITIONAL_FASTSURFER[@]}")
 if [[ "$parallel" == "1" ]] ; then
@@ -352,5 +374,6 @@ if [[ "$parallel" == "1" ]] ; then
   fi
   } | tee -a "$LF"
 fi
-
 run_it "$LF" "${cmda[@]}"
+fi # comment block
+

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -798,7 +798,7 @@ for hemi in lh rh ; do
 
     # for place_surfaces white.preparc we need to directly call it with special long parameter:
     # cmd="recon-all -subject $subject -hemi $hemi -white-preaparc -no-isrunning $hiresflag $fsthreads"
-    cmd="mris_place_surface --adgws-in $sdir/autodet.gw.stats.$hemi.dat --wm $mdir/$wm_file --threads $threads --invol $mdir/brain.finalsurfs.mgz --$hemi --i $sdir/$hemi.orig --o $sdir/${hemi}.white.preaparc --white --seg $mdir/aseg.presurf.mgz --max-cbv-dist 3.5"
+    cmd="mris_place_surface --adgws-in $sdir/autodet.gw.stats.$hemi.dat --wm $mdir/wm.mgz --threads $threads --invol $mdir/brain.finalsurfs.mgz --$hemi --i $sdir/$hemi.orig --o $sdir/${hemi}.white.preaparc --white --seg $mdir/aseg.presurf.mgz --max-cbv-dist 3.5"
     RunIt "$cmd" "$LF" "$CMDF"
 
   fi # long
@@ -969,7 +969,7 @@ for hemi in lh rh ; do
   # CREATE WHITE SURFACE:
   # 4 min compute white :
   cmd="mris_place_surface --adgws-in ../surf/autodet.gw.stats.${hemi}.dat --seg aseg.presurf.mgz \
-    --threads $threads --wm $wm_file --invol brain.finalsurfs.mgz --$hemi --o ../surf/${hemi}.white \
+    --threads $threads --wm wm.mgz --invol brain.finalsurfs.mgz --$hemi --o ../surf/${hemi}.white \
     --white --nsmooth 0 --rip-label ../label/${hemi}.cortex.label \
     --rip-bg --rip-surf ../surf/${hemi}.white.preaparc --aparc $aparc"
   if [ "$long" == "0" ] ; then # cross/regular/base
@@ -982,7 +982,7 @@ for hemi in lh rh ; do
   # CREAT PIAL SURFACE
   # 4 min compute pial :
   cmd="mris_place_surface --adgws-in ../surf/autodet.gw.stats.${hemi}.dat --seg aseg.presurf.mgz \
-    --threads $threads --wm $wm_file --invol brain.finalsurfs.mgz --$hemi --o ../surf/${hemi}.pial.T1 \
+    --threads $threads --wm wm.mgz --invol brain.finalsurfs.mgz --$hemi --o ../surf/${hemi}.pial.T1 \
     --pial --nsmooth 0 --rip-label ../label/${hemi}.cortex+hipamyg.label \
     --pin-medial-wall ../label/${hemi}.cortex.label --aparc $aparc \
     --repulse-surf ../surf/${hemi}.white --white-surf ../surf/${hemi}.white"

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -262,7 +262,7 @@ fi
 
 if [[ "$base" == "1" ]]
 then
-  if [ ! -f "$sd/$subject/base-tps.fastsurfer" ] ; then
+  if [ ! -f "$SUBJECTS_DIR/$subject/base-tps.fastsurfer" ] ; then
     echo "ERROR: $subject is either not found in SUBJECTS_DIR"
     echo "or it is not a longitudinal template directory (base),"
     echo "which needs to contain base-tps.fastsurfer file. Please ensure that"

--- a/recon_surf/talairach-reg.sh
+++ b/recon_surf/talairach-reg.sh
@@ -181,12 +181,12 @@ fi
 pushd "$mdir/transforms" > /dev/null || ( echo "ERROR: Could not change to the transforms directory $mdir/transforms!" | tee -a "$LF" ; exit 1 )
   {
     if [[ ! -e talairach_with_skull.lta ]] ; then
-      cmd=(softlink_or_copy -sf talairach.xfm.lta talairach_with_skull.lta)
+      cmd=(softlink_or_copy talairach.xfm.lta talairach_with_skull.lta)
       echo_quoted "${cmd[@]}"
       "${cmd[@]}"
     fi
     if [[ ! -e talairach.lta ]] ; then
-      cmd=(softlink_or_copy -sf talairach.xfm.lta talairach.lta)
+      cmd=(softlink_or_copy talairach.xfm.lta talairach.lta)
       echo_quoted "${cmd[@]}"
       "${cmd[@]}"
     fi


### PR DESCRIPTION
This PR fixes some bugs that were introduced recently in #593 #594 and probably others. Some stem form the fact that not all edits were merged (e.g. $wm_file variable was not set, but is going to be set in the edit PR #591 ), then this needs to be changed back. Other were from the fact that brun_fastsurfer does not seem to be updated to the version that would be necessary in order to run things in parallel, so those change have been reverted for now. Other bugs include incorrect linking in talairach-reg.sh and incorrect usage of $sd instead of $SUBJECTS_DIR in recon_surf.sh:

- fixes sym linking in `talairach-reg.sh` (affects also regular stream)
- fixes `$SUBJECTS_DIR` during -base in `recon-surf.sh` (affects longitudinal stream)
- $wm-file did not exist yet (needs to be added back together with edits support)
- brun_fastsurfer does not yet support the long flag, so revert to run_fastsrufer
- fix and update help text in long_fastsurfer.sh

