### PR TITLE
Fix allow_root in run_fastsurfer and long_fastsurfer

### DIFF
--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -180,7 +180,7 @@ case $key in
     echo "  pipeline run is a valid longitudinal run!"
     exit 1
     ;;
-  --debug) brun_flags+=("$key") ;;
+  --allow_root|--debug) brun_flags+=("$key") ;;  # --allow_root must be passed to brun
   *)    # unknown option
     POSITIONAL_FASTSURFER[i]=$key
     i=$((i + 1))
@@ -195,7 +195,7 @@ done
 source "${reconsurfdir}/functions.sh"
 
 # Warning if run as root user
-check_allow_root
+check_allow_root "${brun_flags[@]}" # --allow_root must be passed to brun
 
 if [ "${#t1s[@]}" -lt 1 ]
  then

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -146,8 +146,10 @@ function check_allow_root()
     echo "  running FastSurfer as root, because it will lead to files and folders created as root."
     echo "  If you are running FastSurfer in a docker container, you can specify the user"
     echo "  with '-u \$(id -u):\$(id -g)' (see https://docs.docker.com/engine/reference/run/#user)."
-    echo "  If you want to force running as root, you may pass --allow_root to $(basename "$BASH_ARGV0")."
-    if [[ "$allow_root" != "true" ]] ; then exit 1 ; fi
+    if [[ "$allow_root" != "true" ]]; then
+      echo "  If you want to force running as root, you may pass --allow_root to $(basename "$BASH_ARGV0")."
+      exit 1
+    fi
   fi
 }
 

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -122,23 +122,32 @@ function RunBatchJobs()
 
 function check_allow_root()
 {
-  # Will check, if --allow_root is in arguments (to this function or the parent script) and
-  # print an error message as well as exit.
+  # Will check, if --allow_root is in arguments (to this function) and print an error message
+  # as well as exit.
   # Examples:
   # check_allow_root --arg 0 -> message and exit
+  #
+  # If you want a script to check for allow_root, run `check_allow_root "$@"` inside that script
   # some_script_which_calls_check_allow_root_without_parameters --flag -> message and exit
+  #
+  # ```
+  # ...
+  # check_allow_root "$@"
+  # ...
+  # ```
 
   local allow_root="false"
-  for arg in "${BASH_ARGV[@]}" "$@" ; do if [[ "$arg" == "--allow_root" ]] ; then allow_root="true"; break ; fi ; done
+  for arg in "$@" ; do if [[ "$arg" == "--allow_root" ]] ; then allow_root="true"; break ; fi ; done
 
-  if [[ "$allow_root" != "true" ]] && [[ "$(id -u)" == "0" ]]
+  if [[ "$(id -u)" == "0" ]]
   then
-    echo "ERROR: You are trying to run '$BASH_ARGV0' as root. We advice to avoid running FastSurfer"
-    echo "  as root, because it will lead to files and folders created as root."
+    if [[ "$allow_root" == "true" ]] ; then LABEL="WARNING" ; else LABEL="ERROR" ; fi
+    echo "$LABEL: You are trying to run '$(basename "$BASH_ARGV0")' as root. We recommend to avoid"
+    echo "  running FastSurfer as root, because it will lead to files and folders created as root."
     echo "  If you are running FastSurfer in a docker container, you can specify the user"
     echo "  with '-u \$(id -u):\$(id -g)' (see https://docs.docker.com/engine/reference/run/#user)."
-    echo "  If you want to force running as root, you may pass --allow_root to run_fastsurfer.sh."
-    exit 1
+    echo "  If you want to force running as root, you may pass --allow_root to $(basename "$BASH_ARGV0")."
+    if [[ "$allow_root" != "true" ]] ; then exit 1 ; fi
   fi
 }
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -72,6 +72,7 @@ threads_seg="1"
 threads_surf="1"
 # python3.10 -s excludes user-directory package inclusion
 python="python3.10 -s"
+allow_root=()
 version_and_quit=""
 warn_seg_only=()
 warn_base=()
@@ -368,7 +369,7 @@ case $key in
 
   # options that *just* set a flag
   #=============================================================
-  --allow_root) ;; # nothing required to do check by check_allow_root
+  --allow_root) allow_root=("$key") ;;
   # options that set a variable
   --sid) subject="$1" ; shift ;;
   --sd) sd="$1" ; shift ;;
@@ -533,7 +534,7 @@ fi
 source "${reconsurfdir}/functions.sh"
 
 # Warning if run as root user
-check_allow_root
+check_allow_root "${allow_root[@]}"
 
 # from now to the creation of the logfile, all messages are only written to the console and thus lost if the output is
 # lost. If the terminate the script (exit 1 or similar), this is fine and no log file is created. But if we continue,


### PR DESCRIPTION
The flag `--allow_root` no longer skipped the error message printed.

This PR fixes this issue, also a Warning is still printed if `--allow_root` is passed.

The reason is that BASH_ARGV is only available in debug mode (breaking the behavior in check_allow_root).

I am currently building a test docker image to test if the behavior is fixed.

This bug was reported in #653 .