### PR TITLE
Fix inconsistent file and folder permissions

### DIFF
--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -646,14 +646,14 @@ if [[ "$long" == "1" ]] ; then
   # in long we can skip fill as surfaces come from base
   # it would be great to also skip WM, but it is needed in place_surface to clip bright
   # maybe later add code to copy edits from base in maskbfs and wm segmentation, currently not supported!
-  cmd="recon-all -s $subject -asegmerge -normalization2 -maskbfs -segmentation $hiresflag $fsthreads"
+  cmd="recon-all -s $subject -asegmerge -normalization2 -maskbfs -segmentation -umask $(umask) $hiresflag $fsthreads"
   RunIt "$cmd" "$LF"
   # copy over filled from base for stop-edits to transfer to long (a bit of a hack)
   cmd="cp $basedir/mri/filled.mgz $mdir/filled.mgz"
   RunIt "$cmd" "$LF"
 else # cross and base
   # filled is needed to generate initial WM surfaces
-  cmd="recon-all -s $subject -asegmerge -normalization2 -maskbfs -segmentation -fill $hiresflag $fsthreads"
+  cmd="recon-all -s $subject -asegmerge -normalization2 -maskbfs -segmentation -fill -umask $(umask) $hiresflag $fsthreads"
   RunIt "$cmd" "$LF"
 fi
 
@@ -700,7 +700,7 @@ for hemi in lh rh ; do
 
     if [[ "$fstess" == "1" ]]
     then
-      cmd="recon-all -subject $subject -hemi $hemi -tessellate -smooth1 -no-isrunning $hiresflag $fsthreads"
+      cmd="recon-all -subject $subject -hemi $hemi -tessellate -smooth1 -no-isrunning -umask $(umask) $hiresflag $fsthreads"
       RunIt "$cmd" "$LF" "$CMDF"
     else
       # instead of mri_tesselate lego land use marching cube
@@ -772,13 +772,13 @@ for hemi in lh rh ; do
     } | tee -a "$CMDF"
 
     #surface inflation (54sec both hemis) (needed for qsphere and for topo-fixer)
-    cmd="recon-all -subject $subject -hemi $hemi -inflate1 -no-isrunning $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -hemi $hemi -inflate1 -no-isrunning -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
     if [ "$fsqsphere" == "1" ]
     then
       # quick spherical mapping (2min48sec)
-      cmd="recon-all -subject $subject -hemi $hemi -qsphere -no-isrunning $hiresflag $fsthreads"
+      cmd="recon-all -subject $subject -hemi $hemi -qsphere -no-isrunning -umask $(umask) $hiresflag $fsthreads"
       RunIt "$cmd" "$LF" "$CMDF"
     else
       # instead of mris_sphere, directly project to sphere with spectral approach
@@ -805,7 +805,7 @@ for hemi in lh rh ; do
       echo "echo \"\""
     } | tee -a "$CMDF"
 
-    cmd="recon-all -subject $subject -hemi $hemi -fix -no-isrunning $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -hemi $hemi -fix -no-isrunning -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
     # fix the surfaces if they are corrupt
@@ -815,14 +815,14 @@ for hemi in lh rh ; do
     RunIt "$cmd" "$LF" "$CMDF"
 
     # create first WM surface white.preaparc from topo fixed orig surf
-    cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -white-preaparc -no-isrunning $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -white-preaparc -no-isrunning -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
   else # longitudinal stream
     # ... we skip topo fix
 
     # in long we don't use orig.premesh (so switch off remesh for autodetgwstat)
-    cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -no-remesh -no-isrunning $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -hemi $hemi -autodetgwstats -no-remesh -no-isrunning -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
     # for place_surfaces white.preparc we need to directly call it with special long parameter:
@@ -844,7 +844,7 @@ for hemi in lh rh ; do
   # create cortex label (1min)
   # create nicer inflated surface from topo fixed (not needed, just later for visualization)
   # identical for long processing
-  cmd="recon-all -subject $subject -hemi $hemi -cortex-label -smooth2 -inflate2 -curvHK -no-isrunning $hiresflag $fsthreads"
+  cmd="recon-all -subject $subject -hemi $hemi -cortex-label -smooth2 -inflate2 -curvHK -no-isrunning -umask $(umask) $hiresflag $fsthreads"
   RunIt "$cmd" "$LF" "$CMDF"
 
 
