### PR TITLE
Extension: Enable seg=N and surf=N in long_fastsurfer 

### DIFF
--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -48,7 +48,6 @@ fi
 
 
 # Paths
-fastsurfercnndir="$FASTSURFER_HOME/FastSurferCNN"
 reconsurfdir="$FASTSURFER_HOME/recon_surf"
 
 
@@ -58,7 +57,7 @@ sd="$SUBJECTS_DIR"
 tpids=()
 t1s=()
 parallel=0
-log=""
+LF=""
 brun_flags=()
 python="python3.10 -s" # avoid user-directory package inclusion
 
@@ -271,6 +270,9 @@ cmda=("$FASTSURFER_HOME/run_fastsurfer.sh"
 if [[ "$parallel" == "1" ]] ; then
   base_surf_cmdf="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf"
   base_surf_cmdf_log="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf.log"
+  log "Starting base surface reconstruction, logs temporarily diverted to $base_surf_cmdf_log..."
+  log "======================================="
+
   {
     echo "Log file of base surface pipeline"
     date
@@ -298,6 +300,9 @@ cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd 
 if [[ "$parallel" == "1" ]] ; then
   long_seg_cmdf="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf"
   long_seg_cmdf_log="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf.log"
+  log "Starting longitudinal segmentations, logs temporarily diverted to $long_seg_cmdf_log..."
+  log "======================================="
+
   {
     echo "Log file of longitudinal segmentation pipeline"
     date
@@ -325,8 +330,11 @@ if [[ "$parallel" == "1" ]] ; then
 
   # Append the base surface and longitudinal segmentation logs, exit if either failed
   what_failed=()
+  log "======================================="
+  log "Waiting for base surface reconstruction and longitudinal segmentations to finish..."
   wait "$base_surf_pid"
   success1=$?
+  log "done."
   log "Base Surface pipeline Log:"
   log "======================================="
   tee -a "$LF" < "$base_surf_cmdf_log"

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -342,7 +342,7 @@ if [[ "$parallel" == "1" ]] ; then
     log "Base Surface pipeline terminated with error: $success1"
     what_failed+=("Base Surface Pipeline")
   else
-    log "Base Surface pipeline finished successful!"
+    log "Base Surface pipeline finished successfully!"
     rm "$base_surf_cmdf_log" # the content of this file is transferred to LF
   fi
   log "======================================="
@@ -355,7 +355,7 @@ if [[ "$parallel" == "1" ]] ; then
     log "Longitudinal Segmentation pipeline terminated with error: $success2"
     what_failed+=("Longitudinal Segmentation Pipeline")
   else
-    log "Longitudinal Segmentation pipeline finished successful!"
+    log "Longitudinal Segmentation pipeline finished successfully!"
     rm "$long_seg_cmdf_log" # the content of this file is transferred to LF
   fi
   log "======================================="

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -260,6 +260,9 @@ fi
 LF="$SUBJECTS_DIR/$tid/scripts/long_prepare_template.log"
 mkdir -p "$(dirname "$LF")"
 
+export PYTHONPATH
+PYTHONPATH="$FASTSURFER_HOME$([[ -n "$FASTSURFER_HOME" ]] && echo ":$PYTHONPATH")"
+
 
 if [[ -f "$LF" ]]; then log_existed="true"
 else log_existed="false"
@@ -272,6 +275,8 @@ then
 fi
 
 VERSION=$($python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_args[@]}")
+code="$?"
+if [[ "$code" != 0 ]] ; then echo "ERROR: Getting the version failed (code=$code), terminating..." ; exit 1 ; fi
 echo "Version: $VERSION" | tee -a "$LF"
 echo "Log file for long_prepare_template" >> "$LF"
 {

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -177,8 +177,9 @@ case $key in
     ;;
   --sd) sd="$1" ; export SUBJECTS_DIR="$1" ; shift  ;;
   # these flags are passed through to run_prediction.py
-  --vox_size|--device|--viewagg_device|--conform_to_1mm_threshold|--threads)
+  --vox_size|--device|--viewagg_device|--conform_to_1mm_threshold)
     run_pred_flags+=("$key" "$1") ; shift ;;
+  --threads) if [[ "$1" =~ ^(seg=)?([0-9]+) ]] ; then run_pred_flags+=("$key" "${BASH_REMATCH[2]}") ; fi ; shift ;;
   --batch) run_pred_flags+=("--batch_size" "$1") ; shift ;;
   # these known arguments get ignored
   --aseg_name|--conformed_name|--asegdkt_segfile|--brainmask_name|--seg_log|--qc_log) shift ;;

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -517,12 +517,8 @@ done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 # make sure FastSurfer is in the PYTHONPATH
-if [[ "$PYTHONPATH" == "" ]]
-then
-  export PYTHONPATH="$FASTSURFER_HOME"
-else
-  export PYTHONPATH="$FASTSURFER_HOME:$PYTHONPATH"
-fi
+export PYTHONPATH
+PYTHONPATH="$FASTSURFER_HOME$([[ -n "$PYTHONPATH" ]] && echo ":$PYTHONPATH")"
 
 ########################################## VERSION AND QUIT HERE ########################################
 # make sure the python  executable is valid and found


### PR DESCRIPTION
Make long_fastsurfer.sh support `--threads seg=X` and `--threads surf=X` notation bx fixing/adding support to `long_prepare_template.sh`

Add messages to parallel longitudinal processing to make waiting more clear Fix some variables in `long_fastsurfer.sh`

These flags were introduced in #640 

This is tested and works as expected.