### PR TITLE
Fixes additional flags in srun_fastsurfer and T2 processing

### DIFF
--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -623,7 +623,6 @@ def conform(
     mdc_affine = mdc_affine / np.linalg.norm(mdc_affine, axis=1)
     h1["Mdc"] = np.linalg.inv(mdc_affine)
 
-    print(h1.get_zooms())
     h1["fov"] = max(i * v for i, v in zip(h1.get_data_shape(), h1.get_zooms(), strict=False))
     center = np.asarray(img.shape[:3], dtype=float) / 2.0
     h1["Pxyz_c"] = img.affine.dot(np.hstack((center, [1.0])))[:3]

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1061,7 +1061,7 @@ then
   then
         # currently, the order of the T2 preprocessing only is registration to T1w
     cmd=($python "$hypvinndir/run_prediction.py" --sd "${sd}" --sid "${subject}"
-         "${hypvinn_flags[@]}" --regmode "$hypvinn_regmode" --threads "$threads_seg" --async_io
+         "${hypvinn_flags[@]}" --reg_mode "$hypvinn_regmode" --threads "$threads_seg" --async_io
          --batch_size "$batch_size" --seg_log "$seg_log" --device "$device"
          --viewagg_device "$viewagg" --t1)
     if [[ "$run_biasfield" == "1" ]]

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -613,20 +613,14 @@ if [[ -z "$norm_name" ]] ; then norm_name="${sd}/${subject}/mri/orig_nu.mgz" ; f
 if [[ -z "$norm_name_t2" ]] ; then norm_name_t2="${sd}/${subject}/mri/T2_nu.mgz" ;  fi
 if [[ -z "$seg_log" ]] ; then seg_log="${sd}/${subject}/scripts/deep-seg.log" ; fi
 if [[ -z "$build_log" ]] ; then build_log="${sd}/${subject}/scripts/build.log" ; fi
-if [[ -n "$t2" ]]
+# T2 image is only used in segmentation pipeline (but registration is done even if hypvinn is off)
+if [[ -n "$t2" ]] && [[ "$run_seg_pipeline" == 1 ]]
 then
-  if [[ ! -f "$t2" ]]
-  then
-    echo "ERROR: T2 file $t2 does not exist!"
-    exit 1
-  fi
+  if [[ ! -f "$t2" ]] ; then echo "ERROR: T2 file $t2 does not exist!" ; exit 1 ; fi
   copy_name_T2="${sd}/${subject}/mri/orig/T2.001.mgz"
 fi
 
-if [[ -z "$PYTHONUNBUFFERED" ]]
-then
-  export PYTHONUNBUFFERED=0
-fi
+if [[ -z "$PYTHONUNBUFFERED" ]] ; then export PYTHONUNBUFFERED=0 ; fi
 
 # check the vox_size setting
 if [[ "$vox_size" =~ ^[0-9]+([.][0-9]+)?$ ]]
@@ -801,9 +795,7 @@ set +eo > /dev/null
 mkdir -p "$(dirname "$seg_log")"
 
 
-if [[ -f "$seg_log" ]]; then log_existed="true"
-else log_existed="false"
-fi
+if [[ -f "$seg_log" ]]; then log_existed="true" ; else log_existed="false" ; fi
 
 {
   echo "========================================================="

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -914,7 +914,7 @@ then
 
       echo "INFO: Robust scaling (partial conforming) of T2 image..."
       cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_strict_lia
-           --no_vox_size --no_img_size "$t2" "$conformed_name_t2")
+           --no_iso_vox --no_img_size -i "$t2" -o "$conformed_name_t2")
       echo_quoted "${cmd[@]}"
       "${cmd[@]}" 2>&1
       echo "Done."

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -443,7 +443,7 @@ if [[ -n "$subject_list" ]]
 then
   # the test for files (check_subject_images) requires paths to be wrt
   cases=$(translate_cases "$in_dir" "$subject_list" "$in_dir" "${subject_list_delim}" "${subject_list_awk_code_sid}" "${subject_list_awk_code_args}")
-  check_subject_images "$cases"
+  check_subject_images "$in_dir" "$cases"
   if [[ "$debug" == "true" ]]
   then
     log "Debug output of the parsed subject_list:"

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -648,9 +648,10 @@ then
     echo "                --ntasks=1 --time=$timelimit_surf --nodes=1"
     echo "                --cpus-per-task=$num_cpus_surf --mem=${mem_surf}G"
     echo "                --hint=nomultithread"
-    echo "                singularity exec --no-home -B '$hpc_work:/data'"
+    echo "                singularity exec --no-mount home,cwd --cleanenv -B '$hpc_work:/data'"
+    echo "                  -B '$in_dir:/source:ro'"
     if [[ -n "$extra_singularity_options" ]] || [[ -n "$extra_singularity_options_surf" ]]; then
-      echo "                $extra_singularity_options $extra_singularity_options_surf"
+      echo "                  $extra_singularity_options $extra_singularity_options_surf"
     fi
     echo "                '$hpc_work/images/fastsurfer.sif'"
     echo "                /fastsurfer/run_fastsurfer.sh)"

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -656,7 +656,7 @@ then
     echo "$hpc_work/$brun_fastsurfer --run_fastsurfer \"\${run_fastsurfer[*]}\" \\"
     echo "  ${fastsurfer_options[*]} ${fastsurfer_surf_options[*]}"
   } > "$surf_cmd_file"
-  surf_slurm_sched=("--mem-per-cpu=${mem_per_core}G" "--cpus-per-task=$cores_per_task"
+  surf_slurm_sched=("--mem-per-cpu=${mem_per_core}G" "--cpus-per-task=$num_cpus_surf"
                     "--ntasks=$real_num_cases_per_task"
                     "--nodes=1-$real_num_cases_per_task" "--hint=nomultithread"
                     "${jobarray_option[@]}" "$surf_depend"

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -124,7 +124,7 @@ Data- and subject-related options:
   --sid subject-101 --t1 <data-path>/raw/T1w-101A.nii.gz --vox_size 0.9
 
 FastSurfer options:
---fs_license: path to the freesurfer license (either absolute path or relative to pwd)
+--fs_license: path to the freesurfer license (either absolute path or relative to pwd, for surfaces & registration(s))
 --seg_only: only run the segmentation pipeline
 --surf_only: only run the surface pipeline (--sd must contain previous --seg_only processing)
 --***: also standard FastSurfer options can be passed, like --3T, --no_cereb, etc.
@@ -542,7 +542,8 @@ then
                           --statusfile /data/scripts/subject_success
                           # run_fastsurfer options (inside singularity)
                           --sd "/data/cases" --threads "$num_cpus_per_task"
-                          --seg_only "${POSITIONAL_FASTSURFER[@]}")
+                          --seg_only "${POSITIONAL_FASTSURFER[@]}"
+                          --fs_license /data/scripts/.fs_license)
 
   seg_cmd_filename=$hpc_work/scripts/slurm_cmd_seg.sh
   if [[ "$submit_jobs" == "true" ]]


### PR DESCRIPTION
Additional flags (including --t2) did not work properly from the subject_list file in srun_fastsurfer.sh 
The Bug is actually in stools.sh:translate_cases, where the lines are not correct parsed. 
This PR fixes this issue and properly parses the file. Also, the check to find non-existent files in stools.sh:check_subject_images.

This PR also adds a check if files are symlinks, which may cause problems with folders mounted in singularity (this needed a small change in srun_fastsurfer.sh - an additional argument to check_subject_images).

This PR fixes #654 