### PR TITLE
Update the way parallelization is configured

### DIFF
--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -79,7 +79,7 @@ runs:
         echo "::group::FastSurfer Surface reconstruction"
         docker run --rm -t -v "$DATA_DIR:/data" -u $(id -u):$(id -g) --env TQDM_DISABLE=1 "$IMAGE_NAME" \
           --fs_license /data/.fs_license --t1 /data/T1${{ inputs.file-extension }} --sid "${{ inputs.subject-id }}" \
-          --sd /data --parallel --threads 1 --surf_only ${{ inputs.extra-args }}
+          --sd /data --threads $(nproc) --surf_only ${{ inputs.extra-args }}
         echo "::endgroup::"
     - name: Create archive of Processed subject-data
       shell: bash

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -27,8 +27,7 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
-                      --sid subjectX --sd /output \
-                      --parallel
+                      --sid subjectX --sd /output
 ```
 
 #### Docker Flags
@@ -46,7 +45,6 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 * The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
-* The `--parallel` activates processing left and right hemisphere in parallel
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments. 
 
@@ -105,8 +103,7 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --rm --user $(id -u):$(id -g) my_fastsurfer:cuda \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
-                      --sid subjectX --sd /output \
-                      --parallel
+                      --sid subjectX --sd /output
 ```
 
 
@@ -128,8 +125,7 @@ docker run -v /home/user/my_mri_data:/data \
            --fs_license /fs_license/license.txt \
            --t1 /data/subjectX/t1-weighed.nii.gz \
            --device cpu \
-           --sid subjectX --sd /output \
-           --parallel
+           --sid subjectX --sd /output
 ```
 
 As you can see, only the tag of the image is changed from gpu to cpu and the standard docker is used (no --gpus defined). In addition, the `--device cpu` flag is passed to explicitly turn on CPU usage inside FastSurferCNN.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -27,7 +27,8 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
-                      --sid subjectX --sd /output
+                      --sid subjectX --sd /output \
+                      --threads 4 --3T # and more flags
 ```
 
 #### Docker Flags
