### PR TITLE
bump scikit-sparse to 0.4.15 as 0.4.14 does not exist on pypi

### DIFF
--- a/requirements.cpu.txt
+++ b/requirements.cpu.txt
@@ -75,7 +75,7 @@ requests==2.32.3
 rich==13.9.4
 scikit-image==0.25.1
 scikit-learn==1.6.1
-scikit-sparse==0.4.14
+scikit-sparse==0.4.15
 scipy==1.15.1
 setuptools==75.8.0
 shellingham==1.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ requests==2.32.3
 rich==13.9.4
 scikit-image==0.25.1
 scikit-learn==1.6.1
-scikit-sparse==0.4.14
+scikit-sparse==0.4.15
 scipy==1.15.1
 setuptools==75.8.0
 shellingham==1.5.4


### PR DESCRIPTION
this way pip dependencies will differ slightly from conda as used in docker, but scikit-sparse 0.4.14 does not exist for pypi.