### PR TITLE
Unify and change of segmentation/surface syntax

### DIFF
--- a/doc/overview/FLAGS.md
+++ b/doc/overview/FLAGS.md
@@ -44,7 +44,7 @@ In the following, we give an overview of the most important options. You can vie
 * `--no_surfreg`: Skip the surface registration (which creates `sphere.reg`) to safe time. Note, `sphere.reg` will be needed for any cross-subject statistical analysis of thickness maps, so do not use this option if you plan to perform cross-subject analysis. 
 
 ## Some other flags (optional)
-* `--threads`: Target number of threads for all modules (segmentation, surface pipeline), `1` (default) forces FastSurfer to only really use one core. Note, that the default value may change in the future for better performance on multi-core architectures.
+* `--threads`, `--threads_seg` and `--threads_surf`: Target number of threads for all modules, segmentation, and surface pipeline. The default (`1`) tells FastSurfer to only use one core. Note, that the default value may change in the future for better performance on multi-core architectures.
 * `--vox_size`: Forces processing at a specific voxel size. If a number between 0.7 and 1 is specified (below is experimental) the T1w image is conformed to that isotropic voxel size and processed. 
   If "min" is specified (default), the voxel size is read from the size of the minimal voxel size (smallest per-direction voxel size) in the T1w image:
   If the minimal voxel size is bigger than 0.98mm, the image is conformed to 1mm isometric.

--- a/doc/scripts/BATCH.md
+++ b/doc/scripts/BATCH.md
@@ -65,13 +65,13 @@ pipelines, which is useful for optimized GPU loading. Multiple cases may be proc
 
 ```bash
 $FASTSURFER_HOME/brun_fastsurfer.sh --device cuda:0-1 --parallel_subjects seg=2 --parallel_subjects surf=max \
-  --threads seg=8 --threads surf=2 --parallel
+  --threads_seg 8 --threads_surf 2 --parallel
 ```
 will start 2 parallel segmentations (`--parallel_subjects seg=2`) using GPU 0 for case 1 and GPU for case 2 
 (`--device cuda:0-1` -- same as `--device cuda:0,1`). After one of these segmentations 1 is finished, segmentation of 
 case 3 will start on that same device as well as the surface reconstruction (without putting a limit on parallel 
 surface reconstructions, `--parallel_subjects surf=max`). Each segmentation process will aim to use 8 threads/cores
