### PR TITLE
Fixes so de-selecting views for processing for run_prediction is possible

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -262,7 +262,11 @@ class RunModelOnData:
             "sagittal": {"cfg": cfg_sag, "ckpt": ckpt_sag},
             "axial": {"cfg": cfg_ax, "ckpt": ckpt_ax},
         }
-        self.num_classes = max(view["cfg"].MODEL.NUM_CLASSES for view in self.view_ops.values())
+        # self.num_classes = max(view["cfg"].MODEL.NUM_CLASSES for view in self.view_ops.values() if view["cfg"])
+        # currently, num_classes must be 79 in all cases. This seems like it is a config option here, but in reality it
+        # is not, so we hard-code it here. Only sagittal has < 79 classes, but num_classes is only used to set the
+        # dimensions of the view aggregation tensor, which is after splitting the classes from sagittal to all.
+        self.num_classes = 79
         self.models = {}
         for plane, view in self.view_ops.items():
             if all(view[key] is not None for key in ("cfg", "ckpt")):

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -45,8 +45,8 @@ from FastSurferCNN.utils.threads import get_num_threads
 FASTSURFER_ROOT = Path(__file__).parents[2]
 PLANE_SHORT = {"checkpoint": "ckpt", "config": "cfg"}
 PLANE_HELP = {
-    "checkpoint": "{} checkpoint to load",
-    "config": "Path to the {} config file",
+    "checkpoint": "{} checkpoint to load.",
+    "config": "Path to the {} config file ('none' deactivates the view).",
 }
 
 
@@ -423,6 +423,9 @@ def add_plane_flags(
     if configtype not in PLANE_SHORT:
         raise ValueError("type must be either config or checkpoint.")
 
+    def cast_type(__value: str) -> Path | None:
+        return None if configtype == "config" and (not bool(__value) or __value.lower() == "none") else Path(__value)
+
     from FastSurferCNN.utils.checkpoint import load_checkpoint_config_defaults
     defaults = load_checkpoint_config_defaults(configtype, defaults_path)
 
@@ -438,7 +441,7 @@ def add_plane_flags(
         plane_short = plane[: index + 2]
         parser.add_argument(
             f"--{PLANE_SHORT[configtype]}_{plane_short}",
-            type=Path,
+            type=cast_type,
             dest=f"{PLANE_SHORT[configtype]}_{plane_short}",
             help=PLANE_HELP[configtype].format(plane),
             default=path,


### PR DESCRIPTION
Modify run_prediction so the user is able to "deselect" views to not include.

Details:
- parser_defaults.py: Allow empty or none for --cfg_ax, --cfg_sag, --cfg_cor.
- run_prediction.py: If cgf_ax/sag/cor is none/empty, do not use that view

This is also Step 1 for #659, but it is also usefull in some anisotropic voxelsizes settings.