### PR TITLE
Make separate run_fastsurfer.sh invocations more clear in log

### DIFF
--- a/CerebNet/data_loader/augmentation.py
+++ b/CerebNet/data_loader/augmentation.py
@@ -369,8 +369,8 @@ def sample_intensity_stats_from_image(
     n_classes = len(unique_classes)
     if not np.array_equal(unique_classes, np.arange(n_classes)):
         raise ValueError(
-            "classes_list should only contain values between 0 and K-1, "
-            "where K is the total number of classes. Here K = %d" % n_classes
+            f"classes_list should only contain values between 0 and K-1, "
+            f"where K is the total number of classes. Here K = {n_classes}"
         )
     if len(image.shape) == 4:
         h, w, d, n_slices = image.shape

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -739,12 +739,13 @@ fi
 
 {
   echo "========================================================="
-  echo "Start of the log for a new run_fastsurfer.sh invocation
+  echo "Start of the log for a new run_fastsurfer.sh invocation"
   echo "========================================================="
   VERSION=$($python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_cache_args[@]}")
   echo "Version: $VERSION"
   date 2>&1
   echo ""
+  echo "Log file for FastSurfer pipeline, run_fastsurfer.sh and segmentation(s)"
 } | tee -a "$seg_log"
 
 ### IF THE SCRIPT GETS TERMINATED, ADD A MESSAGE
@@ -763,12 +764,25 @@ then
   } | tee -a "$seg_log"
 fi
 
+pushd "${sd}/${subject}" || { echo "Could not access ${sd}/${subject}!" ; exit 1 ; }
+  content_of_subject_dir="$(find "." -type f)"
+popd || exit 1
+num_files_in_subject_dir="$(echo "$content_of_subject_dir" | wc -l)"
+if [[ "$num_files_in_subject_dir" -gt 1 ]] ; then
+  {
+    echo "Found $num_files_in_subject_dir in subject directory \$SUBJECTS_DIR/$subject"
+    # if [[ "$num_files_in_subject_dir" -gt 6 ]] ; then
+    #   echo "$content_of_subject_dir" | head -n 4 ; echo "..." ; echo "$content_of_subject_dir" | tail -n 2
+    # else echo "$content_of_subject_dir"
+    # fi
+    # echo ""
+  } | tee -a "$seg_log"
+fi
 
 if [[ "$run_seg_pipeline" == "1" ]]
 then
   # "============= Running FastSurferCNN (Creating Segmentation aparc.DKTatlas.aseg.mgz) ==============="
   # use FastSurferCNN to create cortical parcellation + anatomical segmentation into 95 classes.
-  echo "Log file for segmentation FastSurferCNN/run_prediction.py" >> "$seg_log"
 
   if [[ "$run_asegdkt_module" == "1" ]]
   then

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -737,8 +737,15 @@ if [[ -f "$seg_log" ]]; then log_existed="true"
 else log_existed="false"
 fi
 
-VERSION=$($python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_cache_args[@]}")
-echo "Version: $VERSION" | tee -a "$seg_log"
+{
+  echo "========================================================="
+  echo "Start of the log for a new run_fastsurfer.sh invocation
+  echo "========================================================="
+  VERSION=$($python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_cache_args[@]}")
+  echo "Version: $VERSION"
+  date 2>&1
+  echo ""
+} | tee -a "$seg_log"
 
 ### IF THE SCRIPT GETS TERMINATED, ADD A MESSAGE
 trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" >> \"$seg_log\" ; }" SIGINT SIGTERM
@@ -762,7 +769,6 @@ then
   # "============= Running FastSurferCNN (Creating Segmentation aparc.DKTatlas.aseg.mgz) ==============="
   # use FastSurferCNN to create cortical parcellation + anatomical segmentation into 95 classes.
   echo "Log file for segmentation FastSurferCNN/run_prediction.py" >> "$seg_log"
-  { date 2>&1 ; echo "" ; } | tee -a "$seg_log"
 
   if [[ "$run_asegdkt_module" == "1" ]]
   then


### PR DESCRIPTION
- Add separator of invocations of the log file in the log
- Move the date information up into the "general" block (so it is not there only for segmentation)
- Add information about the contents of the subjects_dir