### PR TITLE
Edit and establish the workflow "quicktest" on github actions servers 

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,0 +1,67 @@
+# This workflow file is a reusable workflow that will create a docker container from the currently
+# selected branch and crates a docker image in an artifact (fastsurfer-<github-sha>-docker)
+# The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
+
+name: 'Build a FastSurfer docker image'
+description: 'Build a FastSurfer image'
+
+inputs:
+  fastsurfer-home:
+    description: "Path to the FastSurfer checkout directory"
+    default: "."
+    type: string
+  tag:
+    description: "Name to tag the resulting image"
+    default: "auto"
+    type: string
+  freesurfer-build-image:
+    description: "Name of the freesurfer build image"
+    default: "rebuild"
+    type: string
+  target:
+    description: "Name of the target"
+    default: "runtime"
+    type: string
+outputs:
+  image-name:
+    description: "Name of the image in docker"
+    value: ${{ steps.build.outputs.IMAGE_NAME }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Recover freesurfer build image
+      if: ${{ startsWith( inputs.freesurfer-build-image, 'fastsurfer:') }}
+      uses: ./.github/actions/load-docker
+      with:
+        docker-image: ${{ inputs.freesurfer-build-image }}
+        target: build_freesurfer
+    - name: Build FastSurfer Image
+      id: build
+      shell: bash
+      env:
+        FASTSURFER_HOME: ${{ inputs.fastsurfer-home }}
+      run: |
+        echo "::group::Build FastSurfer Image"
+        if [[ "${{ inputs.tag }}" != "auto" ]] ; then image_name="${{ inputs.tag }}" 
+        else v="$(bash $FASTSURFER_HOME/run_fastsurfer.sh --version)" ; image_name="fastsurfer:cpu-${v/+/_}" 
+        fi
+        cmd="python $FASTSURFER_HOME/Docker/build.py --device cpu --tag $image_name --target ${{ inputs.target }}"
+        if [[ "${{ inputs.freesurfer-build-image }}" != "rebuild" ]] ; then 
+          cmd="$cmd --freesurfer_build_image ${{ inputs.freesurfer-build-image }}"
+        fi
+        $cmd
+        echo "::endgroup::"
+        echo "::group::Save image as artifact"
+        echo "IMAGE_NAME=$image_name" | tee /tmp/image_name.env >> $GITHUB_OUTPUT
+        # Export image
+        docker save $image_name -o /tmp/docker-image.tar
+    - name: Save docker image
+      uses: actions/upload-artifact@v4
+      with:
+        name: fastsurfer-${{ github.sha }}-${{ inputs.target }}
+        path: |
+          /tmp/docker-image.tar
+          /tmp/image_name.env

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Recover freesurfer build image
-      if: ${{ startsWith( inputs.freesurfer-build-image, 'fastsurfer:') }}
+      if: ${{ contains( inputs.freesurfer-build-image, 'fastsurfer-build:freesurfer') }}
       uses: ./.github/actions/load-docker
       with:
         docker-image: ${{ inputs.freesurfer-build-image }}
@@ -46,18 +46,18 @@ runs:
       run: |
         echo "::group::Build FastSurfer Image"
         if [[ "${{ inputs.tag }}" != "auto" ]] ; then image_name="${{ inputs.tag }}" 
-        else v="$(bash $FASTSURFER_HOME/run_fastsurfer.sh --version)" ; image_name="fastsurfer:cpu-${v/+/_}" 
+        else v="$(bash "$FASTSURFER_HOME/run_fastsurfer.sh" --version)" ; image_name="fastsurfer:cpu-${v/+/_}" 
         fi
-        cmd="python $FASTSURFER_HOME/Docker/build.py --device cpu --tag $image_name --target ${{ inputs.target }}"
+        cmd=(python "$FASTSURFER_HOME/Docker/build.py" --device cpu --tag "$image_name" --target "${{ inputs.target }}")
         if [[ "${{ inputs.freesurfer-build-image }}" != "rebuild" ]] ; then 
-          cmd="$cmd --freesurfer_build_image ${{ inputs.freesurfer-build-image }}"
+          cmd+=(--freesurfer_build_image "${{ inputs.freesurfer-build-image }}")
         fi
-        $cmd
+        "${cmd[@]}"
         echo "::endgroup::"
         echo "::group::Save image as artifact"
         echo "IMAGE_NAME=$image_name" | tee /tmp/image_name.env >> $GITHUB_OUTPUT
         # Export image
-        docker save $image_name -o /tmp/docker-image.tar
+        docker save "$image_name" -o /tmp/docker-image.tar
     - name: Save docker image
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/load-docker/action.yml
+++ b/.github/actions/load-docker/action.yml
@@ -1,0 +1,36 @@
+name: 'Load a docker image'
+description: 'Load a docker image from an artifact'
+
+inputs:
+  docker-image:
+    type: string
+    description: "The fastsurfer image to use (default: use cached image from prior build-docker build)"
+    default: 'build-cached'
+  target:
+    type: string
+    default: 'runtime'
+outputs:
+  image-name:
+    description: 'the name of the image that was imported'
+    value: ${{ steps.load.outputs.IMAGE_NAME }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore docker image from an artifact
+      if: inputs.docker-image == 'build-cached'
+      uses: actions/download-artifact@v4
+      with:
+        name: fastsurfer-${{ github.sha }}-${{ inputs.target }}
+        path: /tmp
+    - name: Load cached docker image and save IMAGE_NAME in environment
+      id: load
+      shell: bash
+      run: |
+        if [[ "${{ inputs.docker-image }}" == "build-cached" ]] ; then
+          cat /tmp/image_name.env >> $GITHUB_OUTPUT
+          docker load -i /tmp/docker-image.tar
+          rm /tmp/docker-image.tar
+        else
+          echo "IMAGE_NAME=${{ inputs.docker-image }}" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/load-processed/action.yml
+++ b/.github/actions/load-processed/action.yml
@@ -1,0 +1,36 @@
+name: 'Load processed data'
+description: 'Load a docker image from an artifact'
+
+inputs:
+  subject-id:
+    type: string
+    description: "The name of the case folder"
+    required: true
+  subjects-dir:
+    type: string
+    description: "Path to the subjects-dir"
+    default: "/tmp"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Recover processed files
+      uses: actions/download-artifact@v4
+      with:
+        name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}
+        path: /tmp/${{ inputs.subject-id }}.tar.gz
+    - name: Load cached subject directory
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.subjects-dir }}
+        if [[ -d "${{ inputs.subjects-dir }}/${{ inputs.subject-id }}" ]] ; then
+          echo "The expected subject directory ${{ inputs.subjects-dir }}/${{ inputs.subject-id }} already exists!"
+          exit 1
+        fi
+        tar xf /tmp/${{ inputs.subject-id }}.tar.gz -C ${{ inputs.subjects-dir }}
+        rm -f /tmp/${{ inputs.subject-id }}.tar.gz
+        if [[ ! -d "${{ inputs.subjects-dir }}/${{ inputs.subject-id }}" ]] ; then
+          echo "The artifact did not contain the expected output directory ${{ inputs.subjects-dir }}/${{ inputs.subject-id }}!"
+          exit 1
+        fi

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -1,0 +1,93 @@
+# This workflow file is a reusable workflow that will process a single T1 image with docker.
+# The docker image can be built by workflow build-docker or on dockerhub (input image).
+# The image will be downloaded
+# The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
+
+name: 'Run Fastsurfer'
+description: 'Runs FastSurfer'
+
+inputs:
+  docker-image:
+    type: string
+    description: "The fastsurfer image to use (default: use cached image from prior build-docker build)"
+    default: "build-cached"
+  subject-id:
+    type: string
+    description: "The name of the case folder"
+    required: true
+  file-extension:
+    type: string
+    description: "The file extension of the image file to use (default: .nii.gz)."
+    # Should start with "."
+    default: ".nii.gz"
+  extra-args:
+    type: string
+    description: "Extra FastSurfer arguments"
+    default: ""
+  image-href:
+    required: true
+    description: "The url to the file to download for processing"
+  license:
+    required: true
+    description: "The FreeSurfer license"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Load the docker image
+      id: load-docker
+      uses: ./.github/actions/load-docker
+      with:
+        docker-image: ${{ inputs.docker-image }}
+    - name: Set up FreeSurfer License and download T1 image
+      shell: bash
+      env:
+        IMAGE_HREF: ${{ inputs.image-href }}
+        EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        echo "::group::Check arguments and prepare directories"
+        DATA_DIR=$(dirname $(pwd))/data
+        echo "DATA_DIR=$DATA_DIR" >> $GITHUB_ENV  # DATA_DIR is used in the next 2 steps as well
+        mkdir -p $DATA_DIR
+        echo "${{ inputs.license }}" > $DATA_DIR/.fs_license
+        curl -k "$IMAGE_HREF" -o "$DATA_DIR/T1${{ inputs.file-extension }}"
+        if [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--threads/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--parallel/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--fs_license/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--sd/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--sid/}" ]] ; then
+          echo "--threads, --parallel, --fs_license, --sid, --sd are not allowed in extra-args!"
+          exit 1
+        elif [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--surf_only/}" ]] && [[ ! -d "$DATA_DIR/${{ inputs.subject-id }}/mri" ]] ; then
+          echo "Could not find subject folder for ${{ inputs.subject-id }}!"
+          exit 1
+        fi
+        echo "::endgroup::"
+    - name: FastSurfer Segmentation pipeline
+      shell: bash
+      if: ${{ ! contains( inputs.extra-args, '--surf_only' ) }}
+      env:
+        IMAGE_NAME: ${{ steps.load-docker.outputs.image-name }}
+      run: |
+        echo "::group::FastSurfer Segmentation"
+        docker run --rm -t -v "$DATA_DIR:/data" -u $(id -u):$(id -g) --env TQDM_DISABLE=1 "$IMAGE_NAME" \
+          --fs_license /data/.fs_license --t1 /data/T1${{ inputs.file-extension }} --sid "${{ inputs.subject-id }}" \
+          --sd /data --threads $(nproc) --seg_only ${{ inputs.extra-args }}
+        echo "::endgroup::"
+    - name: FastSurfer Surface pipeline
+      shell: bash
+      if: ${{ ! contains( inputs.extra-args, '--seg_only' ) }}
+      env:
+        IMAGE_NAME: ${{ steps.load-docker.outputs.image-name }}
+      run: |
+        echo "::group::FastSurfer Surface reconstruction"
+        docker run --rm -t -v "$DATA_DIR:/data" -u $(id -u):$(id -g) --env TQDM_DISABLE=1 "$IMAGE_NAME" \
+          --fs_license /data/.fs_license --t1 /data/T1${{ inputs.file-extension }} --sid "${{ inputs.subject-id }}" \
+          --sd /data --parallel --threads 1 --surf_only ${{ inputs.extra-args }}
+        echo "::endgroup::"
+    - name: Create archive of Processed subject-data
+      shell: bash
+      run: |
+        echo "::group::Save ${{ inputs.subject-id }} as artifact"
+        tar cfz "$DATA_DIR/${{ inputs.subject-id }}.tar.gz" -C "$DATA_DIR" "${{ inputs.subject-id }}"
+    - name: Save processed data
+      uses: actions/upload-artifact@v4
+      with:
+        name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}
+        path: ${{ env.DATA_DIR }}/${{ inputs.subject-id }}.tar.gz

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,70 @@
+# This workflow file is a reusable workflow that will process a single T1 image with docker.
+# The docker image can be built by workflow build-docker or on dockerhub (input image).
+# The image will be downloaded
+# The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
+
+name: 'Run Fastsurfer'
+description: 'Runs FastSurfer'
+
+inputs:
+  subject-id:
+    type: string
+    description: "The name of the case folder"
+    required: true
+  subjects-dir:
+    type: string
+    description: "Path to the subjects-dir"
+    default: "/tmp/subjects"
+  reference-dir:
+    type: string
+    description: "Path to the reference-dir"
+    default: "/tmp/reference"
+  case-href:
+    required: true
+    type: string
+    description: "The url to the reference file to download for comparison"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        architecture: 'x64'
+        cache: 'pip' # caching pip dependencies
+    - name: Install dependencies
+      shell: bash
+      run: |
+        echo "::group::Create python environment"
+        python -m pip install --progress-bar off --upgrade pip setuptools wheel
+        python -m pip install --progress-bar off .[quicktest]
+        echo "::endgroup::"
+    - name: Download reference data
+      shell: bash
+      env:
+        CASE_HREF: ${{ inputs.case-href }}
+        REF_DIR: ${{ inputs.reference-dir }}
+      run: |
+        echo "::group::Prepare processed and reference data"
+        mkdir -p $REF_DIR
+        echo "REF_DIR=$REF_DIR" >> $GITHUB_ENV
+        curl -k "$CASE_HREF" | tar xf --directory "$REF_DIR"
+    - name: Recover Case data
+      uses: ./.github/actions/load-processed
+      with:
+        subject-id: ${{ inputs.subject-id }}
+        subjects-dir: ${{ inputs.subjects-dir }}
+    # run pytest checks for data consistency/quality
+    - name: Run pytest
+      env:
+        PYTHON_PATH: .
+        FASTSURFER_HOME: ${{ github.workspace }}
+        REF_DIR: ${{ inputs.reference-dir }}
+      shell: bash
+      run: |
+        echo "::endgroup::"
+        echo "::group::Run tests"
+        python -m pytest test/quick_test
+

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,4 +1,4 @@
-name: code-style
+name: AUTO code-style
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: deploy-docker
+name: MAN deploy-docker
 
 on:
 #  release:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy-gpu:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -52,4 +52,4 @@ jobs:
           docker tag ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ github.event.release.tag_name }} ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-latest
       - name: Push Docker image CPU
         run: docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/fastsurfer:cpu-${{ github.event.release.tag_name }}