-(`--threads seg=8`) and each surface reconstruction process will aim to use 2 threads (`--threads surf=2`) with both
+(`--threads_seg 8`) and each surface reconstruction process will aim to use 2 threads (`--threads_surf 2`) with both
 hemispheres processed in parallel (`--parallel`).
 
 Note, if your GPU has sufficient [video memory](../overview/intro.rst#system-requirements), two parallel segmentations

--- a/doc/scripts/BATCH.md
+++ b/doc/scripts/BATCH.md
@@ -34,12 +34,12 @@ Parallelization with `brun_fastsurfer.sh`
 -----------------------------------------
 
 `brun_fastsurfer.sh` has powerful builtin parallel processing capabilities. These are hidden underneath the 
-`--parallel_subjects [seg=|surf=][<n>]` and the `--device <device>` as well as `--viewagg_device <device>` flags.
+`--parallel_subjects* <n>|max` and the `--device <device>` as well as `--viewagg_device <device>` flags.
 One of the core properties of FastSurfer is the split into the segmentation (which uses Deep Learning and therefore 
 benefits from GPUs) and the surface pipeline (which does not benefit from GPUs). For ideal batch processing, we want 
 different resource scheduling.
 
-`--parallel_subjects` allows three parallel batch processing modes: serial, single parallel pipeline and dual parallel
+`--parallel_subjects*` allows three parallel batch processing modes: serial, single parallel pipeline and dual parallel
 pipeline. 
 
 ### Serial processing (default)
@@ -64,19 +64,19 @@ This is ideal for GPU-based processing for segmentation. It will process segment
 pipelines, which is useful for optimized GPU loading. Multiple cases may be processed at the same time.
 
 ```bash
-$FASTSURFER_HOME/brun_fastsurfer.sh --device cuda:0-1 --parallel_subjects seg=2 --parallel_subjects surf=max \
+$FASTSURFER_HOME/brun_fastsurfer.sh --device cuda:0-1 --parallel_subjects_seg 2 --parallel_subjects_surf max \
   --threads_seg 8 --threads_surf 2 --parallel
 ```
-will start 2 parallel segmentations (`--parallel_subjects seg=2`) using GPU 0 for case 1 and GPU for case 2 
-(`--device cuda:0-1` -- same as `--device cuda:0,1`). After one of these segmentations 1 is finished, segmentation of 
+will start 2 parallel segmentations (`--parallel_subjects_seg 2`) using GPU 0 for case 1 and GPU 1 for case 2 
+(`--device cuda:0-1` -- same as `--device cuda:0,1`). After one of these segmentations is finished, the segmentation of 
 case 3 will start on that same device as well as the surface reconstruction (without putting a limit on parallel 
-surface reconstructions, `--parallel_subjects surf=max`). Each segmentation process will aim to use 8 threads/cores
+surface reconstructions, `--parallel_subjects_surf max`). Each segmentation process will aim to use 8 threads/cores
 (`--threads_seg 8`) and each surface reconstruction process will aim to use 2 threads (`--threads_surf 2`) with both
 hemispheres processed in parallel (`--parallel`).
 
 Note, if your GPU has sufficient [video memory](../overview/intro.rst#system-requirements), two parallel segmentations
 can run on the same GPU, but the script cannot schedule more than one process per GPU for multiple GPUs, i.e.
-`--device cuda:0,1 --parallel_subjects seg=4` is not supported.
+`--device cuda:0,1 --parallel_subjects_seg 4` is not supported.
 
 Questions
 ---------

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -161,25 +161,12 @@ key=$(echo "$arg" | tr '[:upper:]' '[:lower:]')
 shift # past argument
 case $key in
   --tid) tid="$1" ; shift ;;
-  --tpids)
-    while [[ $# -gt 0 ]] && [[ $1 != -* ]] 
-    do
-      tpids+=("$1")
-      shift  # past value
-    done
-    ;;
-  --t1s)
-    while [[ $# -gt 0 ]] && [[ $1 != -* ]] 
-    do
-      t1s+=("$1")
-      shift  # past value
-    done
-    ;;
+  --tpids) while [[ $# -gt 0 ]] && [[ $1 != -* ]] ; do tpids+=("$1") ; shift ; done ;;
+  --t1s) while [[ $# -gt 0 ]] && [[ $1 != -* ]] ; do t1s+=("$1") ; shift ; done ;;
   --sd) sd="$1" ; export SUBJECTS_DIR="$1" ; shift  ;;
   # these flags are passed through to run_prediction.py
-  --vox_size|--device|--viewagg_device|--conform_to_1mm_threshold)
-    run_pred_flags+=("$key" "$1") ; shift ;;
-  --threads) if [[ "$1" =~ ^(seg=)?([0-9]+) ]] ; then run_pred_flags+=("$key" "${BASH_REMATCH[2]}") ; fi ; shift ;;
+  --vox_size|--device|--viewagg_device|--conform_to_1mm_threshold) run_pred_flags+=("$key" "$1") ; shift ;;
+  --threads|--threads_seg) run_pred_flags+=("--threads" "$1") ; shift ;;
   --batch) run_pred_flags+=("--batch_size" "$1") ; shift ;;
   # these known arguments get ignored
   --aseg_name|--conformed_name|--asegdkt_segfile|--brainmask_name|--seg_log|--qc_log) shift ;;

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -94,14 +94,14 @@ Data- and subject-related options:
   Note: files will be copied here only after all jobs have finished, so most IO happens on
   a work directory, which can use IO-optimized cluster storage (see --work).
 --work: directory with fast filesystem on cluster
-  (default: \$HPCWORK/fastsurfer-processing/$(date +%Y%m%d-%H%M%S))
+  (default: \$HPCWORK/fastsurfer-processing/<date as YYMMDD-HHMMSS>)
   NOTE: THIS SCRIPT considers this directory to be owned by this script and job!
   No modifications should be made to the directory after the job is started until it is
   finished (if the job fails, cleanup of this directory may be necessary) and it should be
   empty!
 --data: (root) directory to search in for t1 files (default: current work directory).
 --pattern: glob string to find image files in 'data directory' (default: *.{nii,nii.gz,mgz}),
