### PR TITLE
Base/long fix -fsaparc

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1106,12 +1106,16 @@ fi # skip in base
     cmd="mris_ca_label -l $ldir/${hemi}.cortex.label -aseg $mdir/aseg.presurf.mgz -seed 1234 $longflag $subject $hemi $sdir/${hemi}.sphere.reg $CPAtlas $annot"
     RunIt "$cmd" "$LF"
 
+   done # hemi loop
+
+   # skip in base
+   if [ "$base" != "1" ] ; then
     cmd="recon-all -subject $subject -pctsurfcon -hyporelabel -apas2aseg -aparc2aseg -wmparc -parcstats -parcstats2 -parcstats3 $hiresflag $fsthreads"
     RunIt "$cmd" "$LF"
     # removed -balabels here and do that below independent of fsaparc flag
     # removed -segstats here (now part of mri_segstats.py/segstats.py
+   fi # (if not base)
 
-   done # hemi loop
   fi  # (FS-APARC)
 
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1050,12 +1050,11 @@ if [ "$DoParallel" == 1 ] ; then
   RunBatchJobs "$LF" "${CMDFS[@]}"
 fi
 
-# Skip rest in case we have a base run, we are done here (probably we can skip stuff already in surface creation above)
-if [ "$base" != "1" ] ; then
-
 
 # ============================= RIBBON ===============================================
 
+# Skip RIBBON in base
+if [ "$base" != "1" ] ; then
 
 {
   echo ""
@@ -1069,6 +1068,7 @@ if [ "$base" != "1" ] ; then
   cmd="recon-all -subject $subject -cortribbon $hiresflag $fsthreads"
   RunIt "$cmd" "$LF"
 
+fi # skip in base
 
 # ============================= FSAPARC - parc23 surfcon hypo ... =========================================
 
@@ -1109,6 +1109,9 @@ if [ "$base" != "1" ] ; then
     # removed -segstats here (now part of mri_segstats.py/segstats.py
   fi  # (FS-APARC)
 
+
+# Skip rest in case we have a base run, we are done here (probably we can skip stuff already in surface creation above)
+if [ "$base" != "1" ] ; then
 
 # ============================= MAPPED SURF-STATS =========================================
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1073,9 +1073,12 @@ fi # skip in base
 # ============================= FSAPARC - parc23 surfcon hypo ... =========================================
 
   if [ "$fsaparc" == "1" ] ; then
+
+   for hemi in lh rh ; do
+
     {
       echo ""
-      echo "============= Creating surfaces - other FS asegdkt_segfile and stats ======================="
+      echo "============= Creating surfaces $hemi - fsaparc annot a2009s and DKTaparc ======================="
       echo ""
     } | tee -a "$LF"
 
@@ -1107,6 +1110,8 @@ fi # skip in base
     RunIt "$cmd" "$LF"
     # removed -balabels here and do that below independent of fsaparc flag
     # removed -segstats here (now part of mri_segstats.py/segstats.py
+
+   done # hemi loop
   fi  # (FS-APARC)
 
 


### PR DESCRIPTION
Fixes two things in base and long stream when using --fsaparc:
1. before base was skipping the annot creation of the a2009s and DKTatlas
2. hemi loop was missing (so that this only ran on rh)