-        
+

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: doc
+name: AUTO doc
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -24,9 +24,11 @@ on:
   workflow_dispatch:
     inputs:
       docker-image:
-        name: 'Docker image to run with'
         description: 'Which docker image should be used to run this test (build-cached => build from git)'
         default: build-cached
+        type: string
+      freesurfer_build_image:
+        description: 'FreeSurfer build image to build with'
         type: string
 
 env:
@@ -99,13 +101,29 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Get the FreeSurfer version
+        shell: bash
+        run: |
+          # get the FreeSurfer verson from install_fs_pruned.sh
+          {
+            eval "$(grep "^fslink=" ./Docker/install_fs_pruned.sh)"
+            fs_version="$(basename "$(dirname "$fslink")")"
+            fs_version_short="${fs_version//\./}"
+            echo "FS_VERSION=$fs_version"
+            echo "FS_VERSION_SHORT=$fs_version_short"
+            if [[ -n "${{ inputs.freesurfer_build_image }}" ]] ; then
+              echo "FS_BUILD_IMAGE=${{ inputs.freesurfer_build_image }}"
+            else
+              echo "FS_BUILD_IMAGE=deepmi/fastsurfer-build:freesurfer$fs_version_short"
+            fi
+          } > $GITHUB_ENV
       - uses: ./.github/actions/build-docker@dev
         # This action needs the "full" checkout (located at ${{ inputs.fastsurfer-home }})
         with:
           fastsurfer-home: .
           # currently, this image has to be updated and used to circumvent storage limitations in github actions
           # and it is also faster to use this prebuilt, reduced-size freesurfer distribution