@@ -45,6 +46,7 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 * The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
+* [more flags](../doc/overview/FLAGS.md#fastsurfer-flags)
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments. 
 
@@ -95,6 +97,8 @@ PYTHONPATH=<FastSurferRoot>
 python build.py --device cuda --tag my_fastsurfer:cuda
 ```
 
+The build script allows more specific options, that specify different CUDA options as well (see `build.py --help`).
+
 For running the analysis, the command is the same as above for the prebuild option:
 ```bash
 docker run --gpus all -v /home/user/my_mri_data:/data \
@@ -116,7 +120,9 @@ PYTHONPATH=<FastSurferRoot>
 python build.py --device cpu --tag my_fastsurfer:cpu
 ```
 
-For running the analysis, the command is basically the same as above for the GPU option:
+As you can see, only the `--device` to the build command is changed from `cuda` to `cpu`. 
+
+For running the analysis, the command is basically the same as above, except for removing the `--gpus all` GPU option:
 ```bash
 docker run -v /home/user/my_mri_data:/data \
            -v /home/user/my_fastsurfer_analysis:/output \
@@ -124,17 +130,15 @@ docker run -v /home/user/my_mri_data:/data \
            --rm --user $(id -u):$(id -g) my_fastsurfer:cpu \
            --fs_license /fs_license/license.txt \
            --t1 /data/subjectX/t1-weighed.nii.gz \
-           --device cpu \
            --sid subjectX --sd /output
 ```
 
-As you can see, only the tag of the image is changed from gpu to cpu and the standard docker is used (no --gpus defined). In addition, the `--device cpu` flag is passed to explicitly turn on CPU usage inside FastSurferCNN.
-
+FastSurfer will automatically detect, that no GPU is available and use the CPU.
 
 ### Example 3: Experimental Build for AMD GPUs
 
 Here we build an experimental image to test performance when running on AMD GPUs. Note that you need a supported OS and Kernel version and supported GPU for the RocM to work correctly. You need to install the Kernel drivers into 
-your host machine kernel (amdgpu-install --usecase=dkms) for the amd docker to work. For this follow:
+your host machine kernel (`amdgpu-install --usecase=dkms`) for the amd docker to work. For this follow:
 https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html#rocm-install-quick, https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/amdgpu-install.html#amdgpu-install-dkms and https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
 
 ```bash

--- a/Singularity/README.md
+++ b/Singularity/README.md
@@ -31,7 +31,7 @@ To run FastSurfer on a given subject using the Singularity image with GPU access
 
 ```bash
 singularity exec --nv \
-                 --no-home \
+                 --no-mount home,cwd -e\
                  -B /home/user/my_mri_data:/data \
                  -B /home/user/my_fastsurfer_analysis:/output \
                  -B /home/user/my_fs_license_dir:/fs \
@@ -40,11 +40,12 @@ singularity exec --nv \
                  --fs_license /fs/license.txt \
                  --t1 /data/subjectX/orig.mgz \
                  --sid subjectX --sd /output \
-                 --parallel --3T
+                 --3T
 ```
 ### Singularity Flags
 * `--nv`: This flag is used to access GPU resources. It should be excluded if you intend to use the CPU version of FastSurfer
-* `--no-home`: This flag tells singularity to not mount the home directory inside the singularity image (see [Best Practice](#mounting-home))
+* `-e`: Do not transfer the environment variables from the host to the container.
+* `--no-mount home,cwd`: This flag tells singularity to not mount the home directory or the current working directory inside the singularity image (see [Best Practice](#mounting-home))
 * `-B`: These commands mount your data, output, and directory with the FreeSurfer license file into the Singularity container. Inside the container these are visible under the name following the colon (in this case /data, /output, and /fs). 
 
 ### FastSurfer Flags
@@ -52,7 +53,6 @@ singularity exec --nv \
 * The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
-* The `--parallel` activates processing left and right hemisphere in parallel
 * The `--3T` switches to the 3T atlas instead of the 1.5T atlas for Talairach registration. 
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-B` arguments. 
@@ -75,7 +75,7 @@ singularity exec --no-home \
                   --fs_license /fs/license.txt \
                   --t1 /data/subjectX/orig.mgz \
                   --sid subjectX --sd /output \
-                  --parallel --3T
+                  --3T
 ```
 
 ## Singularity Best Practice
@@ -85,5 +85,5 @@ Do not mount the user home directory into the singularity container as the home 
   
 Why? If the user inside the singularity container has access to a user directory, settings from that directory might bleed into the FastSurfer pipeline. For example, before FastSurfer 2.2 python packages installed in the user directory would replace those installed inside the image potentially causing incompatibilities. Since FastSurfer 2.2, `singularity exec ... --version +pip` outputs the FastSurfer version including a full list of python packages. 
 
-How? Singularity automatically mounts the home directory by default. To avoid this, specify `--no-home`. 
+How? Singularity automatically mounts the home directory by default. To avoid this, specify `--no-mount home,cwd`. 
 

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -70,7 +70,7 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
     --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
     --fs_license $FREESURFER_HOME/.license \
-    --edits # more flags as needed, e.g. --parallel --3T --threads 4
+    --edits # more flags as needed, e.g. --3T --threads 4
 ```
 
 Note, a re-run of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited.
@@ -83,7 +83,7 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
     --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
     --fs_license $FREESURFER_HOME/.license \
-    --edits --surf_only # more flags as needed, e.g. --parallel --3T --threads 4
+    --edits --surf_only # more flags as needed, e.g. --3T --threads 4
 ```
 
 ## Bias field correction
@@ -118,7 +118,7 @@ For example:
   $FASTSURFER_HOME/run_fastsurfer.sh \
       --sd $SUBJECTS_DIR --sid case_bias_corrected \
       --t1 $SUBJECTS_DIR/case_bias_only/mri/orig_nu.mgz \
-      --fs_license $FREESURFER_HOME/.license # more flags as needed, e.g. --parallel --3T --threads 4
+      --fs_license $FREESURFER_HOME/.license # more flags as needed, e.g. --3T --threads 4
    ```
 - Step 3: Compare and check if bias field correction fixed the issues:
   ```bash

--- a/doc/overview/EXAMPLES.md
+++ b/doc/overview/EXAMPLES.md
@@ -17,7 +17,7 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
                       --sid subjectX --sd /output \
-                      --parallel --3T
+                      --3T
 ```
 
 Docker Flags:
@@ -31,7 +31,6 @@ FastSurfer Flag:
 * The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
-* The `--parallel` activates processing left and right hemisphere in parallel
 * The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon). 
@@ -60,7 +59,7 @@ singularity exec --nv \
                  --fs_license /fs_license/license.txt \
                  --t1 /data/subjectX/t1-weighted.nii.gz \
                  --sid subjectX --sd /output \
-                 --parallel --3T
+                 --3T
 ```
 
 ### Singularity Flags
@@ -73,7 +72,6 @@ singularity exec --nv \
 * The `--t1` points to the t1-weighted MRI image to analyse (full path, with mounted name inside docker: /home/user/my_mri_data => /data)
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
-* The `--parallel` activates processing left and right hemisphere in parallel
 * The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon).
@@ -106,10 +104,10 @@ fastsurferdir=/home/user/my_fastsurfer_analysis
 # Run FastSurfer
 ./run_fastsurfer.sh --t1 $datadir/subjectX/t1-weighted-nii.gz \
                     --sid subjectX --sd $fastsurferdir \
-                    --parallel --threads 4 --3T
+                    --threads 4 --3T
 ```
 
-The output will be stored in the $fastsurferdir (including the aparc.DKTatlas+aseg.deep.mgz segmentation under $fastsurferdir/subjectX/mri (default location)). Processing of the hemispheres will be run in parallel (--parallel flag) to significantly speed-up surface creation. Omit this flag to run the processing sequentially, e.g. if you want to save resources on a compute cluster.
+The output will be stored in the $fastsurferdir (including the `aparc.DKTatlas+aseg.deep.mgz` segmentation under `$fastsurferdir/subjectX/mri` (default location)). Processing of the hemispheres will be run in parallel (--threads 4 >= 2) to significantly speed-up surface creation. Omit this flag to run the processing sequentially, e.g. if you want to save resources on a compute cluster.
 
 
 ## Example 4: FastSurfer on multiple subjects
@@ -136,7 +134,7 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
                       --sd /output --subject_list /data/subjects_list.txt \
-                      --parallel --3T
+                      --3T
 ```
 ### Singularity
 ```bash
@@ -150,7 +148,7 @@ singularity exec --nv \
                  --fs_license /fs_license/license.txt \
                  --sd /output \
                  --subject_list /data/subjects_list.txt \
-                 --parallel --3T
+                 --3T
 ```
 ### Native
 ```bash
@@ -164,7 +162,7 @@ fastsurferdir=/home/user/my_fastsurfer_analysis
 # Run FastSurfer
 ./brun_fastsurfer.sh --subject_list $datadir/subjects_list.txt \
                      --sd $fastsurferdir \
-                     --parallel --threads 4 --3T
+                     --threads 4 --3T
 ```
 
 ### Flags

--- a/doc/overview/EXAMPLES.md
+++ b/doc/overview/EXAMPLES.md
@@ -1,7 +1,7 @@
 # Examples
 
 ## Example 1: FastSurfer Docker
-After pulling one of our images from Dockerhub, you do not need to have a separate installation of FreeSurfer on your computer (it is already included in the Docker image). However, if you want to run ___more than just the segmentation CNN___, you need to register at the FreeSurfer website (https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license for free. The directory containing the license needs to be mounted and passed to the script via the `--fs_license` flag. Basically for Docker (as for Singularity below) you are starting a container image (with the run command) and pass several parameters for that, e.g. if GPUs will be used and mounting (linking) the input and output directories to the inside of the container image. In the second half of that call you pass parameters to our run_fastsurfer.sh script that runs inside the container (e.g. where to find the FreeSurfer license file, and the input data and other flags). 
+After pulling one of our images from Dockerhub, you do not need to have a separate installation of FreeSurfer on your computer (it is already included in the Docker image). However, if you want to run ___more than just the segmentation CNN___, you need to [register at the FreeSurfer website](https://surfer.nmr.mgh.harvard.edu/registration.html) to acquire a valid license for free. The directory containing the license needs to be mounted and passed to the script via the `--fs_license` flag. Basically for Docker (as for Singularity below) you are starting a container image (with the run command) and pass several parameters for that, e.g. if GPUs will be used and mounting (linking) the input and output directories to the inside of the container image. In the second half of that call you pass parameters to our `run_fastsurfer.sh` script that runs inside the container (e.g. where to find the FreeSurfer license file, and the input data and other flags). 
 
 To run FastSurfer on a given subject using the provided GPU-Docker, execute the following command:
 
@@ -17,7 +17,8 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --fs_license /fs_license/license.txt \
                       --t1 /data/subjectX/t1-weighted.nii.gz \
                       --sid subjectX --sd /output \
-                      --3T
+                      --3T \
+                      --threads 4
 ```
 
 Docker Flags:
@@ -32,6 +33,7 @@ FastSurfer Flag:
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
 * The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
+* The `--threads` tells FastSurfer to use that many threads in segmentation and surface reconstruction. `max` will auto-detect the number of threads available, i.e. `16` on an 8-core system with hypterthreading. If the number of threads is greater than 1, FastSurfer will process the left and right hemispheres in parallel.  
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon). 
 
@@ -59,7 +61,8 @@ singularity exec --nv \
                  --fs_license /fs_license/license.txt \
                  --t1 /data/subjectX/t1-weighted.nii.gz \
                  --sid subjectX --sd /output \
-                 --3T
+                 --3T \
+                 --threads 4
 ```
 
 ### Singularity Flags
@@ -73,6 +76,7 @@ singularity exec --nv \
 * The `--sid` is the subject ID name (output folder name)
 * The `--sd` points to the output directory (its mounted name inside docker: /home/user/my_fastsurfer_analysis => /output)
 * The `--3T` changes the atlas for registration to the 3T atlas for better Talairach transforms and ICV estimates (eTIV)
+* The `--threads` tells FastSurfer to use that many threads in segmentation and surface reconstruction. `max` will auto-detect the number of threads available, i.e. `16` on an 8-core system with hypterthreading. If the number of threads is greater than 1, FastSurfer will process the left and right hemispheres in parallel.  
 
 Note, that the paths following `--fs_license`, `--t1`, and `--sd` are __inside__ the container, not global paths on your system, so they should point to the places where you mapped these paths above with the `-v` arguments (part after colon).
 
@@ -134,7 +138,8 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
                       --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
                       --fs_license /fs_license/license.txt \
                       --sd /output --subject_list /data/subjects_list.txt \
-                      --3T
+                      --3T \
+                      --threads 4
 ```
 ### Singularity
 ```bash
@@ -148,7 +153,8 @@ singularity exec --nv \
                  --fs_license /fs_license/license.txt \
                  --sd /output \
                  --subject_list /data/subjects_list.txt \
-                 --3T
+                 --3T \
+                 --threads 4
 ```
 ### Native
 ```bash

--- a/doc/overview/FLAGS.md
+++ b/doc/overview/FLAGS.md
@@ -39,12 +39,11 @@ In the following, we give an overview of the most important options. You can vie
 * `--fstess`: Use mri_tesselate instead of marching cube (default) for surface creation (not recommended, but more similar to FreeSurfer)
 * `--fsqsphere`: Use FreeSurfer default instead of novel spectral spherical projection for qsphere (also not recommended)
 * `--fsaparc`: Use FS aparc segmentations in addition to DL prediction (slower in this case and usually the mapped ones from the DL prediction are fine)
-* `--parallel`: Run both hemispheres in parallel
 * `--no_fs_T1`: Skip generation of `T1.mgz` (normalized `nu.mgz` included in standard FreeSurfer output) and create `brainmask.mgz` directly from `norm.mgz` instead. Saves 1:30 min.
 * `--no_surfreg`: Skip the surface registration (which creates `sphere.reg`) to safe time. Note, `sphere.reg` will be needed for any cross-subject statistical analysis of thickness maps, so do not use this option if you plan to perform cross-subject analysis. 
 
 ## Some other flags (optional)
-* `--threads`, `--threads_seg` and `--threads_surf`: Target number of threads for all modules, segmentation, and surface pipeline. The default (`1`) tells FastSurfer to only use one core. Note, that the default value may change in the future for better performance on multi-core architectures.
+* `--threads`, `--threads_seg` and `--threads_surf`: Target number of threads for all modules, segmentation, and surface pipeline. The default (`1`) tells FastSurfer to only use one core. Note, that the default value may change in the future for better performance on multi-core architectures. If threads for surface reconstruction is greater than 1, both hemispheres are processed in parallel.
 * `--vox_size`: Forces processing at a specific voxel size. If a number between 0.7 and 1 is specified (below is experimental) the T1w image is conformed to that isotropic voxel size and processed. 
   If "min" is specified (default), the voxel size is read from the size of the minimal voxel size (smallest per-direction voxel size) in the T1w image:
   If the minimal voxel size is bigger than 0.98mm, the image is conformed to 1mm isometric.

--- a/doc/overview/FLAGS.md
+++ b/doc/overview/FLAGS.md
@@ -9,7 +9,7 @@ The `*fastsurfer-flags*` will usually at least include the subject directory (`-
 Additionally, you can use `--seg_only` or `--surf_only` to only run a part of the pipeline or `--no_biasfield`, `--no_cereb` and `--no_asegdkt` to switch off individual segmentation modules.
 Here, we have also added the `--3T` flag, which tells FastSurfer to register against the 3T atlas which is only relevant for the ICV estimation (eTIV).
 
-In the following, we give an overview of the most important options. You can view a full list of options with 
+In the following, we give an overview of the most important options. You can view a [full list of options](FLAGS.md#full-list-of-flags) with 
 
 ```bash
 ./run_fastsurfer.sh --help
@@ -43,7 +43,7 @@ In the following, we give an overview of the most important options. You can vie
 * `--no_surfreg`: Skip the surface registration (which creates `sphere.reg`) to safe time. Note, `sphere.reg` will be needed for any cross-subject statistical analysis of thickness maps, so do not use this option if you plan to perform cross-subject analysis. 
 
 ## Some other flags (optional)
-* `--threads`, `--threads_seg` and `--threads_surf`: Target number of threads for all modules, segmentation, and surface pipeline. The default (`1`) tells FastSurfer to only use one core. Note, that the default value may change in the future for better performance on multi-core architectures. If threads for surface reconstruction is greater than 1, both hemispheres are processed in parallel.
+* `--threads`, `--threads_seg` and `--threads_surf`: Target number of threads for all modules, segmentation, and surface pipeline. The default (`1`) tells FastSurfer to only use one core. Note, that the default value may change in the future for better performance on multi-core architectures. If threads for surface reconstruction is greater than 1, both hemispheres are processed in parallel with half the threads allocated to each hemisphere.
 * `--vox_size`: Forces processing at a specific voxel size. If a number between 0.7 and 1 is specified (below is experimental) the T1w image is conformed to that isotropic voxel size and processed. 
   If "min" is specified (default), the voxel size is read from the size of the minimal voxel size (smallest per-direction voxel size) in the T1w image:
   If the minimal voxel size is bigger than 0.98mm, the image is conformed to 1mm isometric.
@@ -52,3 +52,8 @@ In the following, we give an overview of the most important options. You can vie
 * `--py`: Command for python, used in both pipelines. Default: python3.10
 * `--conformed_name`: Name of the file in which the conformed input image will be saved. Default location: \$SUBJECTS_DIR/\$sid/mri/orig.mgz
 * `-h`, `--help`: Prints help text
+
+## Full list of flags
+```{command-output} ./run_fastsurfer.sh --help
+:cwd: /../
+```

--- a/doc/overview/INSTALL.md
+++ b/doc/overview/INSTALL.md
@@ -251,8 +251,7 @@ docker run -v C:/Users/user/my_mri_data:/data \
            --fs_license /fs_license/license.txt \
            --t1 /data/subjectX/orig.mgz \
            --device cpu \
-           --sid subjectX --sd /output \
-           --parallel
+           --sid subjectX --sd /output
 ```
 Note, the [system requirements](https://github.com/Deep-MI/FastSurfer#system-requirements) of at least 8GB of RAM for the CPU version. If the process fails, check if your [WSL2 distribution has enough memory reserved](https://www.aleksandrhovhannisyan.com/blog/limiting-memory-usage-in-wsl-2/).
 
@@ -283,8 +282,7 @@ docker run --gpus all
            --rm --user $(id -u):$(id -g) deepmi/fastsurfer:latest \
            --fs_license /fs_license/license.txt \
            --t1 /data/subjectX/orig.mgz \
-           --sid subjectX --sd /output \
-           --parallel
+           --sid subjectX --sd /output
 ```
 
 Note the [system requirements](https://github.com/Deep-MI/FastSurfer#system-requirements) of at least 8 GB system memory and 2 GB graphics memory for the GPU version. If the process fails, check if your [WSL2 distribution has enough memory reserved](https://www.aleksandrhovhannisyan.com/blog/limiting-memory-usage-in-wsl-2/).

--- a/doc/overview/LONG.md
+++ b/doc/overview/LONG.md
@@ -57,7 +57,7 @@ singularity exec --nv \
                  --t1s <T1_1> <T1_2> ... \
                  --tpids <tID1> <tID2> ...
                  --sd /output \
-                 --parallel --3T
+                 --3T
 ```
 
 ## Behind the Scenes:
@@ -74,9 +74,11 @@ singularity exec --nv \
 2. Next, the template image will be segmented via a call to `run_fastsurfer.sh --sid <templateID> --base --seg_only ...` where the `--base` flag indicates that the input image will be taken from the already existing template directory. 
 3. This is followed by the surface processing of the template  `run_fastsurfer.sh --sid <templateID> --base --surf_only ...`, which can be combined with the previous step.
 4. Next, the segmentations of each time points, which can theoretically run in parallel with the previous two steps, is performed `run_fastsurfer.sh --sid <tIDn> --long <templateID> --seg_only ...`,
-5. again followed by the surface processing for each time point: `run_fastsurfer.sh --<id <tIDn> --long <templateID> --surf_only`. This step needs to wait until 3. and 4. are finished. 
+5. Again followed by the surface processing for each time point: `run_fastsurfer.sh --<id <tIDn> --long <templateID> --surf_only`. This step needs to wait until 3. and 4. are finished.
+<!-- Maybe reorganize 2. and 3. into 2.A and 2.B and 4. and 5. into 3.A and 3.B -->
 
-Internally we use `brun_fastsurfer.sh` as a helper script to process multiple time points (in 4. and 5.) in parallel (if experimental `--parallel_long` is passed to `long_fastsurfer.sh`). 
+<!-- TODO: update this section to better explain the parallelization effects, --parallel_seg is parallelization of segmentation steps, --parallel_surf is the parallelization of surface steps, which is the more impactful option for logitudinal processing explicitly, because parallel segmentation may run into GPU memory limitations. -->
+Internally we use `brun_fastsurfer.sh` as a helper script to process multiple time points (in 4. and 5.) in parallel (if experimental `--parallel_surf` is passed to `long_fastsurfer.sh`). 
 
 ## Final Statistics:
 

--- a/doc/scripts/BATCH.md
+++ b/doc/scripts/BATCH.md
@@ -34,49 +34,48 @@ Parallelization with `brun_fastsurfer.sh`
 -----------------------------------------
 
 `brun_fastsurfer.sh` has powerful builtin parallel processing capabilities. These are hidden underneath the 
-`--parallel_subjects* <n>|max` and the `--device <device>` as well as `--viewagg_device <device>` flags.
+`--parallel* <n>|max` and the `--device <device>` as well as `--viewagg_device <device>` flags.
 One of the core properties of FastSurfer is the split into the segmentation (which uses Deep Learning and therefore 
 benefits from GPUs) and the surface pipeline (which does not benefit from GPUs). For ideal batch processing, we want 
 different resource scheduling.
 
-`--parallel_subjects*` allows three parallel batch processing modes: serial, single parallel pipeline and dual parallel
-pipeline. 
+`--parallel*` allows three parallel batch processing modes: serial, single parallel pipeline and dual parallel pipeline. 
 
 ### Serial processing (default)
 Each case/image is processed after the other fully, i.e. surface reconstruction of case 1 is fully finished before 
-segmentation of case 2 is started. This setting is the default and represents the manual flags `--parallel_subjects 1`.
+segmentation of case 2 is started. This setting is the default and represents the manual flags `--parallel 1`.
 
 ### Single parallel pipeline
 This mode is ideal for CPU-based processing for segmentation. It will process segmentations and surfaces in series 
 in the same process, but multiple cases are processed at the same time.
 
 ```bash
-$FASTSURFER_HOME/brun_fastsurfer.sh --parallel_subjects 4 --threads 2 --parallel
+$FASTSURFER_HOME/brun_fastsurfer.sh --parallel 4 --threads 2
 ```
 will start 4 segmentations (and surface reconstructions) at the same time, and will start a fifth, when the surface
-processing of one of the four first cases is finished (`--parallel_subjects 4`). It will try to use 2 threads per case
-(`--threads 2`) and perform reconstruction of left and right hemispheres in parallel (`--parallel`).
-`--parallel_subjects max` or `--parallel_subjects` will remove the limit and start all cases at the same time (each with
-the target number of threads given in `--threads`).
+processing of one of the four first cases is finished (`--parallel 4`). It will try to use 2 threads per case
+(`--threads 2`) and perform reconstruction of left and right hemispheres in parallel (`--threads 2`, 2 >= 2).
+`--parallel max` will remove the limit and start all cases at the same time (each with the target number of threads 
+given by `--threads`).
 
 ### Dual parallel pipeline
 This is ideal for GPU-based processing for segmentation. It will process segmentations and surfaces in separate 
 pipelines, which is useful for optimized GPU loading. Multiple cases may be processed at the same time.
 
 ```bash
-$FASTSURFER_HOME/brun_fastsurfer.sh --device cuda:0-1 --parallel_subjects_seg 2 --parallel_subjects_surf max \
-  --threads_seg 8 --threads_surf 2 --parallel
+$FASTSURFER_HOME/brun_fastsurfer.sh --device cuda:0-1 --parallel_seg 2 --parallel_surf max \
+  --threads_seg 8 --threads_surf 4
 ```
-will start 2 parallel segmentations (`--parallel_subjects_seg 2`) using GPU 0 for case 1 and GPU 1 for case 2 
+will start 2 parallel segmentations (`--parallel_seg 2`) using GPU 0 for case 1 and GPU 1 for case 2 
 (`--device cuda:0-1` -- same as `--device cuda:0,1`). After one of these segmentations is finished, the segmentation of 
 case 3 will start on that same device as well as the surface reconstruction (without putting a limit on parallel 
-surface reconstructions, `--parallel_subjects_surf max`). Each segmentation process will aim to use 8 threads/cores
-(`--threads_seg 8`) and each surface reconstruction process will aim to use 2 threads (`--threads_surf 2`) with both
-hemispheres processed in parallel (`--parallel`).
+surface reconstructions, `--parallel_surf max`). Each segmentation process will aim to use 8 threads/cores
+(`--threads_seg 8`) and each surface reconstruction process will aim to use 4 threads (`--threads_surf 4`) with both
+hemispheres processed in parallel (`--threads_surf 4`, 4 >= 2, so right hemisphere will use 2 threads and left as well).
 
 Note, if your GPU has sufficient [video memory](../overview/intro.rst#system-requirements), two parallel segmentations
 can run on the same GPU, but the script cannot schedule more than one process per GPU for multiple GPUs, i.e.
-`--device cuda:0,1 --parallel_subjects_seg 4` is not supported.
+`--device cuda:0,1 --parallel_seg 4` is not supported.
 
 Questions
 ---------

--- a/doc/scripts/long_fastsurfer.rst
+++ b/doc/scripts/long_fastsurfer.rst
@@ -2,7 +2,7 @@ LONG: long_fastsurfer.sh
 ========================
 
 .. note::
-   Please also see the documentation on `longitudinal processing <../overview/LONG.html>`__ .
+   Please also see the documentation on :doc:`../overview/LONG`.
 
 Usage help text
 ---------------

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -80,11 +80,18 @@ FLAGS:
   --tpids <tID1> >tID2> ..  IDs for future time points directories inside
                               \$SUBJECTS_DIR to be created later (during --long)
   --sd  <subjects_dir>      Output directory \$SUBJECTS_DIR (or pass via env var)
-  --parallel_long           (Highly Experimental) Parallelize the long script
   --py <python_cmd>         Command for python, used in both pipelines.
                               Default: "$python"
                               (-s: do no search for packages in home directory)
   -h --help                 Print Help
+
+Parallelization options:
+  All of the following options will activate parallel processing of the base and the longitudinal time-point images
+  where possible. Additionally, the number of different processes for segmentation and surface reconstructionis set.
+  --parallel <n>|max        See above, sets the size of the processing pool for segmentation and surface reconstruction
+  --parallel_seg <n>|max    See above, only sets the size of the processing pool for segmentation (default: 1)
+  --parallel_surf <n>|max   See above, only sets the size of the processing pool for surface reconstruction (default: 1)
+
 
 With the exception of --t1, --t2, --sid, --seg_only and --surf_only, all
 run_fastsurfer.sh options are supported, see 'run_fastsurfer.sh --help'.
@@ -159,7 +166,7 @@ case $key in
     done
     ;;
   --sd) sd="$1" ; export SUBJECTS_DIR="$1" ; shift  ;;
-  --parallel_long) parallel=1 ;;
+  --parallel|--parallel_seg|--parallel_surf) parallel=1 ; brun_flags+=("$key" "$1") ; shift ;;
   --py) python="$1" ; shift ;;
   -h|--help) usage ; exit ;;
   --remove_suffix) echo "ERROR: The --remove_suffix option is not supported by long_prepare_template.sh" ; exit 1 ;;
@@ -326,8 +333,6 @@ fi
 cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --surf_only --long "$tid"
       "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
 if [[ "$parallel" == "1" ]] ; then
-  cmda+=("--parallel_subjects")
-
   # Append the base surface and longitudinal segmentation logs, exit if either failed
   what_failed=()
   log "======================================="

--- a/recon_surf/README.md
+++ b/recon_surf/README.md
@@ -56,8 +56,7 @@ Optional arguments
 * `--fsqsphere`: Use FreeSurfer default instead of novel spectral spherical projection for qsphere
 * `--fsaparc`: Use FS aparc segmentations in addition to DL prediction (slower in this case and usually the mapped ones 
   from the DL prediction are fine)
-* `--parallel`: Run both hemispheres in parallel
-* `--threads`: Set openMP and ITK threads to <int>
+* `--threads`: Set openMP and ITK threads to <int>, activates hemisphere parallelization if threads >= 2.
 
 Other
 -----
@@ -183,7 +182,7 @@ There are however some small differences to be aware of:
 1. the path to and the filename of the t1 image in the subject_list file is optional.
 2. you are not able to specify a custom, conformed t1 image via `--t1 <path>` (`run_fastsurfer.sh --seg_only` will always use `$subjects_dir/$subject_id/mri/orig.mgz`). 
 
-Invoke the following command (make sure you have enough resources to run the given number of subjects in parallel or drop the `--parallel_subjects` flag to run them in series!):
+Invoke the following command (make sure you have enough resources to run the given number of subjects in parallel or drop the `--parallel_surf max` flag to run them in series!):
 
 ```bash
 singularity exec --no-home \
@@ -194,7 +193,7 @@ singularity exec --no-home \
             /fastsurfer/brun_fastsurfer.sh \
             --surf_only \
             --subjects_list /lists/subjects_list.txt \
-            --parallel_subjects \
+            --parallel_surf max \
             --sd /output \
             --fs_license /fs_license/license.txt \
             --3T

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -169,7 +169,8 @@ case $key in
   --threads|--threads_seg) run_pred_flags+=("--threads" "$1") ; shift ;;
   --batch) run_pred_flags+=("--batch_size" "$1") ; shift ;;
   # these known arguments get ignored
-  --aseg_name|--conformed_name|--asegdkt_segfile|--brainmask_name|--seg_log|--qc_log) shift ;;
+  --aseg_name|--conformed_name|--asegdkt_segfile|--brainmask_name|--seg_log|--qc_log|--parallel|--threads_surf) shift ;;
+  --no_cereb|--no_hypothal|--no_biasfield) shift ;;
   --async_io) ;;
   --fs_license) export FS_LICENSE="$1" ; shift ;;
   --remove_suffix) echo "ERROR: The --remove_suffix option is not supported by long_prepare_template.sh" ; exit 1 ;;

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -541,7 +541,7 @@ if [[ "$legacy_parallel_hemi" == 1 ]] ; then
   echo "WARNING: The --parallel flag is obsolete and will be removed in FastSurfer 3."
   echo "  Hemispheres are now automatically processed in parallel, if threads for surface "
   echo "  reconstruction are more than 1 (defined via --threads 2 or --threads_surf 2)!"
-  echo "IMPORTANT NOTE: The threads behavior has also changed, --parallel used to define the"
+  echo "IMPORTANT NOTE: The threads behavior has also changed, --threads used to define the"
   echo "  number of threads per hemisphere, it now defines the number of threads in total!"
   if [[ "$threads_surf" == 1 ]] ; then
     threads_surf=2


### PR DESCRIPTION
- Update the `--parallel_subjects*` flags and rename them to `--parallel*` (`brun_fastsurfer.sh`, `long_fastsurfer.sh`)
- Update the "old" `--parallel` flag (making it legacy, removing from documentation everywhere incl. all examples, but also from the "functionality of the scripts")
- Update the way `--threads` works for surface reconstruction. Before: `run_fastsurfer.sh` fixes `--threads` value, if `--parallel` is set; Now: `run_fastsurfer.sh` does nothing to the threads value for surface reconstruction, but recon-surf.sh has 2 values for threads: for joint parts and for parallel hemisphere parts; if threads is >= 2 parallel hemispheres is automatically activated and the number of threads available to each parallel hemisphere is halved.

- Update the documentation throughout.