### PR TITLE
Mac compatibility: Avoid PCRE grep in recon-surf, stat formatting and mapfile 

### DIFF
--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -125,6 +125,17 @@ function warn_old()
   echo "  use --parallel <n>, --parallel_seg <n>, or --parallel_surf <n>!"
 }
 
+function fail_bash_version_lt4()
+{
+  if [[ ! "$(bash --version | head -n 1)" =~ [vV]ersion[[:space:]][4-9] ]]
+  then
+    echo "ERROR: The brun_fastsurfer script requires at minimum bash version 4 for the options --subject_list and"
+    echo "  subjects via stdin. Specifying a specific number of concurrent processes (--parallel <num>,"
+    echo "  --parallel_seg <num>, --parallel_surf <num>; num is a positive integer) also requires bash 4+."
+    exit 1
+  fi
+}
+
 # PARSE Command line
 inputargs=("$@")
 POSITIONAL=()
@@ -144,6 +155,7 @@ case $key in
   # parse/get the subjects to iterate over
   #===================================================
   --subject_list|--subjects_list)
+    fail_bash_version_lt4
     if [[ ! -f "$1" ]]
     then
       echo "ERROR: Could not find the subject list $1!"
@@ -273,6 +285,7 @@ else
 fi
 if [[ "$subjects_stdin" == "true" ]]
 then
+  fail_bash_version_lt4
   if [[ -t 0 ]] || [[ "$debug" == "true" ]]; then
     echo "Reading subjects from stdin, press Ctrl-D to end input (one subject per line)"
   fi
@@ -546,6 +559,7 @@ function process_by_token()
     # check job count
     if [[ "$max_processes" == "max" ]] ; then spawn_task=1
     else
+      fail_bash_version_lt4
       mapfile -t running_jobs < <(jobs -pr)
       if [[ "${#running_jobs[@]}" -lt "$max_processes" ]] ; then spawn_task=1
       elif [[ "$read_in" == 0 ]] ; then wait "${running_jobs[@]}" # wait for any task to finish (std is already closed)
@@ -611,7 +625,9 @@ function process_by_token()
       fi
     fi
   done
-  mapfile -t running_jobs < <(jobs -pr)
+  if [[ "$(bash --version | head -n 1)" =~ [vV]ersion[[:space:]][4-9] ]] ; then mapfile -t running_jobs < <(jobs -pr)
+  else running_jobs=()
+  fi
   # wait for jobs to finish
   if [[ "$debug" == "true" ]]
   then
@@ -642,11 +658,13 @@ if [[ "$parallel_pipelines" == 1 ]] ; then
   if [[ "$seg_only" == "true" ]] ; then mode=seg
   elif [[ "$surf_only" == "true" ]] ; then mode=surf
   fi
+  if [[ "$num_parallel_seg" != "max" ]] ; then fail_bash_version_lt4 ; fi
   iterate_subjects_with_token "${iterate_subjects_with_token_args[@]}" | \
     process_by_token "$mode" "${process_by_token_args[@]}" | \
     filter_token
 else
   # multiple pipelines
+  if [[ "$num_parallel_seg" != "max" ]] || [[ "$num_parallel_surf" != "max" ]] ; then fail_bash_version_lt4 ; fi
   iterate_subjects_with_token "${iterate_subjects_with_token_args[@]}" | \
     process_by_token "seg" "${process_by_token_args[@]}" | \
     process_by_token "surf" "${process_by_token_args[@]}" | \

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -223,20 +223,7 @@ if [ "${#tpids[@]}" -ne "${#t1s[@]}" ]
 fi
 
 # check that SUBJECTS_DIR exists
-if [[ -z "${sd}" ]]
-then
-  echo "ERROR: No subject directory defined via --sd. This is required!"
-  exit 1
-elif [[ ! -d "${sd}" ]]
-then
-  echo "INFO: The subject directory did not exist, creating it now."
-  if ! mkdir -p "$sd" ; then echo "ERROR: directory creation failed" ; exit 1; fi
-elif [[ "$(stat -c "%u:%g" "$sd")" == "0:0" ]] && [[ "$(id -u)" != "0" ]] && [[ "$(stat -c "%a" "$sd" | tail -c 2)" -lt 6 ]]
-then
-  echo "ERROR: The subject directory ($sd) is owned by root and is not writable. FastSurfer cannot write results! "
-  echo "  This can happen if the directory is created by docker. Make sure to create the directory before invoking docker!"
-  exit 1
-fi
+check_create_subjects_dir_properties "$sd"
 
 if [[ -z "$LF" ]] ; then LF="$sd/$tid/scripts/long_fastsurfer.log" ; fi
 # make sure the directory for the logfile exists, create automatically if the directory is not in $sd

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -1,22 +1,17 @@
 
 # set the binpath variable
-if [ -z "$FASTSURFER_HOME" ]
-then
-  binpath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/"
-else
-  binpath="$FASTSURFER_HOME/recon_surf/"
+if [[ -z "$FASTSURFER_HOME" ]] ; then binpath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/"
+else binpath="$FASTSURFER_HOME/recon_surf/"
 fi
 export binpath
 
 # fs_time command from fs60, fs72 fails in parallel mode, use local one
-# also check for failure (e.g. on mac it fails)
-timecmd="${binpath}fs_time"
-$timecmd echo testing &> /dev/null
-if [ "${PIPESTATUS[0]}" -ne 0 ] ; then
-  echo "time command failing, not using time..."
-  timecmd=""
+# also check for failure (e.g. on mac it fails, so we cannot use it there)
+if FSTIME_LOAD=0 "${binpath}fs_time" echo testing &> /dev/null ; then timecmd="${binpath}fs_time"
+else timecmd="" ; echo "INFO: Testing fs_time was not successful, not reporting per-command runtimes."
 fi
 export timecmd
+export LC_NUMERIC="en_US.UTF-8"
 
 function check_create_subjects_dir_properties()
 {

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -18,6 +18,36 @@ if [ "${PIPESTATUS[0]}" -ne 0 ] ; then
 fi
 export timecmd
 
+function check_create_subjects_dir_properties()
+{
+  # 1: subjects_dir
+  if [[ -z "$1" ]]
+  then
+    echo "ERROR: No subject directory defined via --sd. This is required!"
+    exit 1
+  elif [[ ! -d "$1" ]]
+  then
+    echo "INFO: The subject directory did not exist, creating it now."
+    if [[ "$(id -u)" == 0 ]] ; then echo "WARNING: Creating as root!" ; fi
+    if ! mkdir -p "$1" ; then echo "ERROR: directory creation failed" ; exit 1; fi
+  else
+    if stat --version > /dev/null 2> /dev/null ; then # linux (GNU version of stat, supports --version)
+      user_group=$(stat -c "%u:%g" "$1")
+      world_access=$(stat -c "%a" "$1" | tail -c 2)
+    else # macOS (BSD version of stat)
+      user_group=$(stat -f "%u:%g" "$1")
+      world_access=$(stat -f "%p" "$1" | tail -c 2)
+    fi
+    if [[ "$user_group" == "0:0" ]] && [[ "$(id -u)" != "0" ]] && [[ "$world_access" -lt 6 ]]
+    then
+      echo "ERROR: The subject directory ($1) is owned by root and is not writable."
+      echo "  FastSurfer cannot write results! This can happen if the directory is created"
+      echo "  by docker. Make sure to create the directory before invoking docker!"
+      exit 1
+    fi
+  fi
+}
+
 function RunIt()
 {
   # parameters

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -220,25 +220,7 @@ then
 fi
 
 # check that SUBJECTS_DIR exists
-if [[ -z "$SUBJECTS_DIR" ]]
-then
-  echo "ERROR: No subject directory defined via --sd. This is required!"
-  exit 1;
-fi
-if [[ ! -d "${sd}" ]]
-then
-  echo "INFO: The subject directory did not exist, creating it now."
-  if ! mkdir -p "$SUBJECTS_DIR" ; then echo "ERROR: directory creation failed" ; exit 1; fi
-fi
-if [[ "$(stat -c "%u:%g" "$SUBJECTS_DIR")" == "0:0" ]] && [[ "$(id -u)" != "0" ]] && \
-  [[ "$(stat -c "%a" "$SUBJECTS_DIR" | tail -c 2)" -lt 6 ]]
-then
-  echo "ERROR: The subject directory ($SUBJECTS_DIR) is owned by root and is not writable."
-  echo "  FastSurfer cannot write results! This can happen if the directory is created by"
-  echo "  docker. Make sure to create the directory before invoking docker!"
-  exit 1;
-fi
-
+check_create_subjects_dir_properties "$SUBJECTS_DIR"
 
 ################################## SETUP and LOGFILE ##############################
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -464,7 +464,9 @@ cmd="$python $FASTSURFER_HOME/FastSurferCNN/data_loader/conform.py -i $t1 --chec
 RunIt "$cmd" "$LF"
 
 # look into the CONFORM_LF to find the voxel sizes, the second conform.py call will check the legality of vox_size
-vox_size=$(grep -oP '(?<= - Voxel Size )[0-9\.]+' "$CONFORM_LF")
+vox_size_prefix=" - Voxel Size"
+vox_size=$(grep -oE "${vox_size_prefix} [0-9.]+" "$CONFORM_LF")
+vox_size="${vox_size:${#vox_size_prefix}}"
 # remove the temporary conform_log (all info is also in the recon-surf logfile)
 if [ -f "$CONFORM_LF" ]; then rm -f "$CONFORM_LF" ; fi
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -1402,7 +1402,7 @@ fi # not base run
 # Collect info
 EndTime=$(date)
 tSecEnd=$(date '+%s')
-tRunHours=$(printf %6.3f "$(bc <<< "($tSecEnd - $tSecStart) / 3600")")
+tRunHours=$(LC_NUMERIC="en_US.UTF-8" printf %6.3f "$(bc -l <<< "($tSecEnd - $tSecStart) / 3600")")
 
 {
   echo ""

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -43,7 +43,7 @@ check_version=1       # Check for supported FreeSurfer version (terminate if not
 get_t1=1              # Generate T1.mgz from nu.mgz and brainmask from it (default)
 hires_voxsize_threshold=0.999  # Threshold below which the hires options are passed
 
-if [ -z "$FASTSURFER_HOME" ]
+if [[ -z "$FASTSURFER_HOME" ]]
 then
   binpath="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/"
   FASTSURFER_HOME="$(cd -- "$(dirname "$binpath")" >/dev/null 2>&1 ; pwd -P )/"
@@ -51,14 +51,11 @@ else
   binpath="$FASTSURFER_HOME/recon_surf/"
 fi
 
-
 # check bash version > 3.1 (needed for printf %q)
-function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
-if [ "$(version "${BASH_VERSION}")" -lt "$(version "3.1.0")" ]; then
-    echo "bash ${BASH_VERSION} is too old. Should be newer than 3.1, please upgrade!"
+if [[ "$(printf "%3d%03d%03d" "${BASH_VERSINFO[@]:0:3}")" -lt "3001000" ]] ; then
+    echo "ERROR: FastSurfer requires bash >= 3.1, but is running with bash ${BASH_VERSION}. Please upgrade!"
     exit 1
 fi
-
 
 function usage()
 {

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -843,26 +843,30 @@ then
   } | tee -a "$seg_log"
 fi
 
-pushd "${sd}/${subject}" > /dev/null || { echo "Could not access ${sd}/${subject}!" ; exit 1 ; }
-  function filter_log_build()
-  {
-    # filter expected files $LF and scripts/BUILD.log
-    IFS=""
-    while read -r file ; do
-      if [[ "${sd}/${subject}/${file:2}" != "$seg_log" ]] && [[ "$file" != "./scripts/BUILD.log" ]] ; then echo "$file" ; fi
-    done
-  }
+# mapfile builtin requires bash 4 (BASH_VERSINFO is available in bash 3)
+if [[ "${BASH_VERSINFO[0]}" -gt 3 ]]
+then
+  pushd "${sd}/${subject}" > /dev/null || { echo "Could not access ${sd}/${subject}!" ; exit 1 ; }
+    function filter_log_build()
+    {
+      # filter expected files $LF and scripts/BUILD.log
+      IFS=""
+      while read -r file ; do
+        if [[ "${sd}/${subject}/${file:2}" != "$seg_log" ]] && [[ "$file" != "./scripts/BUILD.log" ]] ; then echo "$file" ; fi
+      done
+    }
 
-  mapfile -t content_of_subject_dir < <(find "." -type f | filter_log_build)
-popd > /dev/null || exit 1
-if [[ "${#content_of_subject_dir[@]}" -gt 1 ]] ; then
-  if [[ "$edits" == "true" ]] ; then LABEL="INFO" ; else LABEL="WARNING" ; fi
-  {
-    echo "$LABEL: Found ${#content_of_subject_dir[@]} files in subject directory \$SUBJECTS_DIR/$subject:"
-    files=("${content_of_subject_dir[@]:0:6}")
-    if [[ "${#content_of_subject_dir[@]}" -gt 6 ]] ; then files+=("...") ; fi
-    echo " Potentially Overwriting: ${files[*]}"
-  } | tee -a "$seg_log"
+    mapfile -t content_of_subject_dir < <(find "." -type f | filter_log_build)
+  popd > /dev/null || exit 1
+  if [[ "${#content_of_subject_dir[@]}" -gt 1 ]] ; then
+    if [[ "$edits" == "true" ]] ; then LABEL="INFO" ; else LABEL="WARNING" ; fi
+    {
+      echo "$LABEL: Found ${#content_of_subject_dir[@]} files in subject directory \$SUBJECTS_DIR/$subject:"
+      files=("${content_of_subject_dir[@]:0:6}")
+      if [[ "${#content_of_subject_dir[@]}" -gt 6 ]] ; then files+=("...") ; fi
+      echo "  Potentially Overwriting: ${files[*]}"
+    } | tee -a "$seg_log"
+  fi
 fi
 
 asegdkt_segfile_manedit=$(add_file_suffix "$asegdkt_segfile" "manedit")

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -563,24 +563,7 @@ if [[ "$legacy_parallel_hemi" == 1 ]] ; then
   fi
 fi
 
-if [[ -z "${sd}" ]]
-then
-  echo "ERROR: No subject directory defined via --sd. This is required!"
-  exit 1
-fi
-if [[ ! -d "${sd}" ]]
-then
-  echo "INFO: The subject directory did not exist, creating it now." | tee -a "$tmpLF"
-  if ! mkdir -p "$sd" ; then echo "ERROR: Subject directory creation failed" ; exit 1 ; fi
-fi
-if [[ "$(stat -c "%u:%g" "$sd")" == "0:0" ]] && [[ "$(id -u)" != "0" ]] && \
-  [[ "$(stat -c "%a" "$sd" | tail -c 2)" -lt 6 ]]
-then
-  echo "ERROR: The subject directory ($sd) is owned by root and is not writable."
-  echo "  FastSurfer cannot write results! This can happen if the directory is created"
-  echo "  by docker. Make sure to create the directory before invoking docker!"
-  exit 1
-fi
+check_create_subjects_dir_properties "$sd"
 
 if [[ -z "$subject" ]]
 then

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -383,6 +383,7 @@ do
   fi
 done
 debugf "$newline\n"
+# the following stat command is not compatible with macOS, but srun_fastsurfer is not expected to be
 shell=$(stat -c %N "/proc/$$/exe" | cut -d">" -f2 | tail -c +3 | head -c -2)
 debug "Running in shell $shell: $($shell --version 2>/dev/null | head -n 1)"
 debug ""


### PR DESCRIPTION
Avoid using grep -P, instead use grep -E and some bash instructions.

This PR addresses #668 and was introduced by #652.

Needs testing to see if grep 2.6 / mac versions of grep on mac support the extended grep syntax.

This PR also addresses 2 more Mac compatibility issues:
- The use of `mapfile` in run_fastsurfer and brun_fastsurfer (the latter will just not be compatible for some specific flags/arguments)
- the use of `stat` which uses `-c` on Linux (GNU coreutils version) and `-f` for similar things on macOS (BSD version)