-   for example --data /data/ --pattern \*/\*/mri/t1.nii.gz
+   for example '--data /data/ --pattern "*/*/mri/t1.nii.gz"'
    will find all images of format /data/<somefolder>/<otherfolder>/mri/t1.nii.gz
 --subject_list: alternative way to define cases to process, files are of format:
   subject_id1=/path/to/t1.mgz
@@ -268,7 +268,7 @@ case $key in
   --time_seg) timelimit_seg=$1 ; shift ;;
   --time_surf) timelimit_surf=$1 ; shift ;;
   --email) email="$1" ; shift ;;
-  --dry) submit_jobs="false" ;;
+  --dry|--dry_run) submit_jobs="false" ;;
   --debug) debug="true" ;;
   --slurm_jobarray) jobarray=$1 ; shift ;;
   --help) usage ; exit ;;
@@ -296,7 +296,7 @@ tmpLF=$(mktemp)
 LF=$tmpLF
 
 function log() { echo "$@" | tee -a "$LF" ; }
-function logf() { printf "%s" "$@" | tee -a "$LF" ; }
+function logf() { printf "$@" | tee -a "$LF" ; }
 
 log "Log of FastSurfer SLURM script"
 log "$(date -R)"
@@ -342,7 +342,7 @@ then
 else
   # all debug messages go into logfile no matter what, but here, not to the console
   function debug () { echo "$@" >> "$LF" ;  }
-  function debugf () { printf "%s" "$@" >> "$LF" ;  }
+  function debugf () { printf "$@" >> "$LF" ;  }
   if [[ "$submit_jobs" == "false" ]]
   then
     log "dry run, no jobs or operations are performed"
@@ -377,16 +377,18 @@ debug "work dir: $hpc_work"
 debug ""
 debug "FastSurfer parameters:"
 debug "singularity image: $singularity_image"
-debug "FreeSurfer license: $fs_license"
+debug "FreeSurfer license: ${fs_license-not set}"
 if [[ "$seg_only" == "true" ]]; then debug "--seg_only"; fi
 if [[ "$surf_only" == "true" ]]; then debug "--surf_only"; fi
 if [[ "$do_parallel" == "true" ]]; then debug "--parallel"; fi
+newline=""
 for p in "${POSITIONAL_FASTSURFER[@]}"
 do
-  if [[ "$p" == --* ]]; then debugf "\n%s" "$p";
-  else debugf " %s" "$p";
+  if [[ "$p" == --* ]]; then debugf "$newline%s" "$p" ; newline="\n"
+  else debugf " %s" "$p" ;
   fi
 done
+debugf "$newline\n"
 shell=$(stat -c %N "/proc/$$/exe" | cut -d">" -f2 | tail -c +3 | head -c -2)
 debug "Running in shell $shell: $($shell --version 2>/dev/null | head -n 1)"
 debug ""
@@ -561,7 +563,8 @@ then
   {
     echo "#!/bin/bash"
     echo "module load singularity"
-    echo "singularity exec --nv -B \"$hpc_work:/data,$in_dir:/source:ro\" --no-home --env TQDM_DISABLE=1 \\"
+    echo "singularity exec --nv -B \"$hpc_work:/data,$in_dir:/source:ro\" --no-mount home,cwd\\"
+    echo "  --cleanenv --env TQDM_DISABLE=1 \\"
     if [[ -n "$extra_singularity_options" ]] || [[ -n "$extra_singularity_options_seg" ]]; then
       echo "  $extra_singularity_options $extra_singularity_options_seg\\"
     fi


### PR DESCRIPTION
Previous commits and versions have often used a --flag (seg|surf)=value syntax. This Syntax is replaced by --flag_(seg|surf) value. This specifically affects brun_fastsurfer.sh and srun_fastsurfer.sh, which had these Syntaxes established.

This PR still needs extensive testing.

Also, not all doc entries are updated (specifically `doc/scripts/BATCH.md` and `doc/scripts/SLURM.md`).