### PR TITLE
LONG: add make_upright to docker

### DIFF
--- a/Docker/install_fs_pruned.sh
+++ b/Docker/install_fs_pruned.sh
@@ -224,6 +224,7 @@ copy_files="
   bin/isanalyze
   bin/isnifti
   bin/lta_convert
+  bin/make_upright
   bin/mpr2mni305
   bin/mri_add_xform_to_header
   bin/mri_annotation2label


### PR DESCRIPTION
For single time point processing in the longitudinal stream, we need my make_upgright script from FreeSurfer, which currently is missing in the docker image.