### PR TITLE
Fix quicktest outputs if FastSurfer fails

### DIFF
--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -109,10 +109,12 @@ runs:
         echo "::group::Save ${{ inputs.subject-id }} as an artifact"
     - name: Create archive of Processed subject-data
       shell: bash
+      if: ${{ always() && steps.load-docker.outcome == 'success' }}
       run: |
         # Archive data code
         tar cfz "$DATA_DIR/${{ inputs.subject-id }}.tar.gz" -C "$DATA_DIR" "${{ inputs.subject-id }}"
     - name: Save processed data
+      if: ${{ always() && steps.load-docker.outcome == 'success' }}
       uses: actions/upload-artifact@v4
       with:
         name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -109,12 +109,12 @@ runs:
         echo "::group::Save ${{ inputs.subject-id }} as an artifact"
     - name: Create archive of Processed subject-data
       shell: bash
-      if: ${{ always() && steps.load-docker.outcome == 'success' }}
+      if: ${{ always() && (steps.prep.outputs.IMAGE_LOADED != 0 || steps.load-docker.outcome == 'success') }}
       run: |
         # Archive data code
         tar cfz "$DATA_DIR/${{ inputs.subject-id }}.tar.gz" -C "$DATA_DIR" "${{ inputs.subject-id }}"
     - name: Save processed data
-      if: ${{ always() && steps.load-docker.outcome == 'success' }}
+      if: ${{ always() && (steps.prep.outputs.IMAGE_LOADED != 0 || steps.load-docker.outcome == 'success') }}
       uses: actions/upload-artifact@v4
       with:
         name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -132,7 +132,7 @@ function RunBatchJobs()
   # now append their logs to the main log file
   for log in "${LOGS[@]}"
   do
-    cat "$log" >> "$LOG_FILE"
+    tee -a "$LOG_FILE" < "$log"
     rm -f "$log"
   done
   echo "PIDs (${PIDS[*]}) completed and logs appended."


### PR DESCRIPTION
Save quicktest processing artifacts output, even if fastsurfer fails, so we can download and inspect the output on fails.

Always print the parallel-processed hemi-wise logfiles to the console, so we have full logs in quicktest actions.