### PR TITLE
Small but important pre-release fixes

### DIFF
--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -16,7 +16,6 @@
 
 # IMPORTS
 import argparse
-import logging
 import sys
 from collections.abc import Iterable
 from enum import Enum
@@ -26,6 +25,7 @@ import nibabel as nib
 import numpy as np
 import numpy.typing as npt
 
+from FastSurferCNN.utils import logging
 from FastSurferCNN.utils.arg_types import VoxSizeOption
 from FastSurferCNN.utils.arg_types import float_gt_zero_and_le_one as __conform_to_one_mm
 from FastSurferCNN.utils.arg_types import target_dtype as __target_dtype
@@ -72,14 +72,14 @@ DEFAULT_CRITERIA_DICT = {
 DEFAULT_CRITERIA = frozenset(DEFAULT_CRITERIA_DICT.values())
 
 
-def options_parse():
+def make_parser() -> argparse.ArgumentParser:
     """
-    Command line option parser.
+    Create an Argument parser for the conform script.
 
     Returns
     -------
-    options
-        Object holding options.
+    argparse.ArgumentParser
+        The parser object.
     """
     parser = argparse.ArgumentParser(usage=HELPTEXT)
     parser.add_argument(
@@ -172,7 +172,25 @@ def options_parse():
         action="store_true",
         help="If verbose, more specific messages are printed",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--log",
+        dest="logfile",
+        default="",
+        action="store",
+        help="If specified, a log file that is written to",
+    )
+    return parser
+
+def options_parse():
+    """
+    Command line option parser.
+
+    Returns
+    -------
+    options
+        Object holding options.
+    """
+    args = make_parser().parse_args()
     if args.input is None:
         raise RuntimeError("ERROR: Please specify input image")
     if not args.check_only and args.output is None:
@@ -972,6 +990,8 @@ if __name__ == "__main__":
         options = options_parse()
     except RuntimeError as e:
         sys.exit(*e.args)
+
+    logging.setup_logging(options.logfile) # logging to only the console
 
     print(f"Reading input: {options.input} ...")
     image = nib.load(options.input)

--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -439,8 +439,9 @@ function run_single()
   elif [[ -n "$statusfile" ]] && [[ "$do_surf" == 1 ]] && [[ "$do_seg" == 0 ]]
   then
     ## if status in statusfile is "Failed" last, skip this
-    IFS=" "
-    while IFS='' read -r line ; do
+    prev_ifs="$IFS" ; IFS=''
+    while read -r line ; do
+      IFS=" "
       subject="$(echo "$line" | cut -d" " -f1)"
       if [[ "$subject" == "$subject_id:" ]] ; then
         statustext="${line:$((${#subject} + 1))}"
@@ -449,7 +450,9 @@ function run_single()
           status=success
         fi
       fi
+      IFS=""
     done < "$statusfile"
+    IFS="$prev_ifs"
     if [[ "$status" == "failed" ]]
     then
       echo "INFO: Skipping $subject_id's surface recon because the segmentation failed."
@@ -512,6 +515,7 @@ function process_by_token()
   do
     if [[ "$read_in" == 1 ]]
     then
+      IFS=""
       read -r -t "$timeout_read_token" line
       returncode="$?"
       if [[ "$returncode" == 1 ]] ; then read_in=0 # EOF, terminate looking at for input
@@ -609,7 +613,8 @@ function process_by_token()
 
 function filter_token()
 {
-  while IFS='' read -r line ; do if [[ "${line:0:17}" != "#@#!NEXT-SUBJECT:" ]] ; then echo "$line" ; fi ; done
+  IFS=""
+  while read -r line ; do if [[ "${line:0:17}" != "#@#!NEXT-SUBJECT:" ]] ; then echo "$line" ; fi ; done
 }
 
 

--- a/recon_surf/README.md
+++ b/recon_surf/README.md
@@ -18,17 +18,14 @@ bias-field corrected image and the bias-field correction is skipped.
 Usage
 =====
 
-```
-{command-output} ./recon_surf.sh --help
-```
 The *recon_surf* directory contains scripts to run the analysis. In addition, a working installation of __FreeSurfer__ 
 (the supported version, usually the most recent) is needed for a native install (or use our Docker/Singularity images). 
 
 The main script is called `recon-surf.sh` which accepts certain arguments via the command line.
 List them by running the following command:
 
-```bash
-./recon-surf.sh --help
+```{command-output} ./recon-surf.sh --help
+:cwd: /../recon_surf/
 ```
 
 Required arguments

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -460,11 +460,11 @@ if [ "$CONFORM_LF" != /dev/null ] ; then  rm -f "$CONFORM_LF" ; fi
 echo "Log file for Conform test" > "$CONFORM_LF"
 
 # check for input conformance
-cmd="$python $FASTSURFER_HOME/FastSurferCNN/data_loader/conform.py -i $t1 --check_only --vox_size min --verbose"
-RunIt "$cmd" "$LF" 2>&1 | tee -a "$CONFORM_LF"
+cmd="$python $FASTSURFER_HOME/FastSurferCNN/data_loader/conform.py -i $t1 --check_only --vox_size min --verbose --log $CONFORM_LF"
+RunIt "$cmd" "$LF"
 
 # look into the CONFORM_LF to find the voxel sizes, the second conform.py call will check the legality of vox_size
-vox_size=$(grep -E " - Voxel Size " "$CONFORM_LF" | cut -d' ' -f5 | cut -d'x' -f1)
+vox_size=$(grep -oP '(?<= - Voxel Size )[0-9\.]+' "$CONFORM_LF")
 # remove the temporary conform_log (all info is also in the recon-surf logfile)
 if [ -f "$CONFORM_LF" ]; then rm -f "$CONFORM_LF" ; fi
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -822,7 +822,16 @@ then
 fi
 
 pushd "${sd}/${subject}" > /dev/null || { echo "Could not access ${sd}/${subject}!" ; exit 1 ; }
-  mapfile -t content_of_subject_dir < <(find "." -type f)
+  function filter_log_build()
+  {
+    # filter expected files $LF and scripts/BUILD.log
+    IFS=""
+    while read -r file ; do
+      if [[ "${sd}/${subject}/${file:2}" != "$seg_log" ]] && [[ "$file" != "./scripts/BUILD.log" ]] ; then echo "$file" ; fi
+    done
+  }
+
+  mapfile -t content_of_subject_dir < <(find "." -type f | filter_log_build)
 popd > /dev/null || exit 1
 if [[ "${#content_of_subject_dir[@]}" -gt 1 ]] ; then
   if [[ "$edits" == "true" ]] ; then LABEL="INFO" ; else LABEL="WARNING" ; fi

--- a/stools.sh
+++ b/stools.sh
@@ -360,7 +360,7 @@ function make_copy_job ()
   fi
   {
     echo "#!/bin/bash"
-    echo "set -e"
+    echo "IFS=''"
     echo "mkdir -p $hpc_work/cases"
     echo "while read subject; do"
     echo "  subject_id=\$(echo \"\$subject\" | cut -d= -f1)"
@@ -412,10 +412,12 @@ function prepend ()
 {
   #param1 string to prepend to every line
   # https://serverfault.com/questions/72744/command-to-prepend-string-to-each-line
+  IFS=""
   while read -r line ; do echo "${1}${line}" ; done
 }
 function append ()
 {
   #param1 string to append to every line
+  IFS=""
   while read -r line ; do echo "${line}$1" ; done
 }


### PR DESCRIPTION
In #649, the output format of `conform.py` is changed. This leads to a bug in recon-surf, where this output is used to read the voxel size. Using the logger meant that the file and line are prepended, which did not used to be prepended. That changes the line and the extraction command became invalid.

Now fixed by using grep in `recon-surf` and adding `setup_logging` in `conform.py`. Also added extra optional `--log` flag to write the log to a file and adding a make_parser function for future integration into documentation.

Make sure all bash read statements are started with IFS="" so initial white spaces are not dropped

Removed the extra warning of expected-to-exist files `scripts/deep-seg.log` and `scripts/BUILD.log`