### PR TITLE
Update matplotlib

### DIFF
--- a/env/fastsurfer.yml
+++ b/env/fastsurfer.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - h5py==3.12.1
 - lapy==1.2.0
-- matplotlib==3.10.0
+- matplotlib==3.10.1
 - nibabel==5.3.2
 - numpy==1.26.4
 - pandas==2.2.3


### PR DESCRIPTION
Update matplotlib version to 3.10.1. The current version 3.10.0 has an issue on the alpha argument when overlaying images - this issue only affects the qc_screenshots from the hypothalamus module.


https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.10.1.html