### PR TITLE
Github workflow changes

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -46,15 +46,19 @@ runs:
         FASTSURFER_HOME: ${{ inputs.fastsurfer-home }}
       run: |
         echo "::group::Build FastSurfer Image"
+        bashopts=
+        if [[ "$RUNNER_DEBUG" == "1" ]] ; then bashopts=-x ; set $bashopts ; fi
         image_name="${{ inputs.tag }}"
         if [[ "$image_name" == "auto" ]] ; then  
-          v="$(bash "$FASTSURFER_HOME/run_fastsurfer.sh" --version --py python)"
+          v="$(bash $bashopts "$FASTSURFER_HOME/run_fastsurfer.sh" --version --py python)"
           image_name="fastsurfer:cpu-${v/+/_}"
         fi
+        if [[ -z "$(which python)" ]] ; then echo "ERROR: Cannot find python!" ; fi
         cmd=(python "$FASTSURFER_HOME/Docker/build.py" --device cpu --tag "$image_name" --target "${{ inputs.target }}")
         if [[ "${{ inputs.freesurfer-build-image }}" != "rebuild" ]] ; then 
           cmd+=(--freesurfer_build_image "${{ inputs.freesurfer-build-image }}")
         fi
+        if [[ "$RUNNER_DEBUG" == "1" ]] ; then cmd+=(--debug) ; fi
         "${cmd[@]}"
         echo "::endgroup::"
         echo "::group::Save image as artifact"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,8 +10,10 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash
@@ -40,29 +42,16 @@ jobs:
             doc-build
             !doc-build/.doctrees
 
-  deploy:
-    # only on push to dev or stable
-    if: ${{ github.event_name == 'push' && contains(fromJSON('["dev", "stable"]'), github.ref_name) }}
-    needs: build
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Download documentation
-        uses: actions/download-artifact@v4
-        with:
-          name: doc
-          path: doc
-      - name: Deploy {dev,stable} documentation
+      # deploy
+      - name: Deploy the {dev,stable} documentation to github.io
+        # only on push to dev or stable
+        if: ${{ success() && github.event_name == 'push' && contains(fromJSON('["dev", "stable"]'), github.ref_name) }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: doc
+          publish_dir: doc-build
+          exclude_assets: '.doctrees'
           # destination_dir: github.ref_name will be dev or stable
           destination_dir: ${{ github.ref_name }}
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: 'github-doc-action[bot]'
+          user_email: 'github-doc-action[bot]@users.noreply.github.com'

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -139,6 +139,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.parse.outputs.DOCKER_IMAGE }}
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+          # no cache is needed, no installations and no cache is faster
+          # cache: 'pip' # caching pip dependencies
       - name: Get the FreeSurfer version
         # we want to build the docker image, get what we want to do for freesurfer (read fslink from install_pruned.sh,
         if: steps.parse.outputs.CONTINUE == 'true' && (steps.parse.outputs.DOCKER_IMAGE == 'build-cached' || startsWith(steps.parse.outputs.DOCKER_IMAGE, 'pr/'))

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -529,7 +529,7 @@ then
     version_cache_args=("${version_cache_args[@]}" --sections "$version_and_quit")
   fi
   $python "$FASTSURFER_HOME/FastSurferCNN/version.py" "${version_cache_args[@]}"
-  exit 1
+  exit $?
 fi
 
 source "${reconsurfdir}/functions.sh"


### PR DESCRIPTION
1. Fix the quicktest workflow
    The main issue here was that `run_fastsurfer.sh --version` exited with error code 1, which meant the build action terminated with no image built. This is now fixed.
2. Reframe the doc deployment from a job as a step.
    The issue here was that in PRs we always had 2 of 3 checks successful, which was misleading. This could be traced back to deploy being a job that was started, but then skipped. Now, deploy is part of the build job, but only executed on the push trigger and not the pull_request trigger. In effect the outcome is the same, but a "skipped check" is no longer created.

# Testing of FastSurfer-doc
- both build and deploy tested in dkuegler/FastSurfer

# Testing of FastSurfer-quicktest

- Build tested in the dkuegler/FastSurfer repository
- Running testing in dkuegler/FastSurfer repository (looking good thus far -- https://github.com/dkuegler/FastSurfer/actions/runs/16937533655/job/47998737137)