### PR TITLE
long processing: run diff command in if statement to catch error

### DIFF
--- a/FastSurferCNN/version.py
+++ b/FastSurferCNN/version.py
@@ -322,9 +322,8 @@ def main(
             futures["checkpoints"] = pool.submit(calculate_md5_for_checkpoints)
 
         if "+pip" in sections and not prefer_cache:
-            futures["pypackages"] = PyPopen(
-                ["-m", "pip", "list", "--verbose"], **kw_root
-            ).as_future(pool)
+            pip_command = "-m pip list --verbose --no-cache-dir --no-color --disable-pip-version-check"
+            futures["pypackages"] = PyPopen(pip_command.split(" "), **kw_root).as_future(pool)
 
     if build_cache_required and build_cache is not False:
         build_cache: VersionDict = futures.pop("build_cache").result()

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -238,11 +238,21 @@ then
   exit 1
 fi
 
-if [[ -z "$LF" ]]
+if [[ -z "$LF" ]] ; then LF="$sd/$tid/scripts/long_fastsurfer.log" ; fi
+# make sure the directory for the logfile exists, create automatically if the directory is not in $sd
+if [[ ! -d "$(dirname "$LF")" ]]
 then
-  LF="$sd/$tid/scripts/long_fastsurfer.log"
+  if [[ "${LF:0:${#sd}}" == "$sd" ]] ; then mkdir -p "$sd/$tid/scripts"
+  else
+    echo "ERROR: The directory for the logfile is outside of the SUBJECTS_DIR and did not exist, please"
+    echo "  create the directory $(dirname "$LF")!"
+    exit 1
+  fi
 fi
 function log () { echo "$1" | tee -a "$LF" ; }
+
+## make sure +eo are unset
+set +eo > /dev/null
 
 log "Logging outputs of $THIS_SCRIPT to $LF"
 log "======================================="

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -193,7 +193,7 @@ done
 if [[ "${#POSITIONAL_FASTSURFER[@]}" -gt 0 ]]
 then
   echo "WARNING: The arguments ${POSITIONAL_FASTSURFER[*]}"
-  echo "  are not recognized and therefore ignored!"
+  echo "  are not recognized and therefore ignored in this (sub-)script!"
 fi
 
 if [ "${#t1s[@]}" -lt 1 ]
@@ -299,8 +299,7 @@ do
   if [ "$s" != "${t1s[0]}" ]
   then
     cmd="mri_diff --notallow-pix --notallow-geo $s ${t1s[0]}"
-    RunIt "$cmd" $LF
-    if [ "${PIPESTATUS[0]}" -ne 0 ]
+    if ! RunIt "$cmd" $LF
     then
       geodiff=1
     fi

--- a/recon_surf/talairach-reg.sh
+++ b/recon_surf/talairach-reg.sh
@@ -179,18 +179,16 @@ fi
 
 # Since we do not run mri_em_register we sym-link other talairach transform files here
 pushd "$mdir/transforms" > /dev/null || ( echo "ERROR: Could not change to the transforms directory $mdir/transforms!" | tee -a "$LF" ; exit 1 )
-  {
-    if [[ ! -e talairach_with_skull.lta ]] ; then
-      cmd=(softlink_or_copy talairach.xfm.lta talairach_with_skull.lta)
-      echo_quoted "${cmd[@]}"
-      "${cmd[@]}"
-    fi
-    if [[ ! -e talairach.lta ]] ; then
-      cmd=(softlink_or_copy talairach.xfm.lta talairach.lta)
-      echo_quoted "${cmd[@]}"
-      "${cmd[@]}"
-    fi
-  } | tee -a "$LF"
+  if [[ ! -e talairach_with_skull.lta ]] ; then
+    cmd=(softlink_or_copy talairach.xfm.lta talairach_with_skull.lta "$LF")
+    echo_quoted "${cmd[@]}"
+    "${cmd[@]}"
+  fi
+  if [[ ! -e talairach.lta ]] ; then
+    cmd=(softlink_or_copy talairach.xfm.lta talairach.lta "$LF")
+    echo_quoted "${cmd[@]}"
+    "${cmd[@]}"
+  fi
 popd > /dev/null || exit 1
 
 # Add xfm to nu

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -782,6 +782,9 @@ then
   exit 1
 fi
 
+## make sure +eo are unset
+set +eo > /dev/null
+
 ########################################## START ########################################################
 mkdir -p "$(dirname "$seg_log")"
 


### PR DESCRIPTION
If images have only a very, very <0.00001 mm difference in resolution in `long_fastsurfer.sh`, it fails without a clear and interpretable error message.

This is due to 2 issues:
1. `RunIt` `exit`s the script if the command it runs returns a non-zero return code. In consequence, long_fastsurfer terminates instead of printing the proper error message.
2. Very small differences in the voxelsize get rounded in the printed output of `mri_diff` but not in the default settings of the check giving very confusing output.

Solutions:
Do not use Run it here 
Print better error messages
Use `mri_diff --res-thresh 0.000001` to detect confusing messages