### PR TITLE
Fix regmode none for hypvinn

### DIFF
--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -370,27 +370,21 @@ class Inference:
         from FastSurferCNN.data_loader.data_utils import load_image, load_maybe_conform
 
         norm_file, norm_data, norm = None, None, None
-        if subject.has_attribute("cereb_statsfile"):
+        if subject.has_attribute("cereb_statsfile") :
             if not subject.can_resolve_attribute("cereb_statsfile"):
                 from FastSurferCNN.utils.parser_defaults import ALL_FLAGS
 
                 raise ValueError(
-                    f"Cannot resolve the intended filename "
-                    f"{subject.get_attribute('cereb_statsfile')} for the "
-                    f"cereb_statsfile, maybe specify an absolute path via "
-                    f"{ALL_FLAGS['cereb_statsfile'](dict)['flag']}."
+                    f"Cannot resolve the intended filename {subject.get_attribute('cereb_statsfile')} for the "
+                    f"cereb_statsfile, maybe specify an absolute path via {ALL_FLAGS['cereb_statsfile'](dict)['flag']}."
                 )
-            if not subject.has_attribute(
-                "norm_name"
-            ) or not subject.fileexists_by_attribute("norm_name"):
+            if not subject.has_attribute("norm_name") or not subject.fileexists_by_attribute("norm_name"):
                 from FastSurferCNN.utils.parser_defaults import ALL_FLAGS
 
                 raise ValueError(
-                    f"Cannot resolve the file name "
-                    f"{subject.get_attribute('norm_name')} for the bias field "
-                    f"corrected image, maybe specify an absolute path via "
-                    f"{ALL_FLAGS['norm_name'](dict)['flag']} or the file does not "
-                    f"exist."
+                    f"Cannot resolve the file name {subject.get_attribute('norm_name')} for the bias field corrected "
+                    f"image, maybe specify an absolute path via {ALL_FLAGS['norm_name'](dict)['flag']} or the file "
+                    f"does not exist."
                 )
 
             norm_file = subject.filename_by_attribute("norm_name")

--- a/CerebNet/run_prediction.py
+++ b/CerebNet/run_prediction.py
@@ -139,10 +139,7 @@ def main(args: argparse.Namespace) -> int | str:
 
     subjects_kwargs = {}
     cereb_statsfile = getattr(args, "cereb_statsfile", None)
-    if cereb_statsfile is None or str(cereb_statsfile) == "default":
-        cereb_statsfile = DEFAULT_CEREBELLUM_STATSFILE
-        args.cereb_statsfile = cereb_statsfile
-    if cereb_statsfile is not None:
+    if cereb_statsfile:
         subjects_kwargs["cereb_statsfile"] = "cereb_statsfile"
         if not hasattr(args, "norm_name"):
             return (

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -34,7 +34,7 @@ from FastSurferCNN.utils.common import SerialExecutor
 from HypVINN.config.hypvinn_files import HYPVINN_MASK_NAME, HYPVINN_SEG_NAME
 from HypVINN.data_loader.data_utils import hypo_map_label2subseg, rescale_image
 from HypVINN.inference import Inference
-from HypVINN.utils import ModalityDict, ModalityMode, ViewOperations
+from HypVINN.utils import ModalityDict, ModalityMode, ViewOperationDefinition, ViewOperations
 from HypVINN.utils.checkpoint import YAML_DEFAULT as CHECKPOINT_PATHS_FILE
 from HypVINN.utils.img_processing_utils import save_segmentation
 from HypVINN.utils.load_config import load_config
@@ -81,21 +81,15 @@ def option_parse() -> argparse.ArgumentParser:
     argparse.ArgumentParser
         The parser object to parse arguments from the command line.
     """
-    parser = argparse.ArgumentParser(
-        description="Script for Hypothalamus Segmentation.",
-    )
+    parser = argparse.ArgumentParser(description="Script for Hypothalamus Segmentation.")
 
     # 1. Directory information (where to read from, where to write from and to incl. search-tag)
-    parser = parser_defaults.add_arguments(
-        parser, ["sd", "sid"],
-    )
+    parser = parser_defaults.add_arguments(parser, ["sd", "sid"])
 
     parser = parser_defaults.add_arguments(parser, ["seg_log"])
 
     # 2. Options for the MRI volumes
-    parser = parser_defaults.add_arguments(
-        parser, ["t1"]
-    )
+    parser = parser_defaults.add_arguments(parser, ["t1"])
     parser.add_argument(
         '--t2',
         type=optional_path,
@@ -133,30 +127,14 @@ def option_parse() -> argparse.ArgumentParser:
 
     # 4. Options for advanced, technical parameters
     advanced = parser.add_argument_group(title="Advanced options")
-    parser_defaults.add_arguments(
-        advanced,
-        ["device", "viewagg_device", "threads", "batch_size", "async_io"],
-    )
+    parser_defaults.add_arguments(advanced, ["device", "viewagg_device", "threads", "batch_size", "async_io"])
 
     files: dict[Plane, str | Path] = {k: "default" for k in PLANES}
     # 5. Checkpoint to load
-    parser_defaults.add_plane_flags(
-        advanced,
-        "checkpoint",
-        files,
-        CHECKPOINT_PATHS_FILE,
-    )
+    parser_defaults.add_plane_flags(advanced, "checkpoint", files, CHECKPOINT_PATHS_FILE)
 
-    parser_defaults.add_plane_flags(
-        advanced,
-        "config",
-        {
-            "coronal": Path("HypVINN/config/HypVINN_coronal_v1.1.0.yaml"),
-            "axial": Path("HypVINN/config/HypVINN_axial_v1.1.0.yaml"),
-            "sagittal": Path("HypVINN/config/HypVINN_sagittal_v1.1.0.yaml"),
-        },
-        CHECKPOINT_PATHS_FILE,
-    )
+    config_files = {plane: Path(f"HypVINN/config/HypVINN_{plane}_v1.1.0.yaml") for plane in PLANES}
+    parser_defaults.add_plane_flags(advanced, "config", config_files, CHECKPOINT_PATHS_FILE)
     return parser
 
 
@@ -235,20 +213,16 @@ def main(
     device : str, default="auto"
         The device to use. Default is "auto", which automatically selects the device.
     viewagg_device : str, default="auto"
-        The view aggregation device to use. Default is "auto", which automatically 
-        selects the device.
+        The view aggregation device to use. Default is "auto", which automatically selects the device.
 
     Returns
     -------
     int, str
-        0, if successful, an error message describing the cause for the
-        failure otherwise.
+        0, if successful, an error message describing the cause for the failure otherwise.
     """
     from concurrent.futures import Future, ProcessPoolExecutor
-    if threads != 1:
-        pool = ProcessPoolExecutor(threads)
-    else:
-        pool = SerialExecutor()
+
+    pool = ProcessPoolExecutor(threads) if threads != 1 else SerialExecutor()
     prep_tasks: dict[str, Future] = {}
 
     # mapped freesurfer orig input name to the hypvinn t1 name
@@ -271,17 +245,14 @@ def main(
 
         if not mode:
             return (
-                f"Failed Evaluation on {subject_name} couldn't determine the "
-                f"processing mode. Please check that T1 or T2 images are "
-                f"available.\nT1 image path: {t1_path}\nT2 image path "
-                f"{t2_path}.\nNo T1 or T2 image available."
+                f"Failed Evaluation on {subject_name} couldn't determine the processing mode. Please check that T1 or "
+                f"T2 images are available.\nT1 image path: {t1_path}\nT2 image path {t2_path}.\nNo T1 or T2 image "
+                f"available."
             )
 
         # Create output directory if it does not already exist.
         create_expand_output_directory(subject_dir, qc_snapshots)
-        logger.info(
-            f"Running HypVINN segmentation pipeline on subject {sid}"
-        )
+        logger.info(f"Running HypVINN segmentation pipeline on subject {sid}")
         logger.info(f"Output will be stored in: {subject_dir}")
         logger.info(f"T1 image input {t1_path}")
         logger.info(f"T2 image input {t2_path}")
@@ -302,24 +273,23 @@ def main(
 
         # Segmentation pipeline
         seg = time()
-        view_ops: ViewOperations = {a: None for a in PLANES}
         logger.info("Setting up HypVINN run")
 
+        _view_ops: list[ViewOperationDefinition] = []
         cfgs = (cfg_ax, cfg_cor, cfg_sag)
         ckpts = (ckpt_ax, ckpt_cor, ckpt_sag)
         for plane, _cfg_file, _ckpt_file in zip(PLANES, cfgs, ckpts, strict=False):
             logger.info(f"{plane} model configuration from {_cfg_file}")
-            view_ops[plane] = {
-                "cfg": set_up_cfgs(_cfg_file, subject_dir, batch_size),
-                "ckpt": _ckpt_file,
-            }
-
-            model = view_ops[plane]["cfg"].MODEL
-            if mode != model.MODE and "HypVinn" not in model.MODEL_NAME:
-                raise AssertionError(
-                    f"Modality mode different between input arg: "
-                    f"{mode} and axial train cfg: {model.MODE}"
+            view_op = ViewOperationDefinition(
+                cfg=set_up_cfgs(_cfg_file, subject_dir, batch_size),
+                ckpt=_ckpt_file,
+            )
+            if mode != view_op["cfg"].MODEL.MODE and "HypVinn" not in view_op["cfg"].MODEL.MODEL_NAME:
+                return (
+                    f"Modality mode different between input arg {mode} and axial train cfg: {view_op['cfg'].MODEL.MODE}"
                 )
+            _view_ops.append(view_op)
+        view_ops: ViewOperations = {k: ops for k, ops in zip(PLANES, _view_ops)}
 
         cfg_fin, ckpt_fin = view_ops["coronal"].values()
 
@@ -456,9 +426,8 @@ def load_volumes(
     """
     Load the volumes of T1 and T2 images.
 
-    This function loads the T1 and T2 images, checks their compatibility based
-    on the mode, and returns the loaded volumes along with their affine
-    transformations, headers, zoom levels, and sizes.
+    This function loads the T1 and T2 images, checks their compatibility based on the mode, and returns the loaded
+    volumes along with their affine transformations, headers, zoom levels, and sizes.
 
     Parameters
     ----------
@@ -482,8 +451,7 @@ def load_volumes(
     Raises
     ------
     RuntimeError
-        If the mode is inconsistent with the provided image paths,
-        or if the number of dimensions of the data is invalid.
+        If the mode is inconsistent with the provided image paths or if the number of dimensions of the data is invalid.
     ValueError
         If the mode is invalid, or if a header is missing.
     AssertionError
@@ -624,8 +592,8 @@ def get_prediction(
 # Processing
 ##
 def set_up_cfgs(
-        cfg: "yacs.config.CfgNode",
-        out_dir: Path,
+        cfg_file: Path | str,
+        out_dir: Path | str,
         batch_size: int = 1,
 ) -> "yacs.config.CfgNode":
     """
@@ -636,9 +604,9 @@ def set_up_cfgs(
 
     Parameters
     ----------
-    cfg : yacs.config.CfgNode
+    cfg_file : Path, str
         The configuration node to load.
-    out_dir : Path
+    out_dir : Path, str
         The output directory where the results will be stored.
     batch_size : int, default=1
         The batch size to use. Default is 1.
@@ -647,15 +615,13 @@ def set_up_cfgs(
     -------
     yacs.config.CfgNode
         The loaded and adjusted configuration node.
-
     """
-    cfg = load_config(cfg)
-    cfg.OUT_LOG_DIR = str(out_dir or cfg.LOG_DIR)
+    cfg = load_config(cfg_file)
+    cfg.OUT_LOG_DIR = str(str(out_dir) or cfg.LOG_DIR)
     cfg.TEST.BATCH_SIZE = batch_size
 
     cfg.MODEL.OUT_TENSOR_WIDTH = cfg.DATA.PADDED_SIZE
     cfg.MODEL.OUT_TENSOR_HEIGHT = cfg.DATA.PADDED_SIZE
-
     return cfg
 
 
@@ -663,9 +629,9 @@ if __name__ == "__main__":
     # arguments
     parser = option_parse()
     args = vars(parser.parse_args())
-    log_name = (args["log_name"] or
-                args["out_dir"] / args["sid"] / "scripts/hypvinn_seg.log")
-    del args["log_name"]
+    log_name = args["log_name"] or (args["out_dir"] / args["sid"] / "scripts/hypvinn_seg.log")
+    if "log_name" in args:
+        del args["log_name"]
 
     from FastSurferCNN.utils.logging import setup_logging
     setup_logging(log_name)

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -289,7 +289,7 @@ def main(
                     f"Modality mode different between input arg {mode} and axial train cfg: {view_op['cfg'].MODEL.MODE}"
                 )
             _view_ops.append(view_op)
-        view_ops: ViewOperations = {k: ops for k, ops in zip(PLANES, _view_ops)}
+        view_ops: ViewOperations = {k: ops for k, ops in zip(PLANES, _view_ops, strict=False)}
 
         cfg_fin, ckpt_fin = view_ops["coronal"].values()
 

--- a/HypVINN/utils/__init__.py
+++ b/HypVINN/utils/__init__.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 from typing import Literal, TypedDict
 
-from yacs.config import CfgNode
 from numpy import ndarray
+from yacs.config import CfgNode
 
 from FastSurferCNN.utils import Plane
+
 
 class ViewOperationDefinition(TypedDict):
     cfg: CfgNode

--- a/HypVINN/utils/__init__.py
+++ b/HypVINN/utils/__init__.py
@@ -1,10 +1,16 @@
-from typing import Any, Literal, Optional
+from pathlib import Path
+from typing import Literal, TypedDict
 
+from yacs.config import CfgNode
 from numpy import ndarray
 
 from FastSurferCNN.utils import Plane
 
-ViewOperations = dict[Plane, dict[Literal["cfg", "ckpt"], Any] | None]
+class ViewOperationDefinition(TypedDict):
+    cfg: CfgNode
+    ckpt: Path
+
+ViewOperations = dict[Plane, ViewOperationDefinition | None]
 ModalityMode = Literal["t1", "t2", "t1t2"]
 ModalityDict = dict[Literal["t1", "t2"], ndarray]
 RegistrationMode = Literal["robust", "coreg", "none"]

--- a/HypVINN/utils/load_config.py
+++ b/HypVINN/utils/load_config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from os.path import join, split, splitext
+from pathlib import Path
 
 from HypVINN.config.hypvinn import get_cfg_hypvinn
 
@@ -49,13 +50,13 @@ def get_config(args):
 
     return cfg
 
-def load_config(cfg_file):
+def load_config(cfg_file: Path | str):
     """
     Load and initialize the configuration from a given file.
 
     Parameters
     ----------
-    cfg_file : str
+    cfg_file : Path, str
         The path to the configuration file. The function will load configurations from this file.
 
     Returns

--- a/HypVINN/utils/mode_config.py
+++ b/HypVINN/utils/mode_config.py
@@ -47,39 +47,26 @@ def get_hypinn_mode(
         If neither T1 nor T2 files exist, or if the corresponding flags were passed but the files do not exist.
     """
     LOGGER.info("Setting up input mode...")
-    if t1_path is not None and t2_path is not None:
-        if t1_path.is_file() and t2_path.is_file():
-            return "t1t2"
+    if t1_path and t2_path and t1_path.is_file() and t2_path.is_file():
+        return "t1t2"
+    elif t1_path and t2_path:
         msg = []
         if not t1_path.is_file():
             msg.append(f"the t1 file does not exist ({t1_path})")
         if not t2_path.is_file():
             msg.append(f"the t2 file does not exist ({t2_path})")
-        raise RuntimeError(
-            f"ERROR: Both the t1 and the t2 flags were passed, but "
-            f"{' and '.join(msg)}."
-        )
-
+        raise RuntimeError(f"Both the t1 and the t2 flags were passed, but {' and '.join(msg)}.")
+    elif t1_path and t1_path.is_file():
+        return "t1"
     elif t1_path:
-        if t1_path.is_file():
-            return "t1"
-        raise RuntimeError(
-            f"ERROR: The t1 flag was passed, but the t1 file does not exist "
-            f"({t1_path})."
+        raise RuntimeError(f"The t1 flag was passed, but the t1 file does not exist ({t1_path}).")
+    elif t2_path and t2_path.is_file():
+        LOGGER.info(
+            "Warning: T2 mode selected. The quality of segmentations based on only a T2 image is significantly "
+            "worse than when T1 images are included."
         )
+        return "t2"
     elif t2_path:
-        if t2_path.is_file():
-            LOGGER.info(
-                "Warning: T2 mode selected. The quality of segmentations based "
-                "on only a T2 image is significantly worse than when T1 images "
-                "are included."
-            )
-            return "t2"
-        raise RuntimeError(
-            f"ERROR: The t2 flag was passed, but the t1 file does not exist "
-            f"({t1_path})."
-        )
+        raise RuntimeError(f"The t2 flag was passed, but the t1 file does not exist ({t2_path}).")
     else:
-        raise RuntimeError(
-            "No t1 or t2 flags were passed, invalid configuration."
-        )
+        raise RuntimeError("No t1 or t2 flags were passed, invalid configuration.")

--- a/HypVINN/utils/preproc.py
+++ b/HypVINN/utils/preproc.py
@@ -73,80 +73,38 @@ def t1_to_t2_registration(
     if threads <= 0:
         threads = get_num_threads()
 
-    if registration_type == "coreg":
-        exe = shutil.which("mri_coreg")
-        if not bool(exe):
-            if os.environ.get("FREESURFER_HOME", ""):
-                exe = os.environ["FREESURFER_HOME"] + "/bin/mri_coreg"
-            else:
-                raise RuntimeError(
-                    "Could not find mri_coreg, source FreeSurfer or set the "
-                    "FREESURFER_HOME environment variable"
-                )
-        args = [exe, "--mov", t2_path, "--targ", t1_path, "--reg", lta_path]
-        args = list(map(str, args)) + ["--threads", str(threads)]
-        LOGGER.info("Running " + " ".join(args))
-        retval = Popen(args).finish()
-        if retval.retcode != 0:
-            LOGGER.error(f"mri_coreg failed with error code {retval.retcode}. ")
-            raise RuntimeError("mri_coreg failed registration")
-
-        else:
-            LOGGER.info(f"{exe} finished in {retval.runtime}!")
-            exe = shutil.which("mri_vol2vol")
-            if not bool(exe):
-                if os.environ.get("FREESURFER_HOME", ""):
-                    exe = os.environ["FREESURFER_HOME"] + "/bin/mri_vol2vol"
-                else:
-                    raise RuntimeError(
-                        "Could not find mri_vol2vol, source FreeSurfer or set "
-                        "the FREESURFER_HOME environment variable"
-                    )
-            args = [
-                exe,
-                "--mov", t2_path,
-                "--targ", t1_path,
-                "--reg", lta_path,
-                "--o", output_path,
-                "--cubic",
-                "--keep-precision",
-            ]
-            args = list(map(str, args))
-            LOGGER.info("Running " + " ".join(args))
-            retval = Popen(args).finish()
-            if retval.retcode != 0:
-                LOGGER.error(
-                    f"mri_vol2vol failed with error code {retval.retcode}."
-                )
-                raise RuntimeError("mri_vol2vol failed applying registration")
-            LOGGER.info(f"{exe} finished in {retval.runtime}!")
-    else:
-        exe = shutil.which("mri_robust_register")
-        if not bool(exe):
-            if os.environ.get("FREESURFER_HOME", ""):
-                exe = os.environ["FREESURFER_HOME"] + "/bin/mri_robust_register"
-            else:
-                raise RuntimeError(
-                    "Could not find mri_robust_register, source FreeSurfer or "
-                    "set the FREESURFER_HOME environment variable"
-                )
-        args = [
-            exe,
-            "--mov", t2_path,
-            "--dst", t1_path,
-            "--lta", lta_path,
-            "--mapmov", output_path,
-            "--cost NMI",
-        ]
-        args = list(map(str, args))
-        LOGGER.info("Running " + " ".join(args))
-        retval = Popen(args).finish()
-        if retval.retcode != 0:
-            LOGGER.error(
-                f"mri_robust_register failed with error code {retval.retcode}."
+    def from_freesurfer_home(fs_binary: str) -> str:
+        if not os.environ.get("FREESURFER_HOME", ""):
+            raise RuntimeError(
+                f"Could not find {fs_binary}, source FreeSurfer or set the FREESURFER_HOME environment variable"
             )
-            raise RuntimeError("mri_robust_register failed registration")
-        LOGGER.info(f"{exe} finished in {retval.runtime}!")
+        return os.environ["FREESURFER_HOME"] + "/bin/" + fs_binary
+
+    def run_fs_binary(fs_binary: str, args: list[str]) -> int:
+        fs_binary = shutil.which(fs_binary) or from_freesurfer_home(fs_binary)
+        args = [fs_binary] + list(map(str, args))
+        LOGGER.info("Running " + " ".join(args))
+        retval = Popen(args).finish()
+        if retval.retcode != 0:
+            LOGGER.error(f"{fs_binary} failed with error code {retval.retcode}.")
+            raise RuntimeError(f"{fs_binary} failed")
+
+        LOGGER.info(f"{fs_binary} finished in {retval.runtime}!")
+
+    if registration_type == "coreg":
+        run_fs_binary(
+            "mri_coreg",
+            ["--mov", t2_path, "--targ", t1_path, "--reg", lta_path, "--threads", str(threads)],
+        )
+        run_fs_binary(
+            "mri_vol2vol",
+            ["--mov", t2_path, "--targ", t1_path, "--reg", lta_path, "--o", output_path, "--cubic", "--keep-precision"],
+        )
+    else:
+        run_fs_binary(
+            "mri_robust_register",
+            ["--mov", t2_path, "--dst", t1_path, "--lta", lta_path, "--mapmov", output_path, "--cost", "NMI"],
+        )
 
     return output_path
 
@@ -167,8 +125,7 @@ def hypvinn_preproc(
     mode : ModalityMode
         The mode for HypVINN. It should be "t1t2".
     reg_mode : RegistrationMode
-        The registration mode. If it is not "none", the function will register T1 to T2
-        images.
+        The registration mode. If it is not "none", the function will register T1 to T2 images.
     t1_path : Path
         The path to the T1 image.
     t2_path : Path
@@ -176,8 +133,8 @@ def hypvinn_preproc(
     subject_dir : Path
         The directory of the subject.
     threads : int, default=-1
-        The number of threads to be used. If it is less than or equal to 0, the number
-        of threads will be automatically determined.
+        The number of threads to be used. If it is less than or equal to 0, the number of threads will be
+        automatically determined.
 
     Returns
     -------
@@ -187,13 +144,10 @@ def hypvinn_preproc(
     Raises
     ------
     RuntimeError
-        If the mode is not "t1t2", or if the registration mode is not "none" and the
-        registration fails.
+        If the mode is not "t1t2", or if the registration mode is not "none" and the registration fails.
     """
     if mode != "t1t2":
-        raise RuntimeError(
-            "hypvinn_preproc should only be called for t1t2 mode."
-        )
+        raise RuntimeError("hypvinn_preproc should only be called for t1t2 mode.")
     registered_t2_path = subject_dir / "mri/T2_nu_reg.mgz"
     if reg_mode != "none":
         from nibabel.analyze import AnalyzeImage
@@ -217,9 +171,7 @@ def hypvinn_preproc(
             registration_type=reg_mode,
             threads=threads,
         )
-        LOGGER.info(
-            f"Registration finish in {time.time() - load_res:0.4f} seconds!"
-        )
+        LOGGER.info(f"Registration finish in {time.time() - load_res:0.4f} seconds!")
     else:
         LOGGER.info(
             "No registration step, registering T1w and T2w is required when running "
@@ -227,10 +179,9 @@ def hypvinn_preproc(
             "predictions. Ignore this message, if input images are already registered."
         )
         try:
-            registered_t2_path.symlink_to(os.path.relpath(t2_path, registered_t2_path))
+            registered_t2_path.symlink_to(os.path.relpath(t2_path, registered_t2_path.parent))
         except FileNotFoundError as e:
-            msg = (f"Could not create symlink. "
-                   f"Does the folder {registered_t2_path.parent} exist?")
+            msg = f"Could not create symlink. Does the folder {registered_t2_path.parent} exist?"
             LOGGER.error(msg)
             raise FileNotFoundError(msg) from e
         except (RuntimeError, OSError):

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1016,8 +1016,8 @@ then
       fi
     else
       # no biasfield, but a t2 is passed; presumably, this is biasfield corrected
-      cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_strict_lia
-           --no_iso_vox --no_img_size "$t2" "$norm_name_t2")
+      cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_strict_lia --no_iso_vox --no_img_size
+           -i "$t2" -o "$norm_name_t2")
       {
         echo "INFO: Robustly rescaling $t2 to uchar ($norm_name_t2), which is"
         echo "  assumed to already be biasfield-corrected."


### PR DESCRIPTION
This PR fixes two issues with HypVINN. Issue 1 was reported by #673. Issue 2 was as of yet unreported, but concerned, the case of `--no_biasfield` given as a parameter to `run_fastsurfer.sh`.

- Fix the creation of the T2 symlink on regmode none
- Fix the arguments to conform, if --no_biasfield and T2 given
- Some formatting cleanup