-          freesurfer-build-image: dkuegler/fastsurfer:fs741-build-image
+          freesurfer-build-image: "${{ env.FS_BUILD_IMAGE }}"
   run-1mm:
     name: 'Run FastSurfer on the 1mm sample image'
     needs: build-docker-latest

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Get the FreeSurfer version
         shell: bash
         run: |
-          # get the FreeSurfer verson from install_fs_pruned.sh
+          # get the FreeSurfer version from install_fs_pruned.sh
           {
             eval "$(grep "^fslink=" ./Docker/install_fs_pruned.sh)"
             fs_version="$(basename "$(dirname "$fslink")")"

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -1,4 +1,4 @@
-name: quicktest
+name: MAN quicktest
 
 # File: quicktest.yaml
 # Author: Taha Abdullah
@@ -7,70 +7,166 @@ name: quicktest
 #  also checks if the FastSurfer environment and output already exist, and if not, it creates them.
 # Usage: This workflow is triggered on a pull request to the dev and main branch. It can also be triggered manually
 #  with workflow-dispatch.
-# Expected/Used Environment Variables:
-#  - MAMBAPATH: Path to the micromamba binary.
-#  - MAMBAROOT: Root path for micromamba.
-#  - RUNNER_FS_OUTPUT: Path to the directory where FastSurfer output is stored.
-#  - RUNNER_FS_MRI_DATA: Path to the directory where MRI data is stored.
-#  - FREESURFER_HOME: Path to the freesurfer directory.
-#  - FS_LICENSE: Path to the FreeSurfer license file.
+# Expected Secrets:
+#  - IMAGE_HREF_08mm: URL to a sample 0.8mm image
+#  - IMAGE_HREF_1mm: URL to a sample 1mm image
+#  - CASE_HREF_08mm: URL to the reference processing of the sample 0.8mm image
+#  - CASE_HREF_1mm: URL to the reference processing of the sample 1mm image
+#  - LICENSE: content of a FreeSurfer license file
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 on:
-#  pull_request:
-#    branches:
-#      - dev
-#      - stable
+  pull_request:
+    types: [labeled, unlabeled]
   workflow_dispatch:
+    inputs:
+      docker-image:
+        name: 'Docker image to run with'
+        description: 'Which docker image should be used to run this test (build-cached => build from git)'
+        default: build-cached
+        type: string
+
+env:
+  SUBJECTS_DIR: /tmp/subjects
+  REFERENCE_DIR: /tmp/reference
 
 jobs:
-  run-quicktest:
-    runs-on: self-hosted
+  parse-action:
+    name: 'Check whether the quicktest should run'
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.parse.CONTINUE }}
+      docker-image: ${{ steps.parse.DOCKER_IMAGE }}
+      extra-args: ${{ steps.parse.EXTRA_ARGS }}
     steps:
-    # Checkout fastsurfer
-    - uses: actions/checkout@v2
-    # Check if the Environment Variables used in further steps are present
-    - name: Check Environment Variables
-      run: |
-        REQUIRED_ENV_VARS=(
-          "MAMBAPATH"
-          "MAMBAROOT"
-          "RUNNER_FS_OUTPUT"
-          "RUNNER_FS_MRI_DATA"
-          "FREESURFER_HOME"
-          "FS_LICENSE"
-        )
-        
-        for VAR_NAME in "${REQUIRED_ENV_VARS[@]}"; do
-          if [ -z "${!VAR_NAME}" ]; then
-            echo "Error: Required environment variable $VAR_NAME is not set"
+      - name: 'Check whether the tests should run'
+        id: parse
+        shell: bash
+        run: |
+          h1="Accept: application/vnd.github+json"
+          h2="X-GitHub-Api-Version: 2022-11-28"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]
+          then
+            if [[ "${{ github.event.action }}" == "labeled" ]] || [[ "${{ github.event.action }}" == "unlabeled" ]]
+            then
+              # not a label-related action, should not be triggered
+              echo "The Workflow '${{ github.workflow }}' was triggered by 'pull_request' of type"
+              echo "  '${{ github.event.action }}' but should only be triggered by 'labeled' or 'unlabeled' actions."
+              exit 1
+            elif [[ "${{ github.event.label.name }}" == "quicktest" ]]
+            then
+              echo "CONTINUE=true" > $GITHUB_OUTPUT
+            else
+              echo "This is a different label that was attached."
+              echo "CONTINUE=false" > $GITHUB_OUTPUT
+            fi
+            echo "DOCKER_IMAGE=build-cached" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]
+          then
+            {
+              echo "CONTINUE=true"
+              if [[ "${{ inputs }}" == "{}" ]] || "${{ inputs.docker-image }}" == "" ]] ; then
+                echo "DOCKER_IMAGE=build-cached"
+              else
+                echo "DOCKER_IMAGE=${{ inputs.docker-image }}"
+              fi
+            } > $GITHUB_OUTPUT
+          else #  this event has no specific rules
+            echo "This workflow is not defind for the event ${{ github.event_name }}!"
             exit 1
           fi
