### PR TITLE
Fix parallel surface generation

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -170,6 +170,7 @@ ENV OS=Linux \
     FREESURFER_HOME=/opt/freesurfer \
     PYTHONUNBUFFERED=0 \
     MPLCONFIGDIR=/tmp \
+    XDG_CACHE_HOME=/tmp/xdgcache \
     PATH=/venv/bin:/opt/freesurfer/bin:$PATH \
     MPLCONFIGDIR=/tmp/matplotlib-config \
     DO_NOT_SEARCH_FS_LICENSE_IN_FREESURFER_HOME="true"

--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -180,8 +180,8 @@ case $key in
       elif [[ "$value" =~ ^surf=[0-9]*$ ]] ; then  num_parallel_surf="${value:5}" ; parallel_pipelines="2" ; warn_old
       elif [[ "$value" =~ ^seg(=-[0-9]*|=max)?$ ]] ; then num_parallel_seg="max" ; parallel_pipelines="2" ; warn_old
       elif [[ "$value" =~ ^seg=[0-9]*$ ]] ; then num_parallel_seg="${value:4}" ; parallel_pipelines="2" ; warn_old
-      elif [[ "$value" =~ ^(-[0-9]+|max)$ ]] ; then parallel_pipelines=1 ; num_parallel_seg="max"
-      elif [[ "$value" =~ ^[0-9]+$ ]] ; then parallel_pipelines=1 ; num_parallel_seg="$value"
+      elif [[ "$value" =~ ^(-[0-9]+|max)$ ]] ; then parallel_pipelines=1 ; num_parallel_seg="max" ; num_parallel_surf="max"
+      elif [[ "$value" =~ ^[0-9]+$ ]] ; then parallel_pipelines=1 ; num_parallel_seg="$value" ; num_parallel_surf="$value"
       elif [[ "$value" =~ ^[0-9]+/[-9]+$ ]] ; then parallel_pipelines=2
         num_parallel_seg="$(echo "$value" | cut -d/ -f1)" ; num_parallel_surf="$(echo "$value" | cut -d/ -f2)"
       else echo "Invalid option for $key: $1" ; exit 1


### PR DESCRIPTION
This PR fixes a bug in brun_fastsurfer.sh, where --surf_only and --parallel ?? would not parallelize the execution

Fix number of processes in --surf_only (if --parallel <N>) for brun_fastsurfer.sh (not 1, but <N>)
Set XDG_CACHE_HOME environment variable in Dockerfile