### PR TITLE
Bugfixes before release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 checkpoints
 Singularity
 doc
+test
 venv
 Tutorial
 **/*.md

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -144,7 +144,8 @@ FROM $CONDA_BUILD_IMAGE AS selected_conda_build_image
 # =========================================
 FROM $RUNTIME_BASE_IMAGE AS runtime
 
-ENV LANG=C.UTF-8
+ENV LANG=C.UTF-8 \
+    LC_NUMERIC=en_US.UTF-8
 
 # Install required packages for freesurfer to dry_run
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -455,11 +455,8 @@ def map_image(
             ornt = nib.orientations.io_orientation(vox2vox)
             new_old_index = list(enumerate(map(int, ornt[:, 0])))
             # if the direction is flipped (ornt[j, 1] == -1), offset has to start at the other end
-            offsets = [ornt[j, 1] * vox2vox[i, 3] + (ornt[j, 1] == -1) * out_shape[i] for i, j in new_old_index]
+            offsets = [ornt[j, 1] * vox2vox[i, 3] + (ornt[j, 1] == -1) * img.shape[j] for i, j in new_old_index]
             offsets = list(map(lambda x: int(x.astype(int)), offsets))
-            LOGGER.debug(f"no interp: offsets {offsets}, ornt {ornt}, shape {out_shape}")
-            LOGGER.debug(f"in center {np.asarray(image_data.shape) / 2}")
-            LOGGER.debug(f"out center {np.asarray(out_shape) / 2}")
             reordered = apply_orientation(image_data, ornt)
             # pad=0 => pad with zeros
             return crop_transform(reordered, offsets=offsets, target_shape=out_shape, pad=0)
@@ -817,20 +814,22 @@ def prepare_mgh_header(
     # nibabel only copies header information, if the file type is the same (here, this would be only of mgh header)
     source_img_shape = img.header.get_data_shape()
     source_vox_size = img.header.get_zooms()
+
+    source_mdc = img.affine[:3, :3] / np.linalg.norm(img.affine[:3, :3], axis=0, keepdims=True)
     # native
     if orientation == "native":
         re_order_axes = [0, 1, 2]
-        rot_scale_mat = img.affine[:3, :3]
+        mdc_affine = np.linalg.inv(source_mdc)
     else:
         _ornt_transform, _ = orientation_to_ornts(img.affine, orientation[-3:])
         re_order_axes = _ornt_transform[:, 0]
         if len(orientation) == 3:  # lia, ras, etc
             # this is a 3x3 matrix
             out_ornt = nib.orientations.axcodes2ornt(orientation[-3:].upper())
-            rot_scale_mat = nib.orientations.inv_ornt_aff(out_ornt, source_img_shape)[:3, :3]
+            mdc_affine = nib.orientations.inv_ornt_aff(out_ornt, source_img_shape)[:3, :3]
         else: # soft lia, ras, ....
-            aff = _ornt_transform[:, 1][None] * img.affine[:3, :3]
-            rot_scale_mat = np.stack([aff[:3, int(ax)] for ax in _ornt_transform[:, 0]], axis=-1)
+            aff = _ornt_transform[:, 1][None] * source_mdc
+            mdc_affine = np.stack([aff[:3, int(ax)] for ax in _ornt_transform[:, 0]], axis=-1)
 
     shape: list[int] = [(source_img_shape if target_img_size is None else target_img_size)[i] for i in re_order_axes]
     h1.set_data_shape(shape + [1])
@@ -838,7 +837,7 @@ def prepare_mgh_header(
     # --> h1['delta']
     h1.set_zooms([(target_vox_size if target_vox_size is not None else source_vox_size)[i] for i in re_order_axes])
 
-    h1["Mdc"] = rot_scale_mat.T / np.linalg.norm(rot_scale_mat, axis=1)
+    h1["Mdc"] = mdc_affine
     # fov should only be defined, if the image has same fov in all directions? fov == one number
     _fov = np.asarray([i * v for i, v in zip(h1.get_data_shape(), h1.get_zooms(), strict=False)])
     if _fov.min() == _fov.max():
@@ -847,9 +846,12 @@ def prepare_mgh_header(
     center = np.asarray(img.shape[:3], dtype=float) / 2.0
     h1["Pxyz_c"] = img.affine.dot(np.hstack((center, [1.0])))[:3]
     # There is a special case here, where an interpolation is triggered, but it is not necessary, if the position of
-    # the center could "fix this" condition: 1. no rotation, no vox-size resampling,
+    # the center could "fix this" condition:
     vox2vox = np.linalg.inv(h1.get_affine()) @ img.affine
-    if not does_vox2vox_rot_require_interpolation(vox2vox, vox_eps=vox_eps, rot_eps=rot_eps):
+    if does_vox2vox_rot_require_interpolation(vox2vox, vox_eps=vox_eps, rot_eps=rot_eps):
+        # 1. has rotation, or vox-size resampling => requires resampling
+        pass
+    else:
         # 2. img_size changes from odd to even and vice versa
         #    i.e. can changing the RAS center make an interpolation unnecessary?
         vec = np.linalg.inv(vox2vox)[:3, 3]
@@ -973,15 +975,6 @@ def is_conform(
         "Number of Dimensions 3": (img.ndim == 3, f"image ndim {img.ndim}")
     }
 
-    # check dimensions
-    img_size_text = f"image dimensions {img.shape}"
-    if img_size in (None, "fov") or _img_size is None:
-        img_size_criteria = f"Dimensions {img_size}"
-        checks[img_size_criteria] = "IGNORED", img_size_text
-    else:
-        img_size_criteria = f"Dimensions {img_size}={'x'.join(map(str, _img_size[:3]))}"
-        checks[img_size_criteria] = np.array_equal(np.asarray(img.shape[:3]), _img_size), img_size_text
-
     # check voxel size, drop voxel sizes of dimension 4 if available
     izoom = np.array(img.header.get_zooms())
     vox_size_text = f"image {'x'.join(map(str, izoom))}"
@@ -992,6 +985,15 @@ def is_conform(
             raise TypeError("_vox_size should be numpy.ndarray here")
         vox_size_criteria = f"Voxel Size {vox_size}={'x'.join(map(str, _vox_size))}"
         checks[vox_size_criteria] = np.allclose(izoom[:3], _vox_size, atol=vox_eps, rtol=0), vox_size_text
+
+    # check dimensions
+    img_size_text = f"image dimensions {img.shape}"
+    if img_size in (None, "fov") or _img_size is None:
+        img_size_criteria = f"Dimensions {img_size}"
+        checks[img_size_criteria] = "IGNORED", img_size_text
+    else:
+        img_size_criteria = f"Dimensions {img_size}={'x'.join(map(str, _img_size[:3]))}"
+        checks[img_size_criteria] = np.array_equal(np.asarray(img.shape[:3]), _img_size), img_size_text
 
     # check orientation LIA
     affcode = "".join(nib.orientations.aff2axcodes(img.affine))
@@ -1168,7 +1170,7 @@ def conformed_vox_img_size(
     elif isinstance(img_size, int) and img_size > 0:
         target_img_size = np.full((3,), img_size)
     elif isinstance(img_size, str) and (img_size := img_size.lower()) in ["fov", "auto"]:
-        thres = threshold_1mm or 0.
+        thres = abs(1.0 - (threshold_1mm or 1.0))
         if target_vox_size is not None and np.allclose(target_vox_size, 1.0, atol=thres) and img_size == "auto":
             target_img_size = np.full((3,), MAX_DIMENSION)
         # (other voxel sizes may use different sizes)

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -148,11 +148,8 @@ def load_image(
     try:
         img = cast(nib.analyze.SpatialImage, nib.load(file, **kwargs))
     except (OSError, FileNotFoundError) as e:
-        raise OSError(
-            f"Failed loading the {name} '{file}' with error: {e.args[0]}"
-        ) from e
-    data = np.asarray(img.dataobj)
-    return img, data
+        raise OSError(f"Failed loading the {name} '{file}' with error: {e.args[0]}") from e
+    return img, np.asarray(img.dataobj)
 
 
 def load_maybe_conform(

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -274,8 +274,9 @@ class RunModelOnData:
 
         try:
             self.vox_size = _vox_size(vox_size)
-        except argparse.ArgumentParser:
-            raise ValueError(f"Invalid value for vox_size, must be between 0 and 1 or 'min', was {vox_size}.") from None
+        except (argparse.ArgumentTypeError, ValueError):
+            condition = "convertible to a float between 0 and 1 or 'min'"
+            raise ValueError(f"Invalid value for vox_size, must be {condition}, was '{vox_size}'.") from None
         self.conform_to_1mm_threshold = conform_to_1mm_threshold
 
     @property
@@ -300,7 +301,7 @@ class RunModelOnData:
             "threshold_1mm": self.conform_to_1mm_threshold,
             "vox_size": self.vox_size,
             "orientation": self.orientation,
-            "img_size": "fov",
+            "img_size": self.image_size,
         }, **kwargs)
 
     def conform_and_save_orig(
@@ -323,7 +324,7 @@ class RunModelOnData:
         LOGGER.info(f"Successfully loaded image from {subject.orig_name}.")
 
         # Save input image to standard location, but only
-        if subject.can_resolve_attribute("copy_orig_name"):
+        if subject.has_attribute("copy_orig_name") and subject.can_resolve_attribute("copy_orig_name"):
             self.async_save_img(subject.copy_orig_name, orig_data, orig, orig_data.dtype)
 
         if not is_conform(orig, **self.__conform_kwargs(verbose=True)):
@@ -383,10 +384,8 @@ class RunModelOnData:
         }
 
         if not np.allclose(_zoom := np.asarray(zoom), np.mean(zoom), atol=1e-4, rtol=1e-3):
-            LOGGER.warning(
-                f"FastSurfer support for anisotropic images is experimental, we detected the following voxel sizes: "
-                f"{_zoom.tolist()}!"
-            )
+            msg = "FastSurfer support for anisotropic images is experimental, we detected the following voxel sizes"
+            LOGGER.warning(f"{msg}: {np.round(_zoom, decimals=4).tolist()}!")
 
         orig_in_lia, back_to_native = to_target_orientation(orig_data, affine, target_orientation="LIA")
         shape = orig_in_lia.shape + (self.get_num_classes(),)
@@ -631,15 +630,14 @@ def main(
         remove_suffix=remove_suffix,
         out_dir=out_dir,
     )
-    config.copy_orig_name = "mri/orig/001.mgz"
+    slist_kwargs = {"segfile": "pred_name"}
+    if out_dir is not None and out_dir != Path(""):
+        config.copy_orig_name = "mri/orig/001.mgz"
+        slist_kwargs["copy_orig_name"] = "copy_orig_name"
 
     try:
         # Get all subjects of interest
-        subjects = SubjectList(
-            config,
-            segfile="pred_name",
-            copy_orig_name="copy_orig_name",
-        )
+        subjects = SubjectList(config, **slist_kwargs)
         subjects.make_subjects_dir()
 
         # Set Up Model

--- a/FastSurferCNN/utils/arg_types.py
+++ b/FastSurferCNN/utils/arg_types.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 from itertools import permutations, product
 from typing import Literal, cast
 
@@ -26,7 +25,7 @@ __axcode = ("rl", "ap", "si")
 __orders = tuple(permutations(range(3)))
 __flips = ((0, 1),) * 3
 ORIENTATIONS = ["".join(__axcode[ii[i]][j] for i, j in enumerate(k)) for ii, k in product(__orders, product(*__flips))]
-VALID_ORIENTATIONS = ["native", *map(lambda x: "soft " + x, ORIENTATIONS), *ORIENTATIONS]
+VALID_ORIENTATIONS = ["native", *map(lambda x: "soft-" + x, ORIENTATIONS), *ORIENTATIONS]
 
 StrictOrientationType = str
 OrientationType = str
@@ -44,23 +43,23 @@ def orientation(a: str) -> OrientationType:
     Parameters
     ----------
     a : str
-        Target orientation type, handles cases.
+        Target orientation type, case-insensitive.
 
     Returns
     -------
     str
-        One of 'native', 'soft <orientation>', or '<orientation>'.
+        One of 'native', 'soft-<orientation>', or '<orientation>'.
 
     Raises
     ------
-    argparse.ArgumentTypeError
-        If the argument is not a valid choice.
+    ValueError
+        If the argument is not a valid orientation.
     """
-    r = a.lower().replace("_", " ").replace("-", " ").strip()
+    r = a.lower().replace("_", "-").replace(" ", "-").strip()
     if r in VALID_ORIENTATIONS:
         return cast(OrientationType, r)
-    valid_orientations = "'native', 'soft-<orientation>', or '<orientation>'"
-    raise argparse.ArgumentTypeError(f"'{a}' is not a valid orientation from {valid_orientations}.") from None
+    valid_orientations_short = "'native', 'soft-<orientation>', or '<orientation>'"
+    raise ValueError(f"'{a}' is not a valid orientation from {valid_orientations_short}.") from None
 
 
 def string_to_bool(a: str) -> bool:
@@ -77,15 +76,17 @@ def string_to_bool(a: str) -> bool:
     bool
         If a is "on", "true", "yes", "y", "1" (case-insensitive).
     """
+    if not isinstance(a, str):
+        return bool(a)
     return a.lower() in ("on", "true", "yes", "y", "1")
 
-def vox_size(a: str) -> VoxSizeOption | None:
+def vox_size(a: str | float | None) -> VoxSizeOption | None:
     """
     Convert the vox_size argument to 'min' or a valid voxel size.
 
     Parameters
     ----------
-    a : str
+    a : str, float, None
         Vox size type. Can be auto, min or a number between 1 an 0.
 
     Returns
@@ -97,17 +98,17 @@ def vox_size(a: str) -> VoxSizeOption | None:
 
     Raises
     ------
-    argparse.ArgumentTypeError
+    ValueError
         If the argument is not "min", "auto" or convertible to a float between 0 and 1.
     """
-    if a is None or a.lower() == "any":
+    if a is None or isinstance(a, str) and a.lower() == "any":
         return None
-    if a.lower() in ["auto", "min"]:
+    if isinstance(a, str) and a.lower() in ["auto", "min"]:
         return "min"
     try:
         return float_gt_zero_and_le_one(a)
-    except argparse.ArgumentError as e:
-        raise argparse.ArgumentTypeError(e.args[0] + " Additionally, vox_sizes may be 'min'.") from None
+    except ValueError as e:
+        raise ValueError(e.args[0] + " Additionally, vox_size may be 'min'.") from None
 
 def img_size(a: str) -> ImageSizeOption | None:
     """
@@ -127,7 +128,7 @@ def img_size(a: str) -> ImageSizeOption | None:
 
     Raises
     ------
-    argparse.ArgumentTypeError
+    ValueError
         If the argument is not "fov", "auto" or convertible to an int greater than 0.
     """
     if a.lower() in ("auto", "fov"):
@@ -136,17 +137,17 @@ def img_size(a: str) -> ImageSizeOption | None:
         return None
     try:
         return int_gt_zero(a)
-    except argparse.ArgumentError as e:
-        raise argparse.ArgumentTypeError(e.args[0] + " Additionally, img_sizes may be 'fov'.") from None
+    except ValueError as e:
+        raise ValueError(e.args[0] + " Additionally, img_size may be 'fov'.") from None
 
 
-def float_gt_zero_and_le_one(a: str) -> float | None:
+def float_gt_zero_and_le_one(a: str | float) -> float | None:
     """
     Check whether a parameters are a float between 0 and one.
 
     Parameters
     ----------
-    a : str
+    a : str, float
         String of a number or none, infinity.
 
     Returns
@@ -157,16 +158,16 @@ def float_gt_zero_and_le_one(a: str) -> float | None:
 
     Raises
     ------
-    argparse.ArgumentTypeError
+    ValueError
         If `a` is neither a float between 0 and 1.
     """
-    if a is None or a.lower() in ["none", "infinity"]:
+    if a is None or isinstance(a, str) and a.lower() in ["none", "infinity"]:
         return None
     a_float = float(a)
     if 0.0 < a_float <= 1.0:
         return a_float
     else:
-        raise argparse.ArgumentTypeError(f"'{a}' is not between 0 and 1.")
+        raise ValueError(f"'{a}' is not between 0 and 1.")
 
 
 def target_dtype(a: str) -> str:
@@ -185,8 +186,8 @@ def target_dtype(a: str) -> str:
 
     Raises
     ------
-    argparse.ArgumentTypeError
-        Invalid dtype.
+    ValueError
+        If the dtype is invalid.
 
     See Also
     --------
@@ -201,13 +202,13 @@ def target_dtype(a: str) -> str:
     msg = "The following dtypes are verified: " + ", ".join(dtypes)
     if np.dtype(_a).name == _a:
         # numpy recognizes the dtype, but nibabel probably does not.
-        print(
-            f"WARNING: While numpy recognizes the dtype {a}, nibabel might not and this might lead to compatibility "
-            f"issues. {msg}"
-        )
+        from logging import getLogger
+
+        warnmsg = f"While numpy recognizes the dtype {a}, nibabel might not leading to compatibility issues. "
+        getLogger(__name__).warning(warnmsg + msg)
         return _a
     else:
-        raise argparse.ArgumentTypeError(f"Invalid dtype {a}. {msg}")
+        raise ValueError(f"Invalid dtype {a}. {msg}")
 
 
 def int_gt_zero(value: str | int) -> int:
@@ -226,12 +227,12 @@ def int_gt_zero(value: str | int) -> int:
 
     Raises
     ------
-    argparse
-        ArgumentTypeError: Invalid value, must not be negative.
+    ValueError
+        Invalid value, must not be negative.
     """
     val = int(value)
     if val <= 0:
-        raise argparse.ArgumentTypeError("Invalid value, must not be negative.")
+        raise ValueError("Invalid value, must not be negative.")
     return val
 
 
@@ -251,16 +252,16 @@ def int_ge_zero(value: str) -> int:
 
     Raises
     ------
-    argparse
-        ArgumentTypeError: Invalid value, must be greater than 0.
+    ValueError
+        Invalid value, must be greater than 0.
     """
     val = int(value)
     if val < 0:
-        raise argparse.ArgumentTypeError("Invalid value, must be greater than 0.")
+        raise ValueError("Invalid value, must be greater than 0.")
     return val
 
 
-def unquote_str(value) -> str:
+def unquote_str(value: str) -> str:
     """
     Unquote a (single quoted) string, i.e. remove one level of single-quotes.
 

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -292,7 +292,8 @@ ALL_FLAGS = {
         help="Choose the primary voxelsize to process, must be either a number between 0 and 1 (below 0.7 is "
              "experimental) or 'min' (default). A number forces processing at that specific voxel size, 'min' "
              "determines the voxel size from the image itself (conforming to the minimum voxel size, or 1 if the "
-             "minimum voxel size is above 0.95mm). ",
+             "minimum voxel size is above 0.95mm). 'any' will try to keep the voxel size unchanged (even anisotropic, "
+             "which is experimental).",
     ),
     "orientation": __arg(
         "--orientation",
@@ -385,9 +386,7 @@ def add_arguments(parser: T_AddArgs, flags: Iterable[str]) -> T_AddArgs:
         if add_flag is not None:
             add_flag(parser)
         else:
-            raise ValueError(
-                f"The flag '{flag}' is not defined in {add_arguments.__qualname__}."
-            )
+            raise ValueError(f"The flag '{flag}' is not defined in {add_arguments.__qualname__}.")
     return parser
 
 

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -11,7 +11,7 @@ if FSTIME_LOAD=0 "${binpath}fs_time" echo testing &> /dev/null ; then timecmd="$
 else timecmd="" ; echo "INFO: Testing fs_time was not successful, not reporting per-command runtimes."
 fi
 export timecmd
-export LC_NUMERIC="en_US.UTF-8"
+if [[ "$LC_NUMERIC" != "en_US.UTF-8" ]] ; then export LC_NUMERIC="en_US.UTF-8" ; fi
 
 function check_create_subjects_dir_properties()
 {
@@ -188,6 +188,7 @@ function softlink_or_copy()
   local LF="$3"
   local ln_cmd=(ln -sf "$1" "$2")
   local cp_cmd=(cp "$1" "$2")
+  if [[ $# -lt 3 ]] || [[ -z "$LF" ]] ; then echo "WARNING: Parameter 3 of softlink_or_copy missing!" ; fi
   if [[ $# -eq 4 ]]
   then
     local CMDF=$4

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1012,7 +1012,7 @@ then
         exit 1
       fi
       # create a symlink of the stats file for the old file name
-      softlink_or_copy "$asegdkt_vinn_statsfile" "$asegdkt_statsfile"
+      softlink_or_copy "$asegdkt_vinn_statsfile" "$asegdkt_statsfile" "$seg_log"
       # create the aseg only statsfile
       mask_name_manedit=$(add_file_suffix "$mask_name" "manedit")
       if [[ -e "$mask_name_manedit" ]] ; then mask_name="$mask_name_manedit" ; fi


### PR DESCRIPTION
This PR fixes several bugs that came up and were resolved during release testing and further review.

Fix the usage of `nibabel.orientations.ornt_transform` after clarification. https://github.com/nipy/nibabel/issues/1418

Fix Argument-Type related bugs.
- "soft LIA" to "soft-LIA"
- ArgumentTypeError to ValueError
- vox_size can accept a float in addition to a str
- fix image_size default value overwriting passed value
- remove test from Docker
- reorder vox_size and image_size check in is_conform so their order in output is swapped
- set LANG to en_US in Dockerfile
- fix image position when cropping with crop_transform
- only reset LC_NUMERIC in recon_surf/functions, if LC_NUMERIC is not en_US