-        done
-        
-        if [ ! -f "$FS_LICENSE" ]; then
-          echo "Error: FreeSurfer license file does not exist at $FS_LICENSE"
-          exit 1
-        fi
-        
-        if [ ! -d "$FREESURFER_HOME" ]; then
-          echo "Error: FreeSurfer installation directory does not exist at $FREESURFER_HOME"
-          exit 1
-        fi
-    # Run FastSurfer on test subjects
-    - name: Run FastSurfer
-      run: |
-        echo "Running FastSurfer..."
-        echo "Output will be saved in data/${GITHUB_SHA:0:7}"
-        export FASTSURFER_HOME=$(pwd)
-        export THIS_RUN_OUTDIR=${GITHUB_SHA:0:7}
-        mkdir -p $SUBJECTS_DIR/$THIS_RUN_OUTDIR
-        export TEST_DIR=$THIS_RUN_OUTDIR
-        export TQDM_DISABLE=1
-        ./brun_fastsurfer.sh --subject_list $RUNNER_FS_MRI_DATA/subjects_list.txt \
-                             --sd $SUBJECTS_DIR/$THIS_RUN_OUTDIR \
-                             --parallel --threads 4 --3T --parallel_subjects surf
-    # run pytest checks for data consistency/quality
-    - name: Run pytest
-      run: |
-        source /venv-pytest/bin/activate
-        python -m pytest test/quick_test
+          if ! gh api -H "$h1" -H "$h2" /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}
+          then
+            echo "Only collaborators explicitly listed as collaborators can trigger this workflow!"
+            echo "CONTINUE=false" > $GITHUB_OUTPUT
+            exit 1
+          fi
+          # later, we might want to extract additional run options from the pr text or issue comments
+          # these should just be added here 
+          # https://api.github.com/repos/${{ github.repository }}/issues/${{ github.number }}
+          # https://api.github.com/repos/${{ github.repository }}/issues/${{ github.number }}/comments
+          # this may also need adaptations in the test script at the bottom
+          echo "EXTRA_ARGS=" >> $GITHUB_OUTPUT
+  build-docker-latest:
+    name: 'Build the current docker image'
+    needs: parse-action
+    runs-on: ubuntu-latest
+    if: ${{ jobs.parse-action.outputs.continue == 'true' }}
+    timeout-minutes: 180
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-docker@dev
+        # This action needs the "full" checkout (located at ${{ inputs.fastsurfer-home }})
+        with:
+          fastsurfer-home: .
+          # currently, this image has to be updated and used to circumvent storage limitations in github actions
+          # and it is also faster to use this prebuilt, reduced-size freesurfer distribution
+          freesurfer-build-image: dkuegler/fastsurfer:fs741-build-image
+  run-1mm:
+    name: 'Run FastSurfer on the 1mm sample image'
+    needs: build-docker-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+      - name: Run FastSurfer with the previously created docker container
+        uses: ./.github/actions/run-fastsurfer@dev
+        with:
+          subject-id: 1.0mm
+          file-extension: ".mgz"
+          image-href: ${{ secrets.IMAGE_HREF_1mm }}
+          license: ${{ secrets.LICENSE }}
+          docker-image: ${{ jobs.parse-action.outputs.docker-image }}
+          extra-args: ${{ jobs.parse-action.outputs.extra-args }}
+  run-08mm:
+    name: Run FastSurfer on the 0.8mm sample image
+    needs: build-docker-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+      - name: Run FastSurfer with the previously created docker container
+        uses: ./.github/actions/run-fastsurfer@dev
+        with:
+          subject-id: 0.8mm
+          file-extension: ".nii.gz"
+          image-href: ${{ secrets.IMAGE_HREF_08mm }}
+          license: ${{ secrets.LICENSE }}
+          docker-image: ${{ jobs.parse-action.outputs.docker-image }}
+          extra-args: ${{ jobs.parse-action.outputs.extra-args }}
+  run-tests-1mm:
+    name: Download data and perform tests (1.0mm)
+    needs: run-1mm
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests for the 1.0mm dataset
+        uses: ./.github/actions/run-tests@dev
+        with:
+          subject-id: "1.0mm"
+          subjects-dir: ${{ env.SUBJECTS_DIR }}
+          reference-dir: ${{ env.REFERENCE_DIR }}
+          case-href: ${{ secrets.CASE_HREF_1mm }}
+  run-tests-08mm:
+    name: Download data and perform tests (0.8mm)
+    needs: run-08mm
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests for the 0.8mm dataset
+        uses: ./.github/actions/run-tests@dev
+        with:
+          subject-id: "0.8mm"
+          subjects-dir: ${{ env.SUBJECTS_DIR }}
+          reference-dir: ${{ env.REFERENCE_DIR }}
+          case-href: ${{ secrets.CASE_HREF_08mm }}

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -75,7 +75,7 @@ jobs:
               fi
             } > $GITHUB_OUTPUT
           else #  this event has no specific rules
-            echo "This workflow is not defind for the event ${{ github.event_name }}!"
+            echo "This workflow is not defined for the event ${{ github.event_name }}!"
             exit 1
           fi
           if ! gh api -H "$h1" -H "$h2" /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /BUILD.info
+/Docker/BUILD.info
 /.idea/**
 /rough_work/**
 
@@ -6,4 +7,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+*/stub


### PR DESCRIPTION
Edit and establish the workflow "quicktest" on github actions servers (compatible with github actions)

The quicktest action is triggered manually (dispatch in actions) or directly from a PR. The former can for example be used to generate the reference data. The latter may be used to add on-demand checks.

The actual test scripts have not been modified and are not expected to seamlessly work, but processing works.

On-demand checks in the pull request are triggered by adding or removing a "quicktest" label. There is a further check to ensure the workflow is only performed if people listed as collaborators changed the label.

This PR adds/changes the github workflow files and adds actions where appropriate.
Github actions are organized in .github/actions
- build-docker
- load-docker
- load-processed
- run-fastsurfer
- run-tests

The core workflow is .github/workflows/quicktest.yml. It requires 5 secrets to be set up in the repository which include the FreeSurfer license and paths to two sample images as well as their reference processing.
The Workflow defines several jobs to enable parallel processing as well as circumvent resource limitations of github actions.

The PR also adds a couple of files to .gitignore for cleaner git messages