### PR TITLE
Add the longitudinal outputs compatibility script

### DIFF
--- a/doc/overview/LONG.md
+++ b/doc/overview/LONG.md
@@ -4,7 +4,7 @@ FastSurfer has a dedicated pipeline to quantify longitudinal changes in T1-weigh
 
 ## What is Longitudinal Processing
 
-In longitudinal studies, MRIs of the same participant are acquired at different time points. Usually, the goal is to quantify potentially subtle anatomical changes representing early disease effects or effects of disease-modifying therapies or drug studies. In these situations, we know that most of the anatomy will be very similar, as compared to cross-sectional differences between participants. Longitudinal processing, as opposed to independent processing of each MRI, tries to make use of the joint information to reduce variance across time, leading to more sensitive estimates of longitudinal changes. This methodological approach leads to increased statistical power to detect subtle changes and, therefore, permits either finding smaller effects or reducing the number of participants needed to detect such an effect - saving time and money. Our paper for the FreeSurfer longitudinal stream (Reuter et al. [2012](https://doi.org/10.1016/j.neuroimage.2012.02.084)) nicely highlights these advantages, such as increased reliability and sensitivity, and describes the general idea. 
+In longitudinal studies, MRIs of the same participant are acquired at different time points. Usually, the goal is to quantify potentially subtle anatomical changes representing early disease effects or effects of disease-modifying therapies or drug studies. In these situations, we know that most of the anatomy will be very similar, as compared to cross-sectional differences between participants. Longitudinal processing, as opposed to independent processing of each MRI, tries to make use of the joint information to reduce variance across time, leading to more sensitive estimates of longitudinal changes. This methodological approach leads to increased statistical power to detect subtle changes and, therefore, permits either finding smaller effects or reducing the number of participants needed to detect such an effect - saving time and money. Our paper for the FreeSurfer longitudinal stream (Reuter et al. [2012](https://doi.org/10.1016/j.neuroimage.2012.02.084)) nicely highlights these advantages, such as increased reliability and sensitivity, and describes the general idea.
 
 Generally, the idea is to: 
 - Align images across time robustly into an unbiased mid-space (Reuter et al. [2010](https://doi.org/10.1016/j.neuroimage.2010.07.020)).
@@ -98,10 +98,10 @@ HOWEVER, this requires that you process these cases also through the longitudina
      --tpids <tID1> <tID2>
    ```
    This will register (align) all time point images into the unbiased mid-space using `mri_robust_template`, after an initial segmentation and skull stripping. It will also create the template image, kind of a mean image across time. For single time point cases, it will align the input into a standard upright position.
-2. **Template Seg**: Next, the template image will be segmented via a call to `run_fastsurfer.sh --sid <templateID> --base --seg_only ...` where the `--base` flag indicates that the input image will be taken from the already existing template directory. 
+2. **Template Seg**: Next, the template image will be segmented via a call to `run_fastsurfer.sh --sid <templateID> --base --seg_only ...` where the `--base` flag indicates that the input image will be taken from the already existing template directory.
 3. **Template Surf**: This is followed by the surface processing of the template  `run_fastsurfer.sh --sid <templateID> --base --surf_only ...`, which can be combined with the previous step.
 4. **Long Seg**: Next, the segmentation of each time point, which can theoretically run in parallel with the previous two steps, is performed `run_fastsurfer.sh --sid <tIDn> --long <templateID> --seg_only ...`,
-5. **Long Surf**: Again followed by the surface processing for each time point: `run_fastsurfer.sh --sid <tIDn> --long <templateID> --surf_only`. This step needs to wait until 3. and 4. (for this time point) are finished. In this step, for example, surfaces are initialized with the ones obtained on the template above and only fine-tuned, instead of being recreated from scratch. 
+5. **Long Surf**: Again followed by the surface processing for each time point: `run_fastsurfer.sh --sid <tIDn> --long <templateID> --surf_only`. This step needs to wait until 3. and 4. (for this time point) are finished. In this step, for example, surfaces are initialized with the ones obtained on the template above and only fine-tuned, instead of being recreated from scratch.
 
 Internally, we use `brun_fastsurfer.sh` as a helper script to process multiple time points in parallel (in the LONG steps 4. and 5.). Here, `--parallel_seg` can be passed to `long_fastsurfer.sh` to specify the number of parallel runs during the segmentation step (4), which is usually limited by GPU memory, if run on the GPU. Further, `--parallel_surf` specifies the number of parallel surface runs on the CPU and is most impactful. It can be combined with `--threads_surf 2` (or higher) to switch on parallelization of the two hemispheres in each surface block. 
 
@@ -119,7 +119,7 @@ source $FREESURFER_HOME/SetUpFreeSurfer.sh
 # Define data directory
 export SUBJECTS_DIR=/home/user/my_fastsurfer_analysis
 
-# Run FastSurfer longitudinally
+# Run long_compat_segmentHA.py script to create missing files and sym-links
 python $FASTSURFER_HOME/recon_surf/long_compat_segmentHA.py \
     --tid <templateID>
 ```

--- a/doc/overview/LONG.md
+++ b/doc/overview/LONG.md
@@ -46,7 +46,7 @@ The above command will, of course, be slightly different when using your preferr
 
 ```bash
 singularity exec --nv \
-                 --no-home \
+                 --no-mount cwd,home \
                  -B /home/user/my_mri_data:/data \
                  -B /home/user/my_fastsurfer_analysis:/output \
                  -B /home/user/my_fs_license_dir:/fs_license \
@@ -90,7 +90,7 @@ HOWEVER, this requires that you process these cases also through the longitudina
 ## Behind the Scenes
 
 `long_fastsurfer.sh` is just a helper script and will perform the following individual steps for you:
-1. [Template Init] It will prepare the subject template by calling `long_prepare_template.sh`:
+1. **Template Init**: It will prepare the subject template by calling `long_prepare_template.sh`:
    ```bash
    long_prepare_template.sh \
      --tid <templateID> \
@@ -98,17 +98,31 @@ HOWEVER, this requires that you process these cases also through the longitudina
      --tpids <tID1> <tID2>
    ```
    This will register (align) all time point images into the unbiased mid-space using `mri_robust_template`, after an initial segmentation and skull stripping. It will also create the template image, kind of a mean image across time. For single time point cases, it will align the input into a standard upright position.
-2. [Template Seg] Next, the template image will be segmented via a call to `run_fastsurfer.sh --sid <templateID> --base --seg_only ...` where the `--base` flag indicates that the input image will be taken from the already existing template directory. 
-3. [Template Surf] This is followed by the surface processing of the template  `run_fastsurfer.sh --sid <templateID> --base --surf_only ...`, which can be combined with the previous step.
-4. [Long Seg] Next, the segmentation of each time point, which can theoretically run in parallel with the previous two steps, is performed `run_fastsurfer.sh --sid <tIDn> --long <templateID> --seg_only ...`,
-5. [Long Surf] Again followed by the surface processing for each time point: `run_fastsurfer.sh --sid <tIDn> --long <templateID> --surf_only`. This step needs to wait until 3. and 4. (for this time point) are finished. In this step, for example, surfaces are initialized with the ones obtained on the template above and only fine-tuned, instead of being recreated from scratch. 
+2. **Template Seg**: Next, the template image will be segmented via a call to `run_fastsurfer.sh --sid <templateID> --base --seg_only ...` where the `--base` flag indicates that the input image will be taken from the already existing template directory. 
+3. **Template Surf**: This is followed by the surface processing of the template  `run_fastsurfer.sh --sid <templateID> --base --surf_only ...`, which can be combined with the previous step.
+4. **Long Seg**: Next, the segmentation of each time point, which can theoretically run in parallel with the previous two steps, is performed `run_fastsurfer.sh --sid <tIDn> --long <templateID> --seg_only ...`,
+5. **Long Surf**: Again followed by the surface processing for each time point: `run_fastsurfer.sh --sid <tIDn> --long <templateID> --surf_only`. This step needs to wait until 3. and 4. (for this time point) are finished. In this step, for example, surfaces are initialized with the ones obtained on the template above and only fine-tuned, instead of being recreated from scratch. 
 
 Internally, we use `brun_fastsurfer.sh` as a helper script to process multiple time points in parallel (in the LONG steps 4. and 5.). Here, `--parallel_seg` can be passed to `long_fastsurfer.sh` to specify the number of parallel runs during the segmentation step (4), which is usually limited by GPU memory, if run on the GPU. Further, `--parallel_surf` specifies the number of parallel surface runs on the CPU and is most impactful. It can be combined with `--threads_surf 2` (or higher) to switch on parallelization of the two hemispheres in each surface block. 
 
-## Final Statistics:
+## Final Statistics
 
 The final results will be located in `$SUBJECTS_DIR/tID1` ... for each time point. These directories will have the same structure as a regular FastSurfer/FreeSurfer output directory. Therefore, you can use the regular downstream analysis tools, e.g. to extract statistics from the stats files. Note that the surfaces are already in vertex correspondence across time for each participant. For group analysis, one would still need to map thickness estimates to the fsaverage spherical template (this is usually done with `mris_preproc`). For longitudinal statistics using the (recommended) linear mixed effects models, see our R toolbox [FS LME R](https://github.com/Deep-MI/fslmer), which can also analyze the mass-univariate situation, e.g. for cortical thickness maps. Alternatively, you can use this Matlab package: [LME Matlab](https://github.com/NeuroStats/lme) and our Matlab tools for time-to-event (survival) analysis: [Survival](https://github.com/NeuroStats/Survival).
 
+Note, that followup tools, e.g. Longitudinal Hippocampus and Amydala pipeline, require additional files. These files can be generated by running the [FastSurfer longitudinal outputs script `recon_surf/long_compat_segmentHA.py`](../scripts/long_compat_segmentHA.rst) on top of the longitudinal processing directory.
+```bash
+# Setup FASTSURFER and FREESURFER
+export FASTSURFER_HOME=/path/to/fastsurfer
+export FREESURFER_HOME=/path/to/freesurfer
+source $FREESURFER_HOME/SetUpFreeSurfer.sh
+
+# Define data directory
+export SUBJECTS_DIR=/home/user/my_fastsurfer_analysis
+
+# Run FastSurfer longitudinally
+python $FASTSURFER_HOME/recon_surf/long_compat_segmentHA.py \
+    --tid <templateID>
+```
 ## References
 
 - Reuter, Schmansky, Rosas, Fischl

--- a/doc/scripts/advanced.rst
+++ b/doc/scripts/advanced.rst
@@ -9,3 +9,4 @@ Advanced scripts
     hypvinn
     recon_surf
     segstats
+    long_compat_segmentHA

--- a/doc/scripts/long_compat_segmentHA.rst
+++ b/doc/scripts/long_compat_segmentHA.rst
@@ -1,0 +1,12 @@
+recon_surf: long_compat_segmentHA.py
+====================================
+
+`long_compat_segmentHA.py` is a compatibility script. It creates files that are not created by the FastSurfer longitudinal pipeline, but needed by other longitudinal tools such as FreeSurfer's longitudinal Hippocampus and Amygdala processing.
+
+
+Full commandline interface of recon_surf/long_compat_segmentHA.py
+-----------------------------------------------------------------
+.. argparse::
+    :module: recon_surf.long_compat_segmentHA
+    :func: make_parser
+    :prog: recon_surf/long_compat_segmentHA.py

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -19,7 +19,7 @@ import os
 import sys
 from functools import lru_cache
 from pathlib import Path
-from subprocess import STDOUT, run
+from subprocess import STDOUT, CompletedProcess
 
 import nibabel as nib
 
@@ -91,11 +91,11 @@ def softlink_or_copy(source: str | Path, target: str | Path) -> None:
         target_path.symlink_to(source_path)
     except OSError:
         # If symlink fails, copy the file
-        import shutil
+        from shutil import copy2
 
         if not target_path.is_absolute():
             target_path = (source.parent / target_path).resolve()
-        shutil.copy2(source_path, target_path)
+        copy2(source_path, target_path)
 
 
 def get_voxel_size(image_file: Path) -> float:
@@ -116,6 +116,22 @@ def get_supported_freesurfer_version() -> str:
             if line.lstrip().startswith("FS_VERSION_SUPPORT"):
                 return line.strip().removeprefix("FS_VERSION_SUPPORT").lstrip(" =").strip("\"")
     return "7.4.1"
+
+
+def run(command: list[str], *args, **kwargs) -> CompletedProcess:
+    """Run the FreeSurfer command `command`."""
+    from shutil import which
+    from subprocess import run as _run
+
+    executable, *arguments = command
+    # do we have executable in PATH?
+    if not (_executable := which(executable)):
+        # if not, do we have it in FREESURFER_HOME/bin ?
+        _executable = which(f"{os.environ['FREESURFER_HOME']}/bin/{executable}")
+    if _executable is None:
+        raise FastSurferCompatError(f"Could not find the FreeSurfer executable {executable}.")
+
+    return _run([_executable, *arguments], *args, **kwargs)
 
 
 def make_parser() -> argparse.ArgumentParser:
@@ -219,7 +235,7 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
 
         # Validate inputs
         subject_dir = subjects_dir / subject
-        validate_inputs(subject_dir)
+        validate_inputs(subjects_dir)
 
         # Set threading environment
         env = dict(os.environ)
@@ -235,7 +251,10 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
                 source = line.strip()
                 if source:
                     target = f"{source}.long.{subject}"
-                    softlink_or_copy(subjects_dir / source, target)
+                    if not (subjects_dir / source).exists():
+                        raise FastSurferCompatError(f"The longitudinal processing {source} could not be found!")
+
+                    softlink_or_copy(source, subjects_dir / target)
                     print(f"Created link: {source} -> {target}")
 
         # Setup variables
@@ -311,7 +330,7 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         softlink_or_copy(segfile.name, mdir / "aparc+aseg.mgz")
         softlink_or_copy("wmparc.DKTatlas.mapped.mgz", mdir / "wmparc.mgz")
 
-        softlink_or_copy(subject_dir / "base-tps.fastsurfer", "base-tps")
+        softlink_or_copy("base-tps.fastsurfer", subject_dir / "base-tps")
 
         print(f"Processing {subject} completed successfully!")
 

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -19,7 +19,7 @@ import os
 import sys
 from functools import lru_cache
 from pathlib import Path
-from subprocess import STDOUT, CompletedProcess
+from subprocess import CompletedProcess
 
 import nibabel as nib
 

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -131,6 +131,8 @@ def run(command: list[str], *args, **kwargs) -> CompletedProcess:
     if _executable is None:
         raise FastSurferCompatError(f"Could not find the FreeSurfer executable {executable}.")
 
+    print((args, kwargs))
+
     return _run([_executable, *arguments], *args, **kwargs)
 
 
@@ -173,7 +175,7 @@ def make_parser() -> argparse.ArgumentParser:
     # Optional arguments
     parser.add_argument("--threads", type=int_gt_zero, default=1,
                         help="Set openMP and ITK threads to <int>.")
-    parser.add_argument("--fs_license", dest="fs_license", type=validate_existing_file,
+    parser.add_argument("--fs_license", dest="fs_license", type=validate_existing_file, default=Path("."),
                         help="Path to FreeSurfer license key file.")
     parser.add_argument("--version", action="version", version=f"long_compat_segmentHA: {VERSION}")
 
@@ -247,7 +249,13 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         env = dict(os.environ)
         env["OMP_NUM_THREADS"] = str(threads)
         env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(threads)
-        env["FS_LICENSE"] = str(fs_license)
+
+        if Path(".") != fs_license:
+            env["FS_LICENSE"] = str(fs_license)
+        elif env.get("FS_LICENSE", None) and not Path(env["FS_LICENSE"]).exists():
+            raise FastSurferCompatError("No valid --fs_license passed, but environment FS_LICENSE does not exist!")
+        # else FS_LICENSE will default to automatic search
+
         env["SUBJECTS_DIR"] = str(subjects_dir)
         if env["FREESURFER_HOME"] not in env["PATH"]:
             env["PATH"] = env["FREESURFER_HOME"] + "/bin:" + env["PATH"]
@@ -256,15 +264,13 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         tpfile = subject_dir / "base-tps.fastsurfer"
         print("Copying/symlinking timepoints...")
         with open(subject_dir / tpfile) as f:
-            for line in f.readlines():
-                source = line.strip()
-                if source:
-                    target = f"{source}.long.{subject}"
-                    if not (subjects_dir / source).exists():
-                        raise FastSurferCompatError(f"The longitudinal processing {source} could not be found!")
+            for long_id in filter(lambda x: bool(x), map(str.strip, f.readlines())):
+                target = f"{long_id}.long.{subject}"
+                if not (subjects_dir / long_id).exists():
+                    raise FastSurferCompatError(f"The longitudinal processing {long_id} could not be found!")
 
-                    softlink_or_copy(source, subjects_dir / target)
-                    print(f"Created link: {source} -> {target}")
+                softlink_or_copy(long_id, subjects_dir / target)
+                print(f"Created link: {long_id} -> {target}")
 
         # Setup variables
         mdir = subject_dir / "mri"

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -14,15 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 import sys
-import argparse
 from functools import lru_cache
 from pathlib import Path
+from subprocess import STDOUT, run
 
 import nibabel as nib
-
-from FastSurferCNN.utils.run_tools import Popen
 
 VERSION = "1.0 2025-08-18 by kueglerd @ DZNE"
 
@@ -50,18 +49,6 @@ def validate_existing_subjects_dir(value: str) -> Path:
     if not path.is_dir():
         raise argparse.ArgumentTypeError(f"Path is not a directory: {value}")
     return path
-
-
-def validate_subject_id(value: str) -> str:
-    """Validate subject ID format"""
-    if not value or not value.strip():
-        raise argparse.ArgumentTypeError("Subject ID cannot be empty")
-    # Remove any potentially problematic characters for filesystem
-    cleaned = value.strip()
-    if "/" in cleaned or "\\" in cleaned:
-        raise argparse.ArgumentTypeError("Subject ID cannot contain path separators")
-    return cleaned
-
 
 def check_freesurfer(check_version: bool = True) -> None:
     """Check if FreeSurfer is properly installed and version is supported"""
@@ -92,7 +79,6 @@ def check_freesurfer(check_version: bool = True) -> None:
         else:
             raise FastSurferCompatError("Could not find/read FreeSurfer build-stamp file.")
 
-
 def softlink_or_copy(source: str | Path, target: str | Path) -> None:
     """Create soft link or copy file if linking fails"""
     source_path = Path(source)
@@ -118,7 +104,7 @@ def get_voxel_size(image_file: Path) -> float:
         img = nib.load(str(image_file))
         return float(img.header.get_zooms()[0])
     except Exception as e:
-        raise FastSurferCompatError(f"ERROR: Could not read voxel size from {image_file}: {e}")
+        raise FastSurferCompatError(f"Could not read voxel size from {image_file}: {e}") from e
 
 
 @lru_cache
@@ -190,7 +176,7 @@ def validate_inputs(subject_dir: Path):
     tpfile = subject_dir / "base-tps.fastsurfer"
     if not tpfile.exists():
         raise FastSurferCompatError(
-            f"{args.subject} is either not found in $SUBJECTS_DIR or it is not a longitudinal template directory "
+            f"{subject_dir.name} is either not found in $SUBJECTS_DIR or it is not a longitudinal template directory "
             f"(base), which needs to contain base-tps.fastsurfer file. Please ensure that the base (template) has been "
             f"created with long_prepare_template.sh."
         )
@@ -281,16 +267,18 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
             cmd.extend(["-threads", str(threads), "-itkthreads", str(threads)])
 
         print("Running: cortical ribbon creation")
-        Popen(cmd, env=env).forward_outputs(timeout=None)
+        completed = run(cmd, env=env, stdout=STDOUT, stderr=STDOUT)
+        if completed.returncode != 0:
+            raise FastSurferCompatError("Creating cortical ribbon failed!")
 
         # mapped aparcDKT to vol (1:30 min)
         segfile = mdir / "aparc.DKTatlas+aseg.mapped.mgz"
         wm_segfile = mdir / "wmparc.DKTatlas.mapped.mgz"
-        threads_flags = ("--threads", threads)
+        threads_flags = ("--threads", str(threads))
 
         def hemi_flags(hemi: str, offset: int) -> list:
             return [
-                f"--{hemi}-annot", ldir / f"{hemi}.aparc.DKTatlas.mapped.annot", offset,
+                f"--{hemi}-annot", ldir / f"{hemi}.aparc.DKTatlas.mapped.annot", str(offset),
                 f"--{hemi}-cortex-mask", ldir / f"{hemi}.cortex.label",
                 f"--{hemi}-white", sdir / f"{hemi}.white", f"--{hemi}-pial", sdir / f"{hemi}.pial",
             ]
@@ -301,7 +289,9 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         for hemi, offset in (("lh", 1000), ("rh", 2000)):
             cmd.extend(hemi_flags(hemi, offset))
 
-        Popen(list(map(str, cmd)), env=env).forward_outputs(timeout=None)
+        completed = run(list(map(str, cmd)), env=env, stdout=STDOUT, stderr=STDOUT)
+        if completed.returncode != 0:
+            raise FastSurferCompatError("Mapping aparcDKT failed!")
 
         # mapped wmparc (1:30 min)
         print("Mapping wmparc...")
@@ -310,7 +300,9 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         for hemi, offset in (("lh", 3000), ("rh", 4000)):
             cmd.extend(hemi_flags(hemi, offset))
 
-        Popen(list(map(str, cmd)), env=env).forward_outputs(timeout=None)
+        completed = run(list(map(str, cmd)), env=env, stdout=STDOUT, stderr=STDOUT)
+        if completed.returncode != 0:
+            raise FastSurferCompatError("Mapping wmparc failed!")
 
         # Create symbolic links
         print("Creating symbolic links...")
@@ -319,12 +311,12 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         softlink_or_copy(segfile.name, mdir / "aparc+aseg.mgz")
         softlink_or_copy("wmparc.DKTatlas.mapped.mgz", mdir / "wmparc.mgz")
 
-        softlink_or_copy(subjects_dir / "base-tps.fastsurfer", "base-tps")
+        softlink_or_copy(subject_dir / "base-tps.fastsurfer", "base-tps")
 
         print(f"Processing {subject} completed successfully!")
 
     except FastSurferCompatError as e:
-        print(str(e))
+        print(f"ERROR: {e}")
         sys.exit(1)
     except KeyboardInterrupt:
         print("\nProcessing interrupted by user.")

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -26,9 +26,11 @@ from FastSurferCNN.utils.run_tools import Popen
 
 VERSION = "1.0 2025-08-18 by kueglerd @ DZNE"
 
+
 class FastSurferCompatError(Exception):
     """Custom exception for FastSurfer compatibility issues"""
     pass
+
 
 def validate_existing_file(value: str) -> Path:
     """Validate that the input is an existing file path"""
@@ -39,6 +41,7 @@ def validate_existing_file(value: str) -> Path:
         raise argparse.ArgumentTypeError(f"Path is not a file: {value}")
     return path
 
+
 def validate_existing_subjects_dir(value: str) -> Path:
     """Validate that the input is an existing directory path"""
     path = Path(value)
@@ -47,6 +50,7 @@ def validate_existing_subjects_dir(value: str) -> Path:
     if not path.is_dir():
         raise argparse.ArgumentTypeError(f"Path is not a directory: {value}")
     return path
+
 
 def validate_subject_id(value: str) -> str:
     """Validate subject ID format"""
@@ -57,6 +61,7 @@ def validate_subject_id(value: str) -> str:
     if "/" in cleaned or "\\" in cleaned:
         raise argparse.ArgumentTypeError("Subject ID cannot contain path separators")
     return cleaned
+
 
 def check_freesurfer(check_version: bool = True) -> None:
     """Check if FreeSurfer is properly installed and version is supported"""
@@ -85,7 +90,8 @@ def check_freesurfer(check_version: bool = True) -> None:
                     f"  source $FREESURFER_HOME/SetUpFreeSurfer.sh"
                 )
         else:
-            FastSurferCompatError("Could not find/read FreeSurfer build-stamp file.")
+            raise FastSurferCompatError("Could not find/read FreeSurfer build-stamp file.")
+
 
 def softlink_or_copy(source: str | Path, target: str | Path) -> None:
     """Create soft link or copy file if linking fails"""
@@ -105,6 +111,7 @@ def softlink_or_copy(source: str | Path, target: str | Path) -> None:
             target_path = (source.parent / target_path).resolve()
         shutil.copy2(source_path, target_path)
 
+
 def get_voxel_size(image_file: Path) -> float:
     """Get voxel size from aseg file using nibabel."""
     try:
@@ -112,6 +119,7 @@ def get_voxel_size(image_file: Path) -> float:
         return float(img.header.get_zooms()[0])
     except Exception as e:
         raise FastSurferCompatError(f"ERROR: Could not read voxel size from {image_file}: {e}")
+
 
 @lru_cache
 def get_supported_freesurfer_version() -> str:
@@ -122,6 +130,7 @@ def get_supported_freesurfer_version() -> str:
             if line.lstrip().startswith("FS_VERSION_SUPPORT"):
                 return line.strip().removeprefix("FS_VERSION_SUPPORT").lstrip(" =").strip("\"")
     return "7.4.1"
+
 
 def make_parser() -> argparse.ArgumentParser:
     """Parse command line arguments"""
@@ -136,13 +145,12 @@ def make_parser() -> argparse.ArgumentParser:
 
                If you use this for research publications, please cite:
 
-               Henschel L, Conjeti S, Estrada S, Diers K, Fischl B, Reuter M, FastSurfer - A
-                fast and accurate deep learning based neuroimaging pipeline, NeuroImage 219
-                (2020), 117012. https://doi.org/10.1016/j.neuroimage.2020.117012
+               Henschel L, Conjeti S, Estrada S, Diers K, Fischl B, Reuter M, FastSurfer - A fast and accurate deep 
+                learning based neuroimaging pipeline, NeuroImage 219 (2020), 117012. 
+                https://doi.org/10.1016/j.neuroimage.2020.117012
 
-               Henschel L*, Kuegler D*, Reuter M. (*co-first). FastSurferVINN: Building
-                Resolution-Independence into Deep Learning Segmentation Methods - A Solution
-                for HighRes Brain MRI. NeuroImage 251 (2022), 118933. 
+               Henschel L, Kuegler D (co-first), Reuter M.. FastSurferVINN: Building Resolution-Independence into 
+                Deep Learning Segmentation Methods - A Solution for HighRes Brain MRI. NeuroImage 251 (2022), 118933. 
                 http://dx.doi.org/10.1016/j.neuroimage.2022.118933
                """
     )
@@ -151,7 +159,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument("--sid", "--tid", dest="subject", required=True, metavar="subject id",
                         help="Template to create directory inside $SUBJECTS_DIR.")
     parser.add_argument("--sd", dest="subjects_dir", type=validate_existing_subjects_dir,
-                        default=Path(os.environ.get("SUBJECTS_DIR", "/")), required=not os.environ.get("SUBJECTS_DIR"),
+                        default=Path(os.environ.get("SUBJECTS_DIR", "/")), required="SUBJECTS_DIR" not in os.environ,
                         help=f"Output directory, default: SUBJECTS_DIR env var ({os.environ.get('SUBJECTS_DIR', '')}).")
 
     # Optional arguments
@@ -167,6 +175,7 @@ def make_parser() -> argparse.ArgumentParser:
                              f"if FreeSurfer {get_supported_freesurfer_version()} is not sourced.")
 
     return parser
+
 
 def validate_inputs(subject_dir: Path):
     """Validate all input arguments and environment"""
@@ -184,13 +193,6 @@ def validate_inputs(subject_dir: Path):
             f"{args.subject} is either not found in $SUBJECTS_DIR or it is not a longitudinal template directory "
             f"(base), which needs to contain base-tps.fastsurfer file. Please ensure that the base (template) has been "
             f"created with long_prepare_template.sh."
-        )
-
-    # Check for aseg.mgz
-    aseg_file = subject_dir / "mri" / "aseg.mgz"
-    if not aseg_file.exists():
-        raise FastSurferCompatError(
-            f"aseg segmentation ({aseg_file}) could not be found! Segmentation must exist at location."
         )
 
     # Check if already processed
@@ -255,19 +257,15 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         ldir = subject_dir / "label"
         sdir = subject_dir / "surf"
         aseg_segfile = mdir / "aseg.mgz"
+        in_segfile = mdir / "aparc.DKTatlas+aseg.deep.mgz"
 
         # Get voxel size and determine hires flag
-        vox_size = get_voxel_size(aseg_segfile)
+        vox_size = get_voxel_size(in_segfile)
         hires_voxsize_threshold = 0.999
 
-        if vox_size < hires_voxsize_threshold:
-            print(f"The voxel size {vox_size} is less than {hires_voxsize_threshold}, "
-                  f"so we are proceeding with hires options.")
-            hiresflag = "-hires"
-        else:
-            print(f"The voxel size {vox_size} is not less than {hires_voxsize_threshold}, "
-                  f"so we are proceeding with standard options.")
-            hiresflag = ""
+        hires = vox_size < hires_voxsize_threshold
+        print(f"The voxel size {vox_size} is {'not ' if hires else ''}less than {hires_voxsize_threshold}, so we are "
+              f"proceeding with {'hires' if hires else 'standard'} options.")
 
         # CREATE cortical ribbon (approx 5mins)
         # CREATE ASEG
@@ -277,8 +275,8 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         print("Creating cortical ribbon...")
         os.umask(_umask := os.umask(0o22))
         cmd = ["recon-all", "-subject", subject, "-cortribbon", "-hyporelabel", "-apas2aseg", "-umask", f"{_umask:o}"]
-        if hiresflag:
-            cmd.append(hiresflag)
+        if hires:
+            cmd.append("-hires")
         if threads > 1:
             cmd.extend(["-threads", str(threads), "-itkthreads", str(threads)])
 
@@ -333,7 +331,7 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         sys.exit(130)
     except Exception as e:
         from traceback import print_exception
-        print(f"Unexpected error:")
+        print("Unexpected error:")
         print_exception(e)
         sys.exit(1)
 

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import argparse
+from functools import lru_cache
+from pathlib import Path
+
+import nibabel as nib
+
+from FastSurferCNN.utils.run_tools import Popen
+
+VERSION = "1.0 2025-08-18 by kueglerd @ DZNE"
+
+class FastSurferCompatError(Exception):
+    """Custom exception for FastSurfer compatibility issues"""
+    pass
+
+def validate_existing_file(value: str) -> Path:
+    """Validate that the input is an existing file path"""
+    path = Path(value)
+    if not path.exists():
+        raise argparse.ArgumentTypeError(f"File does not exist: {value}")
+    if not path.is_file():
+        raise argparse.ArgumentTypeError(f"Path is not a file: {value}")
+    return path
+
+def validate_existing_subjects_dir(value: str) -> Path:
+    """Validate that the input is an existing directory path"""
+    path = Path(value)
+    if not path.exists():
+        raise argparse.ArgumentTypeError(f"Directory does not exist: {value}")
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError(f"Path is not a directory: {value}")
+    return path
+
+def validate_subject_id(value: str) -> str:
+    """Validate subject ID format"""
+    if not value or not value.strip():
+        raise argparse.ArgumentTypeError("Subject ID cannot be empty")
+    # Remove any potentially problematic characters for filesystem
+    cleaned = value.strip()
+    if "/" in cleaned or "\\" in cleaned:
+        raise argparse.ArgumentTypeError("Subject ID cannot contain path separators")
+    return cleaned
+
+def check_freesurfer(check_version: bool = True) -> None:
+    """Check if FreeSurfer is properly installed and version is supported"""
+    freesurfer_home = os.environ.get("FREESURFER_HOME")
+    if not freesurfer_home:
+        raise FastSurferCompatError(
+            f"Did not find $FREESURFER_HOME. A working version of FreeSurfer {get_supported_freesurfer_version()} is "
+            f"needed to run {Path(__name__).name} locally. Make sure to export and source FreeSurfer before running "
+            f"this script:\n"
+            f"  export FREESURFER_HOME=/path/to/your/local/fs{get_supported_freesurfer_version()}\n"
+            f"  source $FREESURFER_HOME/SetUpFreeSurfer.sh"
+        )
+
+    if check_version:
+        build_stamp_file = Path(freesurfer_home) / "build-stamp.txt"
+        if build_stamp_file.exists():
+            with open(build_stamp_file) as f:
+                version_content = f.read().strip()
+            fs_support = get_supported_freesurfer_version()
+            if fs_support not in version_content:
+                raise FastSurferCompatError(
+                    f"You are trying to run recon-surf with FreeSurfer version {version_content}. We are currently "
+                    f"supporting only FreeSurfer {fs_support}. Therefore, make sure to export and source the correct "
+                    f"FreeSurfer version before running this script:\n"
+                    f"  export FREESURFER_HOME=/path/to/your/local/fs{fs_support}\n"
+                    f"  source $FREESURFER_HOME/SetUpFreeSurfer.sh"
+                )
+        else:
+            FastSurferCompatError("Could not find/read FreeSurfer build-stamp file.")
+
+def softlink_or_copy(source: str | Path, target: str | Path) -> None:
+    """Create soft link or copy file if linking fails"""
+    source_path = Path(source)
+    target_path = Path(target)
+
+    if target_path.exists():
+        target_path.unlink()
+
+    try:
+        target_path.symlink_to(source_path)
+    except OSError:
+        # If symlink fails, copy the file
+        import shutil
+
+        if not target_path.is_absolute():
+            target_path = (source.parent / target_path).resolve()
+        shutil.copy2(source_path, target_path)
+
+def get_voxel_size(image_file: Path) -> float:
+    """Get voxel size from aseg file using nibabel."""
+    try:
+        img = nib.load(str(image_file))
+        return float(img.header.get_zooms()[0])
+    except Exception as e:
+        raise FastSurferCompatError(f"ERROR: Could not read voxel size from {image_file}: {e}")
+
+@lru_cache
+def get_supported_freesurfer_version() -> str:
+    """Get FreeSurfer version from FreeSurfer from recon-surf.sh."""
+    recon_surf_script = Path(__file__).parent / "recon-surf.sh"
+    with recon_surf_script.open() as fp:
+        for line in fp.readlines():
+            if line.lstrip().startswith("FS_VERSION_SUPPORT"):
+                return line.strip().removeprefix("FS_VERSION_SUPPORT").lstrip(" =").strip("\"")
+    return "7.4.1"
+
+def make_parser() -> argparse.ArgumentParser:
+    """Parse command line arguments"""
+    from FastSurferCNN.utils.arg_types import int_gt_zero
+
+    parser = argparse.ArgumentParser(
+        description="long_compat_segmentHA.py takes a longitudinally processed subject and creates files "
+                    "missing for other longitudinal processing like the hippocampal subfields stream of FreeSurfer.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+               REFERENCES:
+
+               If you use this for research publications, please cite:
+
+               Henschel L, Conjeti S, Estrada S, Diers K, Fischl B, Reuter M, FastSurfer - A
+                fast and accurate deep learning based neuroimaging pipeline, NeuroImage 219
+                (2020), 117012. https://doi.org/10.1016/j.neuroimage.2020.117012
+
+               Henschel L*, Kuegler D*, Reuter M. (*co-first). FastSurferVINN: Building
+                Resolution-Independence into Deep Learning Segmentation Methods - A Solution
+                for HighRes Brain MRI. NeuroImage 251 (2022), 118933. 
+                http://dx.doi.org/10.1016/j.neuroimage.2022.118933
+               """
+    )
+
+    # Required arguments
+    parser.add_argument("--sid", "--tid", dest="subject", required=True, metavar="subject id",
+                        help="Template to create directory inside $SUBJECTS_DIR.")
+    parser.add_argument("--sd", dest="subjects_dir", type=validate_existing_subjects_dir,
+                        default=Path(os.environ.get("SUBJECTS_DIR", "/")), required=not os.environ.get("SUBJECTS_DIR"),
+                        help=f"Output directory, default: SUBJECTS_DIR env var ({os.environ.get('SUBJECTS_DIR', '')}).")
+
+    # Optional arguments
+    parser.add_argument("--threads", type=int_gt_zero, default=1,
+                        help="Set openMP and ITK threads to <int>.")
+    parser.add_argument("--fs_license", dest="fs_license", type=validate_existing_file,
+                        help="Path to FreeSurfer license key file.")
+    parser.add_argument("--version", action="version", version=f"long_compat_segmentHA: {VERSION}")
+
+    # Dev flags
+    parser.add_argument("--ignore_fs_version", action="store_true",
+                        help=f"Switch on to avoid check for FreeSurfer version. Program will otherwise terminate "
+                             f"if FreeSurfer {get_supported_freesurfer_version()} is not sourced.")
+
+    return parser
+
+def validate_inputs(subject_dir: Path):
+    """Validate all input arguments and environment"""
+    # Check path length
+    if len(str(subject_dir)) > 185:
+        raise FastSurferCompatError(
+            "Subject directory path is very long. This is known to cause errors due to some commands run by "
+            "FreeSurfer versions built for Ubuntu. --sd + --sid should be less than 185 characters long."
+        )
+
+    # Check if subject exists and has required files
+    tpfile = subject_dir / "base-tps.fastsurfer"
+    if not tpfile.exists():
+        raise FastSurferCompatError(
+            f"{args.subject} is either not found in $SUBJECTS_DIR or it is not a longitudinal template directory "
+            f"(base), which needs to contain base-tps.fastsurfer file. Please ensure that the base (template) has been "
+            f"created with long_prepare_template.sh."
+        )
+
+    # Check for aseg.mgz
+    aseg_file = subject_dir / "mri" / "aseg.mgz"
+    if not aseg_file.exists():
+        raise FastSurferCompatError(
+            f"aseg segmentation ({aseg_file}) could not be found! Segmentation must exist at location."
+        )
+
+    # Check if already processed
+    segfile = subject_dir / "mri" / "aparc.DKTatlas+aseg.mapped.mgz"
+    if segfile.exists():
+        raise FastSurferCompatError(
+            f"{segfile} already exists! The output directory must not contain the generated files! {segfile}, "
+            f".../mri/aparc.DKTatlas+aseg.mgz, .../mri/aparc+aseg.mgz, .../mri/wmparc.DKTatlas.mapped.mgz, "
+            f".../mri/wmparc.mgz, and .../base-tps ."
+        )
+
+
+def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, ignore_fs_version: bool = False) -> None:
+    """
+    Takes a longitudinally processed subject and creates files missing for other longitudinal processing like the
+    hippocampal subfields stream of FreeSurfer.
+
+    Parameters
+    ----------
+    subjects_dir : Path
+        The subjects_dir with one subject per subdir.
+    subject : str
+        The subject id.
+    fs_license : Path
+        The path to FreeSurfer license file.
+    threads : int, default=1
+        The number of threads to use.
+    ignore_fs_version : bool, default=False
+        Ignore FreeSurfer version if True.
+    """
+    print(f"\nlong_compat_segmentHA: {VERSION}")
+    print(f"sid {subject}")
+    print()
+
+    try:
+        # Check FreeSurfer
+        check_freesurfer(not ignore_fs_version)
+
+        # Validate inputs
+        subject_dir = subjects_dir / subject
+        validate_inputs(subject_dir)
+
+        # Set threading environment
+        env = dict(os.environ)
+        env["OMP_NUM_THREADS"] = str(threads)
+        env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(threads)
+        env["FS_LICENSE"] = str(fs_license)
+
+        # Create FreeSurfer-compatible timepoint symlinks
+        tpfile = subject_dir / "base-tps.fastsurfer"
+        print("Copying/symlinking timepoints...")
+        with open(subject_dir / tpfile) as f:
+            for line in f.readlines():
+                source = line.strip()
+                if source:
+                    target = f"{source}.long.{subject}"
+                    softlink_or_copy(subjects_dir / source, target)
+                    print(f"Created link: {source} -> {target}")
+
+        # Setup variables
+        mdir = subject_dir / "mri"
+        ldir = subject_dir / "label"
+        sdir = subject_dir / "surf"
+        aseg_segfile = mdir / "aseg.mgz"
+
+        # Get voxel size and determine hires flag
+        vox_size = get_voxel_size(aseg_segfile)
+        hires_voxsize_threshold = 0.999
+
+        if vox_size < hires_voxsize_threshold:
+            print(f"The voxel size {vox_size} is less than {hires_voxsize_threshold}, "
+                  f"so we are proceeding with hires options.")
+            hiresflag = "-hires"
+        else:
+            print(f"The voxel size {vox_size} is not less than {hires_voxsize_threshold}, "
+                  f"so we are proceeding with standard options.")
+            hiresflag = ""
+
+        # CREATE cortical ribbon (approx 5mins)
+        # CREATE ASEG
+        # 25 sec hyporelabel run whatever else can be done without sphere, cortical ribbon and segmentations
+        # -hyporelabel creates aseg.presurf.hypos.mgz from aseg.presurf.mgz
+        # -apas2aseg creates aseg.mgz by editing aseg.presurf.hypos.mgz with surfaces
+        print("Creating cortical ribbon...")
+        os.umask(_umask := os.umask(0o22))
+        cmd = ["recon-all", "-subject", subject, "-cortribbon", "-hyporelabel", "-apas2aseg", "-umask", f"{_umask:o}"]
+        if hiresflag:
+            cmd.append(hiresflag)
+        if threads > 1:
+            cmd.extend(["-threads", str(threads), "-itkthreads", str(threads)])
+
+        print("Running: cortical ribbon creation")
+        Popen(cmd, env=env).forward_outputs(timeout=None)
+
+        # mapped aparcDKT to vol (1:30 min)
+        segfile = mdir / "aparc.DKTatlas+aseg.mapped.mgz"
+        wm_segfile = mdir / "wmparc.DKTatlas.mapped.mgz"
+        threads_flags = ("--threads", threads)
+
+        def hemi_flags(hemi: str, offset: int) -> list:
+            return [
+                f"--{hemi}-annot", ldir / f"{hemi}.aparc.DKTatlas.mapped.annot", offset,
+                f"--{hemi}-cortex-mask", ldir / f"{hemi}.cortex.label",
+                f"--{hemi}-white", sdir / f"{hemi}.white", f"--{hemi}-pial", sdir / f"{hemi}.pial",
+            ]
+
+        print("Mapping aparcDKT to volume...")
+        cmd = ["mri_surf2volseg", "--o", segfile, "--label-cortex", "--i", aseg_segfile, *threads_flags]
+
+        for hemi, offset in (("lh", 1000), ("rh", 2000)):
+            cmd.extend(hemi_flags(hemi, offset))
+
+        Popen(list(map(str, cmd)), env=env).forward_outputs(timeout=None)
+
+        # mapped wmparc (1:30 min)
+        print("Mapping wmparc...")
+        cmd = ["mri_surf2volseg", "--o", wm_segfile, "--label-wm", "--i", segfile, *threads_flags]
+
+        for hemi, offset in (("lh", 3000), ("rh", 4000)):
+            cmd.extend(hemi_flags(hemi, offset))
+
+        Popen(list(map(str, cmd)), env=env).forward_outputs(timeout=None)
+
+        # Create symbolic links
+        print("Creating symbolic links...")
+
+        softlink_or_copy(segfile.name, mdir / "aparc.DKTatlas+aseg.mgz")
+        softlink_or_copy(segfile.name, mdir / "aparc+aseg.mgz")
+        softlink_or_copy("wmparc.DKTatlas.mapped.mgz", mdir / "wmparc.mgz")
+
+        softlink_or_copy(subjects_dir / "base-tps.fastsurfer", "base-tps")
+
+        print(f"Processing {subject} completed successfully!")
+
+    except FastSurferCompatError as e:
+        print(str(e))
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\nProcessing interrupted by user.")
+        sys.exit(130)
+    except Exception as e:
+        from traceback import print_exception
+        print(f"Unexpected error:")
+        print_exception(e)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    parser = make_parser()
+    args = parser.parse_args()
+
+    main(
+        subjects_dir=args.subjects_dir,
+        subject=args.subject,
+        fs_license=args.fs_license,
+        threads=args.threads,
+        ignore_fs_version=args.ignore_fs_version,
+    )

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -136,13 +136,19 @@ def run(command: list[str], *args, **kwargs) -> CompletedProcess:
 
 def make_parser() -> argparse.ArgumentParser:
     """Parse command line arguments"""
-    from FastSurferCNN.utils.arg_types import int_gt_zero
+    from textwrap import dedent
+
+    def int_gt_zero(value: str | int) -> int:
+        val = int(value)
+        if val <= 0:
+            raise ValueError("Invalid value, must not be negative.")
+        return val
 
     parser = argparse.ArgumentParser(
         description="long_compat_segmentHA.py takes a longitudinally processed subject and creates files "
                     "missing for other longitudinal processing like the hippocampal subfields stream of FreeSurfer.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
+        epilog=dedent("""
                REFERENCES:
 
                If you use this for research publications, please cite:
@@ -154,7 +160,7 @@ def make_parser() -> argparse.ArgumentParser:
                Henschel L, Kuegler D (co-first), Reuter M.. FastSurferVINN: Building Resolution-Independence into 
                 Deep Learning Segmentation Methods - A Solution for HighRes Brain MRI. NeuroImage 251 (2022), 118933. 
                 http://dx.doi.org/10.1016/j.neuroimage.2022.118933
-               """
+               """)
     )
 
     # Required arguments
@@ -235,13 +241,16 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
 
         # Validate inputs
         subject_dir = subjects_dir / subject
-        validate_inputs(subjects_dir)
+        validate_inputs(subject_dir)
 
         # Set threading environment
         env = dict(os.environ)
         env["OMP_NUM_THREADS"] = str(threads)
         env["ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS"] = str(threads)
         env["FS_LICENSE"] = str(fs_license)
+        env["SUBJECTS_DIR"] = str(subjects_dir)
+        if env["FREESURFER_HOME"] not in env["PATH"]:
+            env["PATH"] = env["FREESURFER_HOME"] + "/bin:" + env["PATH"]
 
         # Create FreeSurfer-compatible timepoint symlinks
         tpfile = subject_dir / "base-tps.fastsurfer"
@@ -269,7 +278,7 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         hires_voxsize_threshold = 0.999
 
         hires = vox_size < hires_voxsize_threshold
-        print(f"The voxel size {vox_size} is {'not ' if hires else ''}less than {hires_voxsize_threshold}, so we are "
+        print(f"The voxel size {vox_size} is {'' if hires else 'not '}less than {hires_voxsize_threshold}, so we are "
               f"proceeding with {'hires' if hires else 'standard'} options.")
 
         # CREATE cortical ribbon (approx 5mins)
@@ -286,7 +295,8 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
             cmd.extend(["-threads", str(threads), "-itkthreads", str(threads)])
 
         print("Running: cortical ribbon creation")
-        completed = run(cmd, env=env, stdout=STDOUT, stderr=STDOUT)
+
+        completed = run(cmd, env=env)
         if completed.returncode != 0:
             raise FastSurferCompatError("Creating cortical ribbon failed!")
 
@@ -308,7 +318,7 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         for hemi, offset in (("lh", 1000), ("rh", 2000)):
             cmd.extend(hemi_flags(hemi, offset))
 
-        completed = run(list(map(str, cmd)), env=env, stdout=STDOUT, stderr=STDOUT)
+        completed = run(list(map(str, cmd)), env=env)
         if completed.returncode != 0:
             raise FastSurferCompatError("Mapping aparcDKT failed!")
 
@@ -319,7 +329,7 @@ def main(subjects_dir: Path, subject: str, fs_license: Path, threads: int = 1, i
         for hemi, offset in (("lh", 3000), ("rh", 4000)):
             cmd.extend(hemi_flags(hemi, offset))
 
-        completed = run(list(map(str, cmd)), env=env, stdout=STDOUT, stderr=STDOUT)
+        completed = run(list(map(str, cmd)), env=env)
         if completed.returncode != 0:
             raise FastSurferCompatError("Mapping wmparc failed!")
 


### PR DESCRIPTION
The PR adds a compatibility script that generates longitudinal files for subjects processed with longitudinal FastSurfer, but that do not need to be generated for all analysis (#702). These additional files in the template are, however, used by follow-up tools like the longitudinal Hippocampus and Amydala stream of FreeSurfer.

This script generates those needed files.

This PR is currently in draft state as additional testing is required.