@@ -884,7 +884,7 @@ for hemi in lh rh ; do
     then
 
       # SPHERE: Inflate to sphere with minimal metric distortion
-      cmd="recon-all -subject $subject -hemi $hemi -sphere $hiresflag -no-isrunning $fsthreads"
+      cmd="recon-all -subject $subject -hemi $hemi -sphere $hiresflag -no-isrunning -umask $(umask) $fsthreads"
       RunIt "$cmd" "$LF" "$CMDF"
 
       # SURFREG (sphere.reg)
@@ -937,7 +937,7 @@ for hemi in lh rh ; do
 
     # in all cases where sphere.reg is available, create jacobian white (distortion to sphere)
     # and avgcurv (map atlas curvature to subject):
-    cmd="recon-all -subject $subject -hemi $hemi -jacobian_white -avgcurv -no-isrunning $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -hemi $hemi -jacobian_white -avgcurv -no-isrunning -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
   fi
@@ -1051,7 +1051,7 @@ for hemi in lh rh ; do
 # ============================= CURVSTATS ===============================================
 
   # in FS7 curvstats moves here
-  cmd="recon-all -subject $subject -hemi $hemi -curvstats -no-isrunning $hiresflag $fsthreads"
+  cmd="recon-all -subject $subject -hemi $hemi -curvstats -no-isrunning -umask $(umask) $hiresflag $fsthreads"
   RunIt "$cmd" "$LF" "$CMDF"
 
   if [[ "$DoParallel" == "0" ]]
@@ -1100,7 +1100,7 @@ then
   # anatomical stats can run without ribbon, but will omit some surface based measures then
   # wmparc needs ribbon, probably other stuff (aparc to aseg etc).
   # So lets run it to have these measures below.
-  cmd="recon-all -subject $subject -cortribbon $hiresflag $fsthreads"
+  cmd="recon-all -subject $subject -cortribbon -umask $(umask) $hiresflag $fsthreads"
   RunIt "$cmd" "$LF"
 
 fi # skip in base
@@ -1146,7 +1146,7 @@ if [[ "$fsaparc" == "1" ]] ; then
   # skip in base
   if [[ "$base" != "1" ]]
   then
-    cmd="recon-all -subject $subject -pctsurfcon -hyporelabel -apas2aseg -aparc2aseg -wmparc -parcstats -parcstats2 -parcstats3 $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -pctsurfcon -hyporelabel -apas2aseg -aparc2aseg -wmparc -parcstats -parcstats2 -parcstats3 -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF"
     # removed -balabels here and do that below independent of fsaparc flag
     # removed -segstats here (now part of mri_segstats.py/segstats.py
@@ -1200,7 +1200,7 @@ then
     # 25 sec hyporelabel run whatever else can be done without sphere, cortical ribbon and segmentations
     # -hyporelabel creates aseg.presurf.hypos.mgz from aseg.presurf.mgz
     # -apas2aseg creates aseg.mgz by editing aseg.presurf.hypos.mgz with surfaces
-    cmd="recon-all -subject $subject -hyporelabel -apas2aseg $hiresflag $fsthreads"
+    cmd="recon-all -subject $subject -hyporelabel -apas2aseg -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF"
   fi
 

--- a/recon_surf/recon-surfreg.sh
+++ b/recon_surf/recon-surfreg.sh
@@ -304,7 +304,7 @@ for hemi in lh rh; do
   echo "echo \" \"" | tee -a $CMDF
 
   # Surface registration for cross-subject correspondence (registration to fsaverage)
-  cmd="recon-all -subject $subject -hemi $hemi -sphere -no-isrunning $fsthreads"
+  cmd="recon-all -subject $subject -hemi $hemi -sphere -no-isrunning -umask $(umask) $fsthreads"
   RunIt "$cmd" $LF "$CMDF"
 
   # (mr) FIX: sometimes FreeSurfer Sphere Reg. fails and moves pre and post central

--- a/recon_surf/spherically_project_wrapper.py
+++ b/recon_surf/spherically_project_wrapper.py
@@ -15,7 +15,7 @@
 
 # IMPORTS
 import argparse
-import shlex
+from os import umask
 from subprocess import PIPE, Popen
 from typing import Any
 
@@ -45,7 +45,7 @@ def setup_options():
     return args
 
 
-def call(command: str, **kwargs: Any) -> int:
+def call(command: list[str], **kwargs: Any) -> int:
     """
     Run command with arguments.
 
@@ -53,7 +53,7 @@ def call(command: str, **kwargs: Any) -> int:
 
     Parameters
     ----------
-    command : str
+    command : list[str]
         Command to call.
     **kwargs : Any
         Keyword arguments.
@@ -66,9 +66,7 @@ def call(command: str, **kwargs: Any) -> int:
     """
     kwargs["stdout"] = PIPE
     kwargs["stderr"] = PIPE
-    command_split = shlex.split(command)
-
-    p = Popen(command_split, **kwargs)
+    p = Popen(command, **kwargs)
     stdout, stderr = p.communicate()
 
     if stdout:
@@ -82,15 +80,15 @@ def call(command: str, **kwargs: Any) -> int:
     return p.returncode
 
 
-def spherical_wrapper(command1: str, command2: str, **kwargs: Any) -> int:
+def spherical_wrapper(command1: list[str], command2: list[str], **kwargs: Any) -> int:
     """
     Run the first command. If it fails the fallback command is run instead.
 
     Parameters
     ----------
-    command1 : str
+    command1 : list[str]
         Command to call.
-    command2 : str
+    command2 : list[str]
         Fallback command to call.
     **kwargs : Any
         Arguments. The same as for the Popen constructor.
@@ -105,9 +103,7 @@ def spherical_wrapper(command1: str, command2: str, **kwargs: Any) -> int:
     code_1 = call(command1, **kwargs)
 
     if code_1 != 0:
-        print(
-            f"Command {command1} failed.\nRunning fallback command: {command2}"
-        )
+        print(f"Command {command1} failed.\nRunning fallback command: {command2}")
         code_1 = call(command2, **kwargs)
 
     return code_1
@@ -116,36 +112,29 @@ def spherical_wrapper(command1: str, command2: str, **kwargs: Any) -> int:
 if __name__ == "__main__":
 
     opts = setup_options()
-    cmd1 = (
-        opts.py
-        + " "
-        + opts.binpath
-        + "spherically_project.py -i "
-        + opts.sdir
-        + "/"
-        + opts.hemi
-        + ".smoothwm.nofix -o "
-        + opts.sdir
-        + "/"
-        + opts.hemi
-        + ".qsphere.nofix"
-    )
+    cmd1 = [
+        opts.py,
+        f"{opts.binpath}spherically_project.py",
+        "-i", f"{opts.sdir}/{opts.hemi}.smoothwm.nofix",
+        "-o", f"{opts.sdir}/{opts.hemi}.qsphere.nofix",
+    ]
 
+    threading = ()
     if opts.threads > 1:
-        threading = (
-            "-threads " + str(opts.threads) + " -itkthreads " + str(opts.threads)
-        )
-    else:
-        threading = ""
+        threading = ("-threads", str(opts.threads), "-itkthreads", str(opts.threads))
 
-    cmd2 = (
-        "recon-all -s "
-        + opts.subject
-        + " -hemi "
-        + opts.hemi
-        + " -qsphere -no-isrunning "
-        + threading
-    )
+    # get the umask (for some reason this can only be returned if it is also set, so we set it to 2 just to get the
+    # current value)
+    umask = umask(_umask := umask(0o02))
+    cmd2 = [
+        "recon-all",
+        "-s", opts.subject,
+        "-hemi", opts.hemi,
+        "-qsphere",
+        "-no-isrunning",
+        "-umask", str(_umask),
+        *threading,
+    ]
     # make sure the process has a username, so nibabel does not crash in write_geometry
     from os import environ
     env = dict(environ)


### PR DESCRIPTION
Addressing #679 "Inconsistent permissions of output directories and files".

recon-all starts running by setting umask to 002.
This overwrites the OS settings and forces 0o773 file permissions. Here, we decide to use the user-defined setting of the environment. Thus, all calls to recon-all must include the "-umask $(umask -p)" argument.

- Add "-umask $(umask -p)" to all recon-all calls
- Some formatting cleanup of recon_surf/spherically_project_wrapper.py