### PR TITLE
Fix srun_fastsurfer termination on files inspection

### DIFF
--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -230,7 +230,7 @@ LF="$SUBJECTS_DIR/$tid/scripts/long_prepare_template.log"
 mkdir -p "$(dirname "$LF")"
 
 export PYTHONPATH
-PYTHONPATH="$FASTSURFER_HOME$([[ -n "$PYTHONPATH" ]] && echo ":$PYTHONPATH")"
+PYTHONPATH="$FASTSURFER_HOME$([[ -n "$PYTHONPATH" ]] && echo ":$PYTHONPATH" || echo "")"
 
 ## make sure +eo are unset
 set +eo > /dev/null

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -506,7 +506,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 # make sure FastSurfer is in the PYTHONPATH
 export PYTHONPATH
-PYTHONPATH="$FASTSURFER_HOME$([[ -n "$PYTHONPATH" ]] && echo ":$PYTHONPATH")"
+PYTHONPATH="$FASTSURFER_HOME$([[ -n "$PYTHONPATH" ]] && echo ":$PYTHONPATH" || echo "")"
 
 ########################################## VERSION AND QUIT HERE ########################################
 # make sure the python  executable is valid and found

--- a/stools.sh
+++ b/stools.sh
@@ -209,8 +209,8 @@ function check_subject_images ()
   done
   if [[ -n "$missing_subject_ids" ]]
   then
-    condition=$([[ -n "$missing_subject_imgs" ]] && echo " or missing")
-    condition+=$([[ -n "$symlink_subject_imgs" ]] && echo " or symlinks")
+    condition=$([[ -n "$missing_subject_imgs" ]] && echo " or missing" || echo "")
+    condition+=$([[ -n "$symlink_subject_imgs" ]] && echo " or symlinks" || echo "")
     echo "$([[ "${condition:4:1}" == m ]] && echo "ERROR" || echo "WARNING"): Some images are ${condition:4}!"
     echo "Subject IDs: ${missing_subject_ids:2}"
     if [[ -n "$missing_subject_imgs" ]] ; then echo "Missing files: ${missing_subject_imgs:2}" ; fi


### PR DESCRIPTION
This PR fixes issues of srun_fastsurfer terminating without proper error message. 

This occurs when pipeline-checks return with a non-zero value and terminating, if its condition is not met. See #740.

In stools (and srun_fastsurfer), we use such a condition to generate the content of a variable, but this may terminate the script if run with `set -e` which srun_fastsurfer.sh sets itself.

So this addresses situations, where a short if-else statement is intented in bash of the form: `[[ <condition> ]] && echo "true-value" || echo "false-value"`, but the `false-value` is intended to be "" and thus abbreviated to `[[ <condition> ]] && echo "true-value"` (which returns a non-zero exit code in for the whole statement).