### PR TITLE
Add workaround for SSL certificate mismatch error with mamba/conda at DZNE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /BUILD.info
 /Docker/BUILD.info
+/Docker/custom-ssl.crt
 /.idea/**
 /rough_work/**
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG FORGE_VERSION=24.11.2-1
+ARG FORGE_VERSION=25.3.1-0
 
 # Install conda
 RUN wget --no-check-certificate -qO ~/miniforge.sh \
@@ -86,34 +86,31 @@ ENV PATH=/opt/miniforge/bin:$PATH
 FROM build_base AS build_common
 
 # get install scripts into docker
-COPY ./env/fastsurfer.yml ./Docker/conda_pack.sh ./Docker/install_env.py /install/
+ARG MAMBA_SSL_CERTIFICATE=""
+COPY ./env/fastsurfer.yml ./Docker/conda_pack.sh ./Docker/install_env.py ${MAMBA_SSL_CERTIFICATE} /install/
 
-# SHELL ["/bin/bash", "--login", "-c"]
+SHELL ["/bin/bash", "--login", "-c", "-e"]
 # Install conda for gpu
 
+ARG MAMBA_SSL_VERIFY=""
 ARG DEBUG=false
-RUN python /install/install_env.py -m base -i /install/fastsurfer.yml \
-      -o /install/base-env.yml && \
-    mamba env create -qy -f "/install/base-env.yml" | tee /install/env-create.log ; \
-    if [ "${DEBUG}" != "true" ]; then \
-      rm /install/base-env.yml ; \
-    fi
+ENV PIP_ROOT_USER_ACTION=ignore
+RUN python /install/install_env.py -m base -i /install/fastsurfer.yml -o /install/base-env.yml && \
+    mamba env create -qy -f "/install/base-env.yml" $([ "$DEBUG" == "true" ] && echo "-vvv") \
+      | tee /install/env-create.log ; \
+    if [ "${DEBUG}" != "true" ]; then rm /install/base-env.yml ; fi
 
 FROM build_common AS build_conda
 
 ARG DEBUG=false
 ARG DEVICE=cu118
 # install additional packages for cuda/rocm/cpu
-RUN python /install/install_env.py -m ${DEVICE} -i /install/fastsurfer.yml \
-      -o /install/${DEVICE}-env.yml && \
-    mamba env update -q -n "fastsurfer" -f "/install/${DEVICE}-env.yml" \
+RUN python /install/install_env.py -m ${DEVICE} -i /install/fastsurfer.yml -o /install/${DEVICE}-env.yml && \
+    mamba env update -qy -n "fastsurfer" -f "/install/${DEVICE}-env.yml" $([ "$DEBUG" == "true" ] && echo "-vvv") \
       | tee /install/env-update.log && \
     /install/conda_pack.sh "fastsurfer" && \
-    echo "DEBUG=$DEBUG\nDEVICE=$DEVICE\n" > /install/build_conda.args ;  \
-    if [ "${DEBUG}" != "true" ]; then \
-      mamba env remove -qy -n "fastsurfer" && \
-      rm -R /install ; \
-    fi
+    echo "DEBUG=$DEBUG\nDEVICE=$DEVICE\n" > /install/build_conda.args ; \
+    if [ "${DEBUG}" != "true" ]; then mamba env remove -qy -n "fastsurfer" && rm -R /install ; fi
 
 # create a stage for pruned Freesurfer
 FROM build_base AS build_freesurfer
@@ -126,9 +123,9 @@ ARG FREESURFER_URL=default
 
 # install freesurfer and point to new python location
 RUN /install/install_fs_pruned.sh /opt --upx --url $FREESURFER_URL && \
-rm /opt/freesurfer/bin/fspython &&  \
-rm -R /install && \
-ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
+    rm /opt/freesurfer/bin/fspython && \
+    rm -R /install && \
+    ln -s /venv/bin/python3 /opt/freesurfer/bin/fspython
 
 
 # =======================================================

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -116,7 +116,6 @@ docker run --gpus all -v /home/user/my_mri_data:/data \
 In order to build the docker image for FastSurfer (FastSurferCNN + recon-surf; on CPU; including FreeSurfer) simply go to the parent directory (FastSurfer) and execute the docker build command directly:
 
 ```bash
-PYTHONPATH=<FastSurferRoot>
 python build.py --device cpu --tag my_fastsurfer:cpu
 ```
 
@@ -142,7 +141,6 @@ your host machine kernel (`amdgpu-install --usecase=dkms`) for the amd docker to
 https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html#rocm-install-quick, https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/amdgpu-install.html#amdgpu-install-dkms and https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
 
 ```bash
-PYTHONPATH=<FastSurferRoot>
 python build.py --device rocm --tag my_fastsurfer:rocm
 ```
 
@@ -205,6 +203,14 @@ To build a docker image with attestation and provenance, i.e. Software Bill Of M
       ```
       Also note, that the image storage location with containerd is not defined by the docker config file `/etc/docker/daemon.json`, but by the containerd config `/etc/containerd/config.toml`, which will likely not exist. You can [create a default config](https://github.com/containerd/containerd/blob/main/docs/getting-started.md#customizing-containerd) file with `containerd config default > /etc/containerd/config.toml`, in this config file edit the `"root"`-entry (default value is `/var/lib/containerd`).  
 4. Finally, you can now build the FastSurfer image with `python Docker/build.py ... --attest`. This will add the additional flags to the docker build command.
+
+## Setting the ssl_verify parameter of mamba
+
+The `build.py` script supports the `--ssl_verify` flag, which can be passed `"False"` or the path to an alternative root certificate.
+
+```bash
+python build.py --device cpu --tag my_fastsurfer:cpu --ssl_verify /path/to/custom-cert.srt
+```
 
 ## Building for release
 

--- a/Docker/build.py
+++ b/Docker/build.py
@@ -320,15 +320,17 @@ def make_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="enables the DEBUG build flag.",
     )
-    default_ssl_verify = lambda x: os.environ.get("MAMBA_SSL_VERIFY", os.environ.get("CONDA_SSL_VERIFY", x))
+
+    def _default_ssl_verify(x):
+        return os.environ.get("MAMBA_SSL_VERIFY", os.environ.get("CONDA_SSL_VERIFY", x))
     expert.add_argument(
         "--ssl_verify",
         type=_validate_ssl_verify,
-        default=default_ssl_verify(True),
+        default=_default_ssl_verify(True),
         metavar="{True,False,<path>}",
         help="ssl certificate to use for condaforge, from None/False (ignore), True (default system certificate), or a "
              "certificate file path (defaults to the value of the MAMBA_SSL_VERIFY (or CONDA_SSL_VERIFY) environment "
-             f"variable, here: {default_ssl_verify('True (neither set)')}).",
+             f"variable, here: {_default_ssl_verify('True (neither set)')}).",
     )
     return parser
 
@@ -673,7 +675,7 @@ def main(
     #    kwargs["build_arg"] = " ".join(kwargs["build_arg"])
     if ssl_verify is not True:
         if ssl_verify is False:
-            kwargs["build_arg"].append(f"MAMBA_SSL_VERIFY=<false>")
+            kwargs["build_arg"].append("MAMBA_SSL_VERIFY=<false>")
         else:
             _ssl_cert = "./Docker/custom-ssl.crt"
             if (fastsurfer_home / _ssl_cert).exists():

--- a/Docker/build.py
+++ b/Docker/build.py
@@ -174,6 +174,15 @@ class CacheSpec:
     __repr__ = format_cache_from
 
 
+def _validate_ssl_verify(value) -> Path | bool:
+    """Validate the SSL certificate value from false/none/true/path to certificate."""
+    if value.lower() in ("false", "<false>", "none"):
+        return False
+    elif value.lower() in ("true", "<true>"):
+        return True
+    return Path(value)
+
+
 def make_parser() -> argparse.ArgumentParser:
     try:
         from FastSurferCNN.segstats import HelpFormatter
@@ -226,12 +235,10 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--cache",
         type=CacheSpec,
-        help=f"""cache as defined in https://docs.docker.com/build/cache/backends/ 
-                 (using --cache-to syntax, parameters are automatically filtered for use 
-                 in --cache-to and --cache-from), e.g.: 
-                 --cache type=registry,ref=server/fastbuild,mode=max.
-                 Will default to the environment variable FASTSURFER_BUILD_CACHE: 
-                 {cache_kwargs.get('default', 'N/A')}""",
+        help=f"""cache as defined in https://docs.docker.com/build/cache/backends/ (using --cache-to syntax, 
+             parameters are automatically filtered for use in --cache-to and --cache-from), e.g.: 
+             --cache type=registry,ref=server/fastbuild,mode=max will default to the environment variable 
+             FASTSURFER_BUILD_CACHE: {cache_kwargs.get('default', 'N/A')}""",
         metavar="type={inline,local,...}[,<param>=<value>[,...]]",
         **cache_kwargs,
     )
@@ -274,11 +281,9 @@ def make_parser() -> argparse.ArgumentParser:
         "--action",
         choices=("load", "push"),
         default="load",
-        help="Which action to perform after building the image (if a docker-container "
-             "is detected): "
+        help="Which action to perform after building the image (if a docker-container is detected): "
              "'load' loads the image into the current docker context (default), "
-             "'push' pushes the image to the registry (needs --tag <registry>/"
-             "<name+maybe organization>:<tag>)",
+             "'push' pushes the image to the registry (needs --tag <registry>/<name+maybe organization>:<tag>)",
     )
     expert.add_argument(
         "--freesurfer_build_image",
@@ -287,7 +292,8 @@ def make_parser() -> argparse.ArgumentParser:
         help="""explicitly specifies an image to copy freesurfer binaries from.
                 freesurfer binaries are expected to be in /opt/freesurfer in the image, 
                 like the runtime image. By default, uses the "build_freesurfer" stage in 
-                the Dockerfile (either by building it or from cache, see --cache).""")
+                the Dockerfile (either by building it or from cache, see --cache).""",
+    )
     expert.add_argument(
         "--conda_build_image",
         type=docker_image,
@@ -295,24 +301,34 @@ def make_parser() -> argparse.ArgumentParser:
         help="""explicitly specifies an image to copy the python environment from.
                 The environment is expected to be in /venv in the image, like the 
                 runtime image. By default, uses the "build_conda" stage in the 
-                Dockerfile (either by building it or from cache, see --cache).""")
+                Dockerfile (either by building it or from cache, see --cache).""",
+    )
     expert.add_argument(
         "--runtime_base_image",
         type=docker_image,
         metavar="image[:tag]",
-        help="explicitly specifies the base image to build the runtime image from "
-             "(default: ubuntu:22.04).")
+        help="explicitly specifies the base image to build the runtime image from (default: ubuntu:22.04).",
+    )
     expert.add_argument(
         "--build_base_image",
         type=docker_image,
         metavar="image[:tag]",
-        help="explicitly specifies the base image to build the build images from "
-             "(default: ubuntu:22.04).")
-
+        help="explicitly specifies the base image to build the build images from (default: ubuntu:22.04).",
+    )
     expert.add_argument(
         "--debug",
         action="store_true",
-        help="enables the DEBUG build flag."
+        help="enables the DEBUG build flag.",
+    )
+    default_ssl_verify = lambda x: os.environ.get("MAMBA_SSL_VERIFY", os.environ.get("CONDA_SSL_VERIFY", x))
+    expert.add_argument(
+        "--ssl_verify",
+        type=_validate_ssl_verify,
+        default=default_ssl_verify(True),
+        metavar="{True,False,<path>}",
+        help="ssl certificate to use for condaforge, from None/False (ignore), True (default system certificate), or a "
+             "certificate file path (defaults to the value of the MAMBA_SSL_VERIFY (or CONDA_SSL_VERIFY) environment "
+             f"variable, here: {default_ssl_verify('True (neither set)')}).",
     )
     return parser
 
@@ -616,6 +632,7 @@ def main(
         dry_run: bool = False,
         tag_dev: bool = True,
         fastsurfer_home: Path | None = None,
+        ssl_verify: Path | bool = True,
         **keywords,
         ) -> int | str:
     from FastSurferCNN.version import has_git
@@ -654,7 +671,17 @@ def main(
         value = keywords.get(key) or getattr(DEFAULTS, upper_key)
         kwargs["build_arg"].append(f"{upper_key}={value}")
     #    kwargs["build_arg"] = " ".join(kwargs["build_arg"])
-
+    if ssl_verify is not True:
+        if ssl_verify is False:
+            kwargs["build_arg"].append(f"MAMBA_SSL_VERIFY=<false>")
+        else:
+            _ssl_cert = "./Docker/custom-ssl.crt"
+            if (fastsurfer_home / _ssl_cert).exists():
+                (fastsurfer_home / _ssl_cert).unlink()
+            from shutil import copy2
+            copy2(ssl_verify, fastsurfer_home / _ssl_cert)
+            kwargs["build_arg"].append(f"MAMBA_SSL_CERTIFICATE={_ssl_cert}")
+            kwargs["build_arg"].append(f"MAMBA_SSL_VERIFY=/install/{Path(_ssl_cert).name}")
     build_filename = fastsurfer_home / "Docker/BUILD.info"
     if has_git():
         version_sections = "+git"
@@ -662,9 +689,8 @@ def main(
         # try creating the build file without git info
         version_sections = ""
         logger.warning(
-            "Failed to create the git_status section in the BUILD.info file. "
-            "The resulting build file will not have valid git information, so "
-            "the version command of FastSurfer in the image will not complete."
+            "Failed to create the git_status section in the BUILD.info file. The resulting build file will not have "
+            "valid git information, so the version command of FastSurfer in the image will not complete."
         )
 
     with open(build_filename, "w") as build_file, \

--- a/Docker/conda_pack.sh
+++ b/Docker/conda_pack.sh
@@ -9,6 +9,9 @@ set -e
 
 # Install conda-pack
 mamba install -c conda-forge conda-pack
+# make sure setuptools is <81 for conda-pack 0.8.1 https://github.com/conda/conda-pack/issues/391
+setuptools_major=$(mamba list setuptools -e | sed '/^#/d' | grep -oE '=[^.]+\.')
+if [[ "${setuptools_major:1:-1}" -lt 81 ]] ; then mamba install -c conda-forge "setuptools<81" ; fi
 # Use conda-pack to create a standalone environment in /venv
 conda-pack -n "$1" -o /tmp/env.tar
 mkdir /venv

--- a/Docker/install_env.py
+++ b/Docker/install_env.py
@@ -120,6 +120,7 @@ def main(args):
                 # pip is automatically added in front of the '- pip:' subsection
                 pass
             elif package_pip == "pip:":
+                # this adds "- pip" and "- pip:"  to buffer
                 buffer = ("" if has_pip else indent + "pip\n") + line
                 pip_indent = indent_count
             elif mode == "base" and package_pip not in all_special_packages or \


### PR DESCRIPTION
Support changes to the SSL_CERTIFICATE verification interface

- Adds the --ssl_verify flag to Docker/build.py, which accepts "False" or a path to an alternative root certificate, also uses the MAMBA_SSL_VERIFY or CONDA_SSL_VERIFY environment variables to populate this
- Adds logic to build.py, Dockerfile
- Improve debug output
- Adds the documentation
- Also fixes the pip root user warning
- Fix the conda-pack warning for setuptools