### PR TITLE
Fix and update spherical project

### DIFF
--- a/FastSurferCNN/utils/run_tools.py
+++ b/FastSurferCNN/utils/run_tools.py
@@ -14,15 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import subprocess
 from collections.abc import Generator, Sequence
 from concurrent.futures import Executor, Future
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partialmethod
-
-# TODO: python3.9+
-# from collections.abc import Generator
+from typing import IO, AnyStr
 
 
 @dataclass
@@ -77,28 +76,41 @@ class Popen(subprocess.Popen):
         super().__init__(*args, **kwargs)
 
     def messages(self, timeout: float) -> Generator[MessageBuffer, None, None]:
+        """
+
+        Parameters
+        ----------
+        timeout : float
+            Time in seconds to wait, before checking if the process is still alive.
+
+        Yields
+        -------
+        MessageBuffer
+            A MessageBuffer object with stdout and stderr information.
+        """
         from subprocess import TimeoutExpired
 
+        yielded_returncode = None
         start = self._starttime or datetime.now()
         while self.poll() is None:
             try:
                 stdout, stderr = self.communicate(timeout=timeout)
+                yielded_returncode = self.returncode
                 yield MessageBuffer(
                     out=stdout if stdout else b"",
                     err=stderr if stderr else b"",
-                    retcode=self.returncode,
+                    retcode=yielded_returncode,
                     runtime=(datetime.now() - start).total_seconds(),
                 )
             except TimeoutExpired:
                 pass
 
-        _stdout = (
-            b"" if self.stdout is None or self.stdout.closed else self.stdout.read()
-        )
-        _stderr = (
-            b"" if self.stderr is None or self.stderr.closed else self.stderr.read()
-        )
-        if _stderr != b"" or _stdout != b"":
+        def data_to_read(file: IO[AnyStr] | None) -> bool:
+            return file is not None and not file.closed
+
+        _stdout = self.stdout.read() if data_to_read(self.stdout) else b""
+        _stderr = self.stderr.read() if data_to_read(self.stderr) else b""
+        if _stderr != b"" or _stdout != b"" or yielded_returncode is None:
             yield MessageBuffer(
                 out=_stdout,
                 err=_stderr,
@@ -175,7 +187,7 @@ class Popen(subprocess.Popen):
             msg.retcode = self.returncode
         return msg
 
-    def as_future(self, pool: Executor, timeout: float = None) -> Future:
+    def as_future(self, pool: Executor, timeout: float | None = None) -> Future:
         """
         Similar to `finish` in its application, but as non-blocking Future.
 
@@ -183,6 +195,8 @@ class Popen(subprocess.Popen):
         ----------
         pool : Executor
             A concurrent.futures.Executor, usually a ThreadPoolExecutor.
+        timeout : float, optional
+            Time in seconds to wait, before returning to host process (None: unlimited).
 
         Returns
         -------
@@ -198,6 +212,48 @@ class Popen(subprocess.Popen):
 
     async def async_finish(self, timeout: float = None) -> MessageBuffer:
         return self.finish(timeout)
+
+    def forward_output(
+        self,
+        file: io.TextIOBase | None = None,
+        encoding: str | None = None,
+        timeout: float | None = None,
+        out_prefix: str = "",
+        err_prefix: str = "!",
+    ) -> MessageBuffer:
+        """
+        Forwards the stdout and stderr every timeout to file. Returns the full output
+        as a MessageBuffer object.
+
+        Parameters
+        ----------
+        file: IO.TextIO, optional
+
+        encoding: str, optional
+            Charset to encode.
+        timeout: float, optional
+            Interval to let the child process, before returning to the parent (this)
+            process.
+        out_prefix: str, default=""
+            String to prefix lines from the stdout output.
+        err_prefix: str, default="!"
+            String to prefix lines from the stderr output.
+
+        Returns
+        -------
+        MessageBuffer
+            Full stdout, stderr and returncode.
+        """
+        done = MessageBuffer()
+        for outputs in self.messages(timeout=timeout):
+            outputs.forward_output(
+                file=file,
+                encoding=encoding,
+                out_prefix=out_prefix,
+                err_prefix=err_prefix,
+            )
+            done += outputs
+        return done
 
 
 class PyPopen(Popen):

--- a/FastSurferCNN/utils/run_tools.py
+++ b/FastSurferCNN/utils/run_tools.py
@@ -222,21 +222,19 @@ class Popen(subprocess.Popen):
         err_prefix: str = "!",
     ) -> MessageBuffer:
         """
-        Forwards the stdout and stderr every timeout to file. Returns the full output
-        as a MessageBuffer object.
+        Forwards the stdout and stderr every timeout to file. Returns the full output as a MessageBuffer object.
 
         Parameters
         ----------
-        file: IO.TextIO, optional
-
-        encoding: str, optional
+        file : IO.TextIO, optional
+            The file or stream to which the output should be forwarded.
+        encoding : str, optional
             Charset to encode.
-        timeout: float, optional
-            Interval to let the child process, before returning to the parent (this)
-            process.
-        out_prefix: str, default=""
+        timeout : float, optional
+            Interval to let the child process, before returning to the parent (this) process.
+        out_prefix : str, default=""
             String to prefix lines from the stdout output.
-        err_prefix: str, default="!"
+        err_prefix : str, default="!"
             String to prefix lines from the stderr output.
 
         Returns

--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -11,7 +11,12 @@ if FSTIME_LOAD=0 "${binpath}fs_time" echo testing &> /dev/null ; then timecmd="$
 else timecmd="" ; echo "INFO: Testing fs_time was not successful, not reporting per-command runtimes."
 fi
 export timecmd
-if [[ "$LC_NUMERIC" != "en_US.UTF-8" ]] ; then export LC_NUMERIC="en_US.UTF-8" ; fi
+
+if [[ "$(locale decimal_point)" != "." ]] ; then export LC_NUMERIC="en_US.UTF-8" ; fi
+if [[ "$(locale decimal_point)" != "." ]] ; then
+  echo "WARNING: Could not change \$LC_NUMERIC, but FastSurfer requires decimal_point=., please configure your locale"
+  echo "  to use a '.' decimal_point, e.g. export LC_NUMERIC=en_US.UTF-8 !"
+fi
 
 function check_create_subjects_dir_properties()
 {

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -781,13 +781,9 @@ for hemi in lh rh ; do
       cmd="recon-all -subject $subject -hemi $hemi -qsphere -no-isrunning -umask $(umask) $hiresflag $fsthreads"
       RunIt "$cmd" "$LF" "$CMDF"
     else
-      # instead of mris_sphere, directly project to sphere with spectral approach
-      # equivalent to -qsphere
-      # (23sec)
-      cmd="$python ${binpath}spherically_project_wrapper.py --hemi $hemi --sdir $sdir"
-      printf -v tmp %q "$python"
-      cmd="$cmd --subject $subject --threads=$threads_hemi --py ${tmp} --binpath ${binpath}"
-      RunIt "$cmd" "$LF" "$CMDF"
+      # instead of mris_sphere, directly project to sphere with spectral approach equivalent to -qsphere (23sec)
+      cmda=("${binpath}spherically_project_wrapper.py" --hemi "$hemi" --sdir "$sdir" --subject "$subject")
+      run_it_cmdf "$LF" "$CMDF" $python "${cmda[@]}" --threads "$threads_hemi"
     fi
 
   fi # not long
@@ -1369,7 +1365,7 @@ fi # not base run
 # Collect info
 EndTime=$(date)
 tSecEnd=$(date '+%s')
-tRunHours=$(LC_NUMERIC="en_US.UTF-8" printf %6.3f "$(bc -l <<< "($tSecEnd - $tSecStart) / 3600")")
+tRunHours=$(printf %6.3f "$(bc -l <<< "($tSecEnd - $tSecStart) / 3600")")
 
 {
   echo ""

--- a/recon_surf/spherically_project.py
+++ b/recon_surf/spherically_project.py
@@ -17,6 +17,7 @@
 import math
 import optparse
 import sys
+from pathlib import Path
 
 import nibabel.freesurfer.io as fs
 import numpy as np
@@ -265,9 +266,7 @@ def tria_spherical_project(
     # do a few mean curvature flow euler steps to make more convex
     # three should be sufficient
     if flow_iter > 0:
-        tflow = tria_mean_curvature_flow(
-            TriaMesh(vn, tria.t), max_iter=flow_iter, use_cholmod=use_cholmod
-        )
+        tflow = tria_mean_curvature_flow(TriaMesh(vn, tria.t), max_iter=flow_iter, use_cholmod=use_cholmod)
         vn = tflow.v
 
     # project to sphere and scaled to have the same scale/origin as FS:
@@ -304,26 +303,24 @@ def tria_spherical_project(
 
 
 def spherically_project_surface(
-        insurf: str,
-        outsurf: str,
-        use_cholmod: bool = True
+        insurf: Path | str,
+        outsurf: Path | str,
+        use_cholmod: bool = True,
 ) -> None:
     """Take path to insurf, spherically projects it, outputs it to outsurf.
 
     Parameters
     ----------
-    insurf : str
+    insurf : Path, str
         Path to input surface file
-    outsurf : str
+    outsurf : Path, str
         Path to output surface file
     use_cholmod : bool
         Try to use the Cholesky decomposition from the cholmod. Defaults to True
 
     """
     surf = fs.read_geometry(insurf, read_metadata=True)
-    projected = tria_spherical_project(
-        TriaMesh(surf[0], surf[1]), flow_iter=3, use_cholmod=use_cholmod
-    )
+    projected = tria_spherical_project(TriaMesh(surf[0], surf[1]), flow_iter=3, use_cholmod=use_cholmod)
     fs.write_geometry(outsurf, projected.v, projected.t, volume_info=surf[2])
 
 

--- a/recon_surf/spherically_project_wrapper.py
+++ b/recon_surf/spherically_project_wrapper.py
@@ -15,9 +15,7 @@
 
 # IMPORTS
 import argparse
-from os import umask
-from subprocess import PIPE, Popen
-from typing import Any
+from pathlib import Path
 
 
 def setup_options():
@@ -33,110 +31,63 @@ def setup_options():
     parser = argparse.ArgumentParser(description="Wrapper for spherical projection")
 
     parser.add_argument("--hemi", type=str, help="Hemisphere to analyze.")
-    parser.add_argument("--sdir", type=str, help="Surface directory of subject.")
+    parser.add_argument("--sdir", type=Path, help="Surface directory of subject.")
     parser.add_argument("--subject", type=str, help="Name (ID) of subject.")
     parser.add_argument("--threads", type=int, help="Number of threads to use.")
-    parser.add_argument("--py", type=str, help="which python version to use.")
-    parser.add_argument(
-        "--binpath", type=str, help="directory of spherically_project.py script."
-    )
 
     args = parser.parse_args()
     return args
 
 
-def call(command: list[str], **kwargs: Any) -> int:
-    """
-    Run command with arguments.
-
-    Wait for command to complete. Sends output to logging module.
-
-    Parameters
-    ----------
-    command : list[str]
-        Command to call.
-    **kwargs : Any
-        Keyword arguments.
-        
-
-    Returns
-    -------
-    int
-       Returncode of called command.
-    """
-    kwargs["stdout"] = PIPE
-    kwargs["stderr"] = PIPE
-    p = Popen(command, **kwargs)
-    stdout, stderr = p.communicate()
-
-    if stdout:
-        for line in stdout.decode("utf-8").split("\n"):
-            print(line)
-    if stderr:
-        print("stderr")
-        for line in stderr.decode("utf-8").split("\n"):
-            print(line)
-
-    return p.returncode
-
-
-def spherical_wrapper(command1: list[str], command2: list[str], **kwargs: Any) -> int:
-    """
-    Run the first command. If it fails the fallback command is run instead.
-
-    Parameters
-    ----------
-    command1 : list[str]
-        Command to call.
-    command2 : list[str]
-        Fallback command to call.
-    **kwargs : Any
-        Arguments. The same as for the Popen constructor.
-
-    Returns
-    -------
-    code_1
-        Return code of command1. If command1 failed return code of command2.
-    """
-    # First try to run standard spherical project
-    print(f"Running command: {command1}")
-    code_1 = call(command1, **kwargs)
-
-    if code_1 != 0:
-        print(f"Command {command1} failed.\nRunning fallback command: {command2}")
-        code_1 = call(command2, **kwargs)
-
-    return code_1
-
-
 if __name__ == "__main__":
-
+    import sys
     opts = setup_options()
-    cmd1 = [
-        opts.py,
-        f"{opts.binpath}spherically_project.py",
-        "-i", f"{opts.sdir}/{opts.hemi}.smoothwm.nofix",
-        "-o", f"{opts.sdir}/{opts.hemi}.qsphere.nofix",
-    ]
 
-    threading = ()
-    if opts.threads > 1:
-        threading = ("-threads", str(opts.threads), "-itkthreads", str(opts.threads))
+    # identify whether sksparse is installed (in which case we can use_cholmod in LaPy
+    try:
+        # ignore ruff F401 (unused import)
+        from sksparse import cholmod  # noqa F401
+        has_sksparse = True
+    except ImportError:
+        has_sksparse = False
+        # First try to run standard spherical project
+    try:
+        from os import environ
 
-    # get the umask (for some reason this can only be returned if it is also set, so we set it to 2 just to get the
-    # current value)
-    umask = umask(_umask := umask(0o02))
-    cmd2 = [
-        "recon-all",
-        "-s", opts.subject,
-        "-hemi", opts.hemi,
-        "-qsphere",
-        "-no-isrunning",
-        "-umask", str(_umask),
-        *threading,
-    ]
-    # make sure the process has a username, so nibabel does not crash in write_geometry
-    from os import environ
-    env = dict(environ)
-    env.setdefault("USERNAME", "UNKNOWN")
-    spherical_wrapper(cmd1, cmd2, env=env)
+        from recon_surf.spherically_project import spherically_project_surface
+
+        source_surface = opts.sdir / f"{opts.hemi}.smoothwm.nofix"
+        projected_surface = opts.sdir / f"{opts.hemi}.qsphere.nofix"
+        print(f"Reading in surface: {source_surface} ...")
+
+        # make sure the process has a username, so nibabel does not crash in write_geometry
+        environ.setdefault("USERNAME", "UNKNOWN")
+
+        # only switch cholmod on if we have scikit sparse cholmod (cholmod on will be faster)
+        spherically_project_surface(source_surface, projected_surface, use_cholmod=has_sksparse)
+        print(f"Spherically projected surface output to: {projected_surface}")
+
+    except Exception as e:
+        import shutil
+        from os import umask
+        from traceback import print_exception
+
+        from FastSurferCNN.utils.run_tools import Popen
+
+        print_exception(e)
+
+        # get the umask (for some reason this can only be returned if it is also set, so we set it to 2 just to get the
+        # current value)
+        umask(_umask := umask(0o02))
+
+        # run the FreeSurfer fallback command
+        recon_all = shutil.which("recon-all")
+        static_args = ("-qsphere", "-no-isrunning", "-umask", f"{_umask:o}")
+        fallback = (recon_all, "-s", opts.subject, " -hemi ", opts.hemi) + static_args
+        if opts.threads > 1:
+            fallback += ("-threads", str(opts.threads), "-itkthreads", str(opts.threads))
+
+        print(f"spherical_project.py failed.\nRunning fallback command: {' '.join(fallback)}")
+        process = Popen(fallback, env=dict(environ, SUBJECTS_DIR=str(opts.sdir)))
+        done = process.forward_output(encoding="utf-8", timeout=None)
+        sys.exit(done.retcode)


### PR DESCRIPTION
Currently, recon-surf crashes in the dev docker, because it tries to run `"python 3.10 -s"` -- which obviously does not exist, it would correctly be `python3.10 -s`.

To fix this issue, we can even fully cut out a call to python, by just importing python another time instead of starting a new child python instance.

This PR includes:
- Let the `spherically_project_wrapper` script import and call the functionality of `spherically_project`, i.e. try to not create a new python process.
- Adds the `forward_output` function to `run_tools.Popen` to collect both stderr and stdout into one output stream while at the same time adding an optional prefix.
- Formatting cleanup of `run_tools` and `spherically_project`
- Less changes to the LC_NUMERIC environment variable, which raises warnings (due to not being allowed to change this variable on non en_US.UTF-8 systems. Now, these messages are reduced and required decimal point properties are better warned about (FreeSurfer requires a LOCALE with a decimal point of ".").