### PR TITLE
Improvements to brun_fastsurfer.sh

### DIFF
--- a/doc/overview/EXAMPLES.md
+++ b/doc/overview/EXAMPLES.md
@@ -168,10 +168,7 @@ fastsurferdir=/home/user/my_fastsurfer_analysis
 ```
 
 ### Flags
-The `brun_fastsurfer.sh` script accepts almost all `run_fastsurfer.sh` flags (exceptions are `--t1` and `--sid`). In addition, 
-* the `--parallel_subjects` runs all subjects in parallel (experimental, parameter may change in future releases). This is particularly useful for surfaces computation `--surf_only`.
-* to run segmentation in series, but surfaces in parallel, you may use `--parallel_subjects surf`.
-* these options are in contrast (and in addition) to `--parallel`, which just parallelizes the hemispheres of one case.
+The `brun_fastsurfer.sh` script accepts almost all `run_fastsurfer.sh` flags (exceptions are `--t1` and `--sid`). In addition, it has [powerful parallelization options](../scripts/BATCH.md#parallelization-with-brun_fastsurfersh).
 
 ## Example 5: Quick Segmentation
 
@@ -181,7 +178,7 @@ For many applications you won't need the surfaces. You can run only the aparc+DK
 ./run_fastsurfer.sh --t1 $datadir/subject1/t1-weighted.nii.gz \
                     --asegdkt_segfile $outputdir/subject1/aparc.DKTatlas+aseg.deep.mgz \
                     --conformed_name $outputdir/subject1/conformed.mgz \
-                    --threads 4 --seg_only --no_cereb
+                    --threads 4 --seg_only --no_cereb --no_hypothal
 ```
 
 This will produce the segmentation in a conformed space (just as FreeSurfer would do). It also writes the conformed image that fits the segmentation.

--- a/doc/scripts/BATCH.md
+++ b/doc/scripts/BATCH.md
@@ -8,6 +8,76 @@ Usage
 :cwd: /../
 ```
 
+Subject Lists
+-------------
+
+The input files and options may be specified in three ways:
+
+1. By writing them into the console (or by piping them in) (default) (one case per line),
+2. by passing a subject list file `--subject_list <filename>` (one case per line), or
+3. by passing them on the command line `--subjects "<subject_id>=<t1 file>" [more cases]` (no additional options 
+   supported).
+
+These files/input options will usually be in the format `<subject_id>=<t1 file> [additional options]`, where additional
+options are optional and enable passing options different to the "general options" given on the command line to 
+`brun_fastsurfer.sh`. One example for such a case-specific option is an optional T2w image (e.g. for the 
+[HypVINN](../overview/OUTPUT_FILES.md#hypvinn-module)). An example subject list file might look like this:
+
+```
+001=/data/study/raw/T1w-001.nii.gz --t2 /data/study/raw/T2w-001.nii.gz
+002=/data/study/raw/T1w-002.nii.gz --t2 /data/study/raw/T2w-002.nii.gz
+002=/data/study/raw/T1w-003-alt.nii.gz --t2 /data/study/raw/T2w-003.nii.gz
+... 
+```
+
+Parallelization with `brun_fastsurfer.sh`
+-----------------------------------------
+
+`brun_fastsurfer.sh` has powerful builtin parallel processing capabilities. These are hidden underneath the 
+`--parallel_subjects [seg=|surf=][<n>]` and the `--device <device>` as well as `--viewagg_device <device>` flags.
+One of the core properties of FastSurfer is the split into the segmentation (which uses Deep Learning and therefore 
+benefits from GPUs) and the surface pipeline (which does not benefit from GPUs). For ideal batch processing, we want 
+different resource scheduling.
+
+`--parallel_subjects` allows three parallel batch processing modes: serial, single parallel pipeline and dual parallel
+pipeline. 
+
+### Serial processing (default)
+Each case/image is processed after the other fully, i.e. surface reconstruction of case 1 is fully finished before 
+segmentation of case 2 is started. This setting is the default and represents the manual flags `--parallel_subjects 1`.
+
+### Single parallel pipeline
+This mode is ideal for CPU-based processing for segmentation. It will process segmentations and surfaces in series 
+in the same process, but multiple cases are processed at the same time.
+
+```bash
+$FASTSURFER_HOME/brun_fastsurfer.sh --parallel_subjects 4 --threads 2 --parallel
+```
+will start 4 segmentations (and surface reconstructions) at the same time, and will start a fifth, when the surface
+processing of one of the four first cases is finished (`--parallel_subjects 4`). It will try to use 2 threads per case
+(`--threads 2`) and perform reconstruction of left and right hemispheres in parallel (`--parallel`).
+`--parallel_subjects max` or `--parallel_subjects` will remove the limit and start all cases at the same time (each with
+the target number of threads given in `--threads`).
+
+### Dual parallel pipeline
+This is ideal for GPU-based processing for segmentation. It will process segmentations and surfaces in separate 
+pipelines, which is useful for optimized GPU loading. Multiple cases may be processed at the same time.
+
+```bash
+$FASTSURFER_HOME/brun_fastsurfer.sh --device cuda:0-1 --parallel_subjects seg=2 --parallel_subjects surf=max \
+  --threads seg=8 --threads surf=2 --parallel
+```
+will start 2 parallel segmentations (`--parallel_subjects seg=2`) using GPU 0 for case 1 and GPU for case 2 
+(`--device cuda:0-1` -- same as `--device cuda:0,1`). After one of these segmentations 1 is finished, segmentation of 
+case 3 will start on that same device as well as the surface reconstruction (without putting a limit on parallel 
+surface reconstructions, `--parallel_subjects surf=max`). Each segmentation process will aim to use 8 threads/cores
+(`--threads seg=8`) and each surface reconstruction process will aim to use 2 threads (`--threads surf=2`) with both
+hemispheres processed in parallel (`--parallel`).
+
+Note, if your GPU has sufficient [video memory](../overview/intro.rst#system-requirements), two parallel segmentations
+can run on the same GPU, but the script cannot schedule more than one process per GPU for multiple GPUs, i.e.
+`--device cuda:0,1 --parallel_subjects seg=4` is not supported.
+
 Questions
 ---------
 Can I disable the progress bars in the output?

--- a/stools.sh
+++ b/stools.sh
@@ -403,11 +403,8 @@ function print_status ()
   local info=$2
   local retval=$3
   local text
-  if [[ "$retval" != "0" ]]
-  then
-    text="Failed $info with exit code $retval"
-  else
-    text="Finished $info successfully"
+  if [[ "$retval" != "0" ]] ; then text="Failed $info with exit code $retval"
+  else text="Finished $info successfully"
   fi
   echo "$subject_id: $text"
 }
@@ -415,8 +412,10 @@ function prepend ()
 {
   #param1 string to prepend to every line
   # https://serverfault.com/questions/72744/command-to-prepend-string-to-each-line
-  while read -r line;
-  do
-    echo "${1}${line}"
-  done
+  while read -r line ; do echo "${1}${line}" ; done
+}
+function append ()
+{
+  #param1 string to append to every line
+  while read -r line ; do echo "${line}$1" ; done
 }


### PR DESCRIPTION
Add parallelization features to brun_fastsurfer.sh

brun_fastsurfer can now schedule segmentation for multiple GPUs, and parallel segmentation.
It is much cleaner now and ready to be extended for longitudinal processing as well.

This issue also fixed the one case failing terminates the entire brun processing run and adds `--threads surf=n` and  `--threads seg=n` options for run_fastsurfer to enable better control over threads.

Also fixes #620