### PR TITLE
Create a dedicated BUILD.info file for docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ Docker/Dockerfile*
 *.txt
 venv
 /srun_fastsurfer.sh
+BUILD.info

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -203,8 +203,7 @@ ENV PYTHONPATH=/fastsurfer:/opt/freesurfer/python/packages \
 RUN cd /fastsurfer ; python3 FastSurferCNN/download_checkpoints.py --all && \
     python3 -m compileall * && \
     python3 FastSurferCNN/version.py --sections +git+checkpoints+pip \
-      --build_cache BUILD.info -o fullBUILD.info && \
-    mv fullBUILD.info BUILD.info
+      --build_cache Docker/BUILD.info -o BUILD.info
 
 # TODO: SBOM info of FastSurfer and FreeSurfer are missing, it is unclear how to add
 #       those at the moment, as the buildscanner syft does not find simple package.json

--- a/Docker/build.py
+++ b/Docker/build.py
@@ -654,7 +654,7 @@ def main(
         kwargs["build_arg"].append(f"{upper_key}={value}")
     #    kwargs["build_arg"] = " ".join(kwargs["build_arg"])
 
-    build_filename = fastsurfer_home / "BUILD.info"
+    build_filename = fastsurfer_home / "Docker/BUILD.info"
     if has_git():
         version_sections = "+git"
     else:


### PR DESCRIPTION
This PR will generate a dedicated BUILD.info file in the docker build process. 
This changes the storage location, so the native install will not use this file.

BUILD.info file will now only be copied/used from "Docker/"