### PR TITLE
Update the docker build defaults

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -31,7 +31,7 @@
 #   Which miniforge file to download to install mamba
 #   from https://github.com/conda-forge/miniforge/releases/download/
 #   ${FORGE_VERSION}/Miniforge3-${FORGE_VERSION}-Linux-x86_64.sh
-#   - default: Miniforge3-23.11.0-0-Linux-x86_64.sh
+#   - default: Miniforge3-24.11.2-1-Linux-x86_64.sh
 
 # DOCUMENTATION FOR TARGETS (use '--target <VALUE>'):
 # To select which imaged will be tagged with '-t'
@@ -71,8 +71,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG PYTHON_VERSION=3.10
-ARG FORGE_VERSION=24.3.0-0
+ARG FORGE_VERSION=24.11.2-1
 
 # Install conda
 RUN wget --no-check-certificate -qO ~/miniforge.sh \

--- a/env/fastsurfer.yml
+++ b/env/fastsurfer.yml
@@ -2,7 +2,6 @@ name: fastsurfer
 
 channels:
   - conda-forge
-  - defaults
 
 dependencies:
 - h5py=3.11.0

--- a/env/fastsurfer_reconsurf.yml
+++ b/env/fastsurfer_reconsurf.yml
@@ -2,7 +2,6 @@
 name: fastsurfer_reconsurf
 
 channels:
-  - defaults
   - conda-forge
   
 dependencies:


### PR DESCRIPTION
- Remove the conda `defaults` channel (not needed)
  This would retrieve information from `repo.anaconda.com`, which is blocked at the DZNE.
  We confirmed that removing the `defaults` channel does not change the python packages.
  Miniforge by default uses the `conda-forge` (community-maintained) channel, not the `defaults` (maintained by anaconda) channel.
- Update the Miniforge version (24.11.2-1)