### PR TITLE
Fix links to actions in quicktest workflow

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: docker/setup-buildx-action@v3
     - name: Recover freesurfer build image
       if: ${{ contains( inputs.freesurfer-build-image, 'fastsurfer-build:freesurfer') }}
-      uses: ./.github/actions/load-docker
+      uses: Deep-MI/FastSurfer/.github/actions/load-docker@dev
       with:
         docker-image: ${{ inputs.freesurfer-build-image }}
         target: build_freesurfer

--- a/.github/actions/load-processed/action.yml
+++ b/.github/actions/load-processed/action.yml
@@ -16,11 +16,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Recover processed files
-      uses: actions/download-artifact@v4
-      with:
-        name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}
-        path: /tmp/${{ inputs.subject-id }}.tar.gz
     - name: Load cached subject directory
       shell: bash
       run: |
@@ -29,9 +24,8 @@ runs:
           echo "The expected subject directory ${{ inputs.subjects-dir }}/${{ inputs.subject-id }} already exists!"
           exit 1
         fi
-        tar xf /tmp/${{ inputs.subject-id }}.tar.gz -C ${{ inputs.subjects-dir }}
-        rm -f /tmp/${{ inputs.subject-id }}.tar.gz
-        if [[ ! -d "${{ inputs.subjects-dir }}/${{ inputs.subject-id }}" ]] ; then
-          echo "The artifact did not contain the expected output directory ${{ inputs.subjects-dir }}/${{ inputs.subject-id }}!"
-          exit 1
-        fi
+    - name: Recover processed files
+      uses: actions/download-artifact@v4
+      with:
+        name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}
+        path: ${{ inputs.subjects-dir }}/${{ inputs.subject-id }}

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -63,27 +63,20 @@ runs:
           exit 1
         fi
         # Check if the docker needs to be loaded (fail if not)
-        if [[ -z "$(docker images -q "${{ inputs.docker-image }}")" ]] ; then di="0" ; else di="1" ; fi
-        echo "IMAGE_LOADED=$di" >> $GITHUB_OUTPUT
+        if [[ -z "$(docker images -q "${{ inputs.docker-image }}")" ]] ; then img_loaded="0" ; else img_loaded="1" ; fi
+        echo "IMAGE_LOADED=$img_loaded" >> $GITHUB_OUTPUT
         echo "::endgroup::"
     - name: Load the docker image
       if: steps.prep.outputs.IMAGE_LOADED == 0
       id: load-docker
-      uses: ./.github/actions/load-docker
+      uses: Deep-MI/FastSurfer/.github/actions/load-docker@dev
       with:
         docker-image: ${{ inputs.docker-image }}
-    - name: Reuse loaded image
-      if: steps.prep.outputs.IMAGE_LOADD != 0
-      id: load-docker
-      shell: bash
-      run: |
-        # populate image-name
-        echo "image-name=${{ inputs.docker-image }}" > $GITHUB_OUTPUT
     - name: FastSurfer Segmentation pipeline
       shell: bash
       if: ${{ ! contains( inputs.extra-args, '--surf_only' ) }}
       env:
-        IMAGE_NAME: ${{ steps.load-docker.outputs.image-name }}
+        IMAGE_NAME: ${{ steps.prep.outputs.IMAGE_LOADED == 0 && steps.load-docker.outputs.image-name || inputs.docker-image }}
       run: |
         # Segmentation call
         echo "::group::FastSurfer Segmentation"
@@ -95,7 +88,7 @@ runs:
       shell: bash
       if: ${{ ! contains( inputs.extra-args, '--seg_only' ) }}
       env:
-        IMAGE_NAME: ${{ steps.load-docker.outputs.image-name }}
+        IMAGE_NAME: ${{ steps.prep.outputs.IMAGE_LOADED == 0 && steps.load-docker.outputs.image-name || inputs.docker-image }}
       run: |
         # Surface pipeline call
         echo "::group::FastSurfer Surface reconstruction"
@@ -113,14 +106,14 @@ runs:
         if [[ "${{ contains( inputs.extra-args, '--surf_only' ) }}" == "0" ]] ; then docker container rm seg_container ; fi
         if [[ "${{ contains( inputs.extra-args, '--seg_only' ) }}" == "0" ]] ; then docker container rm surf_container ; fi
         echo "::endgroup::"
+        echo "::group::Save ${{ inputs.subject-id }} as an artifact"
     - name: Create archive of Processed subject-data
       shell: bash
       run: |
         # Archive data code
-        echo "::group::Save ${{ inputs.subject-id }} as an artifact"
         tar cfz "$DATA_DIR/${{ inputs.subject-id }}.tar.gz" -C "$DATA_DIR" "${{ inputs.subject-id }}"
     - name: Save processed data
       uses: actions/upload-artifact@v4
       with:
         name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}
-        path: ${{ env.DATA_DIR }}/${{ inputs.subject-id }}.tar.gz
+        path: ${{ env.DATA_DIR }}/${{ inputs.subject-id }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -59,7 +59,7 @@ runs:
         rm -f "$REF_DIR/ref-download-data"
         echo "::endgroup::"
     - name: Recover Case data
-      uses: ./.github/actions/load-processed
+      uses: Deep-MI/FastSurfer/.github/actions/load-processed@dev
       with:
         subject-id: ${{ inputs.subject-id }}
         subjects-dir: ${{ inputs.subjects-dir }}
@@ -70,6 +70,7 @@ runs:
         FASTSURFER_HOME: ${{ github.workspace }}
         REF_DIR: ${{ inputs.reference-dir }}
       shell: bash
+      continue-on-error: true  # pytest only exits with code 0, if all tests pass
       run: |
         echo "::group::Run tests"
         flags=("--junit-xml=${{ inputs.junit-file }}")

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -35,7 +35,20 @@ on:
         description: 'FreeSurfer build image to build with ("" (default) => deepmi/fastsurfer-build:freesurferXXX; extract version from Docker/install_fs_pruned.sh)'
         type: string
 
-permissions: read-all
+permissions:
+  actions: read
+  attestations: read
+  checks: write
+  contents: read
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: write
+  repository-projects: read
+  security-events: read
+  statuses: read
 
 env:
   SUBJECTS_DIR: /tmp/subjects
@@ -190,7 +203,7 @@ jobs:
           license: ${{ secrets.QUICKTEST_LICENSE }}
           docker-image: ${{ needs.build-docker.outputs.docker-image }}
           extra-args: ${{ matrix.extra-args }} ${{ needs.build-docker.outputs.extra-args }}
-          cleanup: 'true'
+          cleanup: 'false'
       - name: Run tests
         uses: Deep-MI/FastSurfer/.github/actions/run-tests@dev
         with:
@@ -216,3 +229,5 @@ jobs:
         with:
           report_paths: /tmp/fastsurfer-quicktest-*.junit.xml
           check_name: Annotate the test results as checks
+          fail_on_failure: 'true'
+          fail_on_parse_error: 'true'

--- a/test/quicktest/test_stats.py
+++ b/test/quicktest/test_stats.py
@@ -7,7 +7,8 @@ import pytest
 
 from FastSurferCNN.segstats import PVStats
 
-from .common import Approx, SubjectDefinition, Tolerances, write_table_file
+from .common import SubjectDefinition, Tolerances, write_table_file
+from .helper import Approx
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
- Previously, the links to actions were inconsistent (not always linking to the same version, which led to conflicts)
- Simplify the structure of processed subject directories (no double compression)
- Fix an import statement in test/quicktest

Tested interim version (that is also why this is in Deep-MI/FastSurfer).

The tests still fail, and are not fixed, but the workflow works now.