### PR TITLE
Updates in preparation for FastSurferCC

### DIFF
--- a/CerebNet/datasets/utils.py
+++ b/CerebNet/datasets/utils.py
@@ -16,7 +16,7 @@
 # IMPORTS
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TypedDict, TypeVar
+from typing import Literal, TypedDict, TypeVar
 
 import nibabel as nib
 import numpy as np
@@ -63,6 +63,7 @@ CLASS_NAMES = {
 subseg_labels = {"cereb_subseg": np.array(list(CLASS_NAMES.values()))}
 
 AT = TypeVar("AT", np.ndarray, torch.Tensor)
+AffineMatrix4x4 = np.ndarray[tuple[Literal[4], Literal[4]], np.dtype[float]]
 
 
 class LTADict(TypedDict):
@@ -70,7 +71,7 @@ class LTADict(TypedDict):
     nxforms: int
     mean: list[float]
     sigma: float
-    lta: npt.NDArray[float]
+    lta: AffineMatrix4x4
     src_valid: int
     src_filename: str
     src_volume: list[int]

--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -32,9 +32,9 @@ from CerebNet.utils import checkpoint as cp
 from FastSurferCNN.data_loader.conform import crop_transform
 from FastSurferCNN.utils import PLANES, Plane, logging
 from FastSurferCNN.utils.arg_types import ImageSizeOption, OrientationType
-from FastSurferCNN.utils.common import SerialExecutor, SubjectDirectory, SubjectList, find_device
+from FastSurferCNN.utils.common import SubjectDirectory, SubjectList, find_device
 from FastSurferCNN.utils.mapper import JsonColorLookupTable, Mapper, TSVLookupTable
-from FastSurferCNN.utils.threads import get_num_threads
+from FastSurferCNN.utils.threads import SerialExecutor, get_num_threads
 
 if TYPE_CHECKING:
     import yacs.config
@@ -430,9 +430,9 @@ class Inference:
         start_time = time.time()
         with logging_redirect_tqdm():
             if self._async_io:
-                from FastSurferCNN.utils.common import pipeline as iterate
+                from FastSurferCNN.utils.threads import pipeline as iterate
             else:
-                from FastSurferCNN.utils.common import iterate
+                from FastSurferCNN.utils.threads import iterate
             iter_subjects = iterate(self.pool, self._get_subject_dataset, subject_dirs)
             futures = []
             for idx, (subject, _data) in tqdm(enumerate(iter_subjects), total=len(subject_dirs), desc="Subject"):

--- a/CerebNet/inference.py
+++ b/CerebNet/inference.py
@@ -34,7 +34,7 @@ from FastSurferCNN.utils import PLANES, Plane, logging
 from FastSurferCNN.utils.arg_types import ImageSizeOption, OrientationType
 from FastSurferCNN.utils.common import SubjectDirectory, SubjectList, find_device
 from FastSurferCNN.utils.mapper import JsonColorLookupTable, Mapper, TSVLookupTable
-from FastSurferCNN.utils.threads import SerialExecutor, get_num_threads
+from FastSurferCNN.utils.parallel import SerialExecutor, get_num_threads
 
 if TYPE_CHECKING:
     import yacs.config
@@ -430,9 +430,9 @@ class Inference:
         start_time = time.time()
         with logging_redirect_tqdm():
             if self._async_io:
-                from FastSurferCNN.utils.threads import pipeline as iterate
+                from FastSurferCNN.utils.parallel import pipeline as iterate
             else:
-                from FastSurferCNN.utils.threads import iterate
+                from FastSurferCNN.utils.parallel import iterate
             iter_subjects = iterate(self.pool, self._get_subject_dataset, subject_dirs)
             futures = []
             for idx, (subject, _data) in tqdm(enumerate(iter_subjects), total=len(subject_dirs), desc="Subject"):

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -666,7 +666,7 @@ def conform(
         Conform the image to this image size, e.g. a specific smaller size (for example for high-res), or automatically
         determine the image size from the field of view ('fov' or 'auto', the former may yield non-cube-images). `None`
         disables this criterion.
-    dtype : type, None, default=np.unit8
+    dtype : type, None, default=np.uint8
         The dtype to enforce in the image (default: UCHAR, as mri_convert -c). `None` disregards this criterion.
     orientation : "soft-<orientationcode>", "<orientationcode>", "native", None, default="lia"
         Which orientation of the data/affine to force, <orientationcode> is [rlapsi]{3}, ie.e. any of lia, ras, etc.,
@@ -906,7 +906,7 @@ def is_conform(
         img: nib.analyze.SpatialImage,
         vox_size: VoxSizeOption | None = 1.0,
         img_size: ImageSizeOption | None = 256,
-        dtype: type | None = np.uint8,
+        dtype: npt.DTypeLike | None = np.uint8,
         orientation: OrientationType | None = "lia",
         verbose: bool = True,
         vox_eps: float = 1e-4,
@@ -1012,7 +1012,7 @@ def is_conform(
         checks["Dtype None"] = "IGNORED", dtype_text
     else:
         _dtype: npt.DTypeLike = to_dtype(dtype)
-        _dtype_name = _dtype.name if hasattr(_dtype, "name") else str(dtype)
+        _dtype_name = _dtype.name if hasattr(_dtype, "name") else str(getattr(np.dtype(_dtype), "name", dtype))
         checks[f"Dtype {_dtype_name}"] = np.issubdtype(img.get_data_dtype(), _dtype), dtype_text
 
     _is_conform = all(map(lambda x: x[0], checks.values()))
@@ -1037,7 +1037,7 @@ def is_conform(
     return _is_conform
 
 
-def to_dtype(dtype: str | np.dtype | type) -> npt.DTypeLike:
+def to_dtype(dtype: str | np.dtype | type | npt.DTypeLike) -> npt.DTypeLike:
     """
     Make sure to convert dtype to a numpy compatible dtype.
 
@@ -1061,7 +1061,8 @@ def to_dtype(dtype: str | np.dtype | type) -> npt.DTypeLike:
             return np.unsignedinteger
         elif hasattr(np, suptype):
             return getattr(np, suptype)
-    return np.dtype(dtype)
+        return np.dtype(dtype)
+    return dtype
 
 
 def is_orientation(

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -13,16 +13,29 @@
 # limitations under the License.
 
 # IMPORTS
-import copy
 import optparse
 import sys
+from functools import partial
+from pathlib import Path
+from typing import TypeVar, cast
 
 import nibabel as nib
 import numpy as np
 import scipy.ndimage
-from numpy import typing as npt
 from skimage.filters import gaussian
 from skimage.measure import label
+
+from FastSurferCNN.utils import logging
+from FastSurferCNN.utils.brainvolstats import mask_in_array
+from FastSurferCNN.utils.logging import setup_logging
+from FastSurferCNN.utils.threads import thread_executor
+
+_T = TypeVar("_T", bound=np.number)
+_TDType = np.dtype[_T]
+_TShape = TypeVar("_TShape", bound=tuple[int, ...])
+
+
+LOGGER = logging.getLogger(__name__)
 
 HELPTEXT = """
 Script to reduce aparc+aseg to aseg by mapping cortex labels back to left/right GM.
@@ -91,7 +104,7 @@ def options_parse():
     return options
 
 
-def reduce_to_aseg(data_inseg: np.ndarray) -> np.ndarray:
+def reduce_to_aseg(data_inseg: np.ndarray[_TShape, _TDType]) -> np.ndarray[_TShape, _TDType]:
     """
     Reduce the input segmentation to a simpler segmentation (for all data orientations, LIA/etc).
 
@@ -106,7 +119,7 @@ def reduce_to_aseg(data_inseg: np.ndarray) -> np.ndarray:
     data_inseg : np.ndarray, torch.Tensor
         The reduced segmentation.
     """
-    print("Reducing to aseg ...")
+    LOGGER.info("Reducing to aseg ...")
     # replace 2000... with 42
     data_inseg[data_inseg >= 2000] = 42
     # replace 1000... with 3
@@ -114,13 +127,13 @@ def reduce_to_aseg(data_inseg: np.ndarray) -> np.ndarray:
     return data_inseg
 
 
-def create_mask(aseg_data: npt.NDArray[int], dnum: int, enum: int) -> npt.NDArray[int]:
+def create_mask(aseg_data: np.ndarray[_TShape, _TDType], dnum: int, enum: int) -> np.ndarray[_TShape, np.dtype[bool]]:
     """
     Create dilated mask (works for all data orientations, LIA/etc).
 
     Parameters
     ----------
-    aseg_data : npt.NDArray[int]
+    aseg_data : int np.ndarray
         The input segmentation data.
     dnum : int
         The number of iterations for the dilation operation.
@@ -129,16 +142,16 @@ def create_mask(aseg_data: npt.NDArray[int], dnum: int, enum: int) -> npt.NDArra
 
     Returns
     -------
-    npt.NDArray[int]
-        Returns aseg_data.
+    bool np.ndarray same shape as aseg_data
+        Returns mask.
     """
-    print("Creating dilated mask ...")
+    LOGGER.info("Creating dilated mask ...")
 
     # treat lateral orbital frontal and parsorbitalis special to avoid capturing too much of eye nerve
-    lat_orb_front_mask = np.logical_or(aseg_data == 2012, aseg_data == 1012)
-    parsorbitalis_mask = np.logical_or(aseg_data == 2019, aseg_data == 1019)
-    frontal_mask = np.logical_or(lat_orb_front_mask, parsorbitalis_mask)
-    print("Frontal region special treatment: ", format(np.sum(frontal_mask)))
+    lat_orb_front_mask = [2012, 1012]
+    parsorbitalis_mask = [2019, 1019]
+    frontal_mask = mask_in_array(aseg_data, lat_orb_front_mask + parsorbitalis_mask)
+    LOGGER.info(f"Frontal region special treatment: {np.sum(frontal_mask)}")
 
     # reduce to binary
     datab = aseg_data > 0
@@ -154,22 +167,20 @@ def create_mask(aseg_data: npt.NDArray[int], dnum: int, enum: int) -> npt.NDArra
     # extract largest component
     labels = label(datab)
     assert labels.max() != 0  # assume at least 1 real connected component
-    print(f"  Found {labels.max()} connected component(s)!")
+    LOGGER.info(f"  Found {labels.max()} connected component(s)!")
 
     if labels.max() > 1:
-        print("  Selecting largest component!")
+        LOGGER.info("  Selecting largest component!")
         datab = labels == np.argmax(np.bincount(labels.flat)[1:]) + 1
 
     # add frontal regions back to mask
     datab[frontal_mask] = 1
 
     # set mask
-    aseg_data[~datab] = 0
-    aseg_data[datab] = 1
-    return aseg_data
+    return datab.astype(np.uint8)
 
 
-def flip_wm_islands(aseg_data : np.ndarray) -> np.ndarray:
+def flip_wm_islands(aseg_data : np.ndarray[_TShape, _TDType]) -> np.ndarray[_TShape, _TDType]:
     """
     Flip labels of disconnected white matter islands to the other hemisphere (works for all data orientations, LIA/etc).
 
@@ -193,27 +204,22 @@ def flip_wm_islands(aseg_data : np.ndarray) -> np.ndarray:
     rh_wm = 41
     rh_gm = 42
 
-    # for lh get largest component and islands
-    mask = aseg_data == lh_wm
-    labels = label(mask, background=0)
-    assert labels.max() != 0  # assume at least 1 connected component
-    bc = np.bincount(labels.flat)[1:]
-    largestID = np.argmax(bc) + 1
-    largestCC = labels == largestID
-    lh_islands = (~largestCC) & (labels > 0)
+    def _islands(data: np.ndarray[_TShape, np.dtype], _label: int) -> np.ndarray[_TShape, np.dtype[bool]]:
+        # for lh get largest component and islands
+        mask = data == _label
+        labels = label(mask, background=0)
+        assert labels.max() != 0  # assume at least 1 connected component
+        bc = np.bincount(labels.flat)[1:]
+        largest_id = np.argmax(bc) + 1
+        largest_cc = labels == largest_id
+        return (~largest_cc) & (labels > 0)
 
-    # same for rh
-    mask = aseg_data == rh_wm
-    labels = label(mask, background=0)
-    assert labels.max() != 0  # assume at least 1 CC
-    bc = np.bincount(labels.flat)[1:]
-    largestID = np.argmax(bc) + 1
-    largestCC = labels == largestID
-    rh_islands = (labels != largestID) & (labels > 0)
+    lh_islands, rh_islands = thread_executor().map(partial(_islands, aseg_data), [lh_wm, rh_wm])
+
 
     # get signed probability for lh and rh (by smoothing joined GM+WM labels)
-    lhmask = (aseg_data == lh_wm) | (aseg_data == lh_gm)
-    rhmask = (aseg_data == rh_wm) | (aseg_data == rh_gm)
+    lhmask = np.logical_or(aseg_data == lh_wm, aseg_data == lh_gm)
+    rhmask = np.logical_or(aseg_data == rh_wm, aseg_data == rh_gm)
     ii = gaussian(lhmask.astype(float) * (-1) + rhmask.astype(float), sigma=1.5)
 
     # flip island
@@ -222,17 +228,50 @@ def flip_wm_islands(aseg_data : np.ndarray) -> np.ndarray:
     flip_data = aseg_data.copy()
     flip_data[rhswap] = lh_wm
     flip_data[lhswap] = rh_wm
-    print(f"FlipWM: rh {rhswap.sum()} and lh {lhswap.sum()} flipped.")
+    LOGGER.info(f"FlipWM: rh {rhswap.sum()} and lh {lhswap.sum()} flipped.")
 
     return flip_data
+
+
+def create_mask_and_save(
+        seg: np.ndarray[_TShape, np.dtype],
+        seg_affine: np.ndarray[tuple[int, int], np.dtype[float]],
+        seg_header: nib.analyze.SpatialHeader,
+        filename: Path | None = None,
+) -> np.ndarray[_TShape, np.dtype[bool]]:
+    """Convenience function for brainmask generation plus saving."""
+    mask_data = create_mask(seg, 5, 4)
+    if filename is not None:
+        LOGGER.info(f"Outputting mask: {filename}")
+        mask = nib.MGHImage(mask_data, seg_affine, seg_header)
+        mask.to_filename(filename)
+    return mask_data
+
+
+def reduce_to_aseg_and_save(
+        seg: np.ndarray[_TShape, np.dtype],
+        seg_affine: np.ndarray[tuple[int, int], np.dtype[float]],
+        seg_header: nib.analyze.SpatialHeader,
+        filename: Path | None = None,
+) -> np.ndarray[_TShape, np.dtype[np.uint8]]:
+    """Convenience function for reduce_to_aseg plus saving."""
+    _data = reduce_to_aseg(seg)
+
+    if filename is not None:
+        LOGGER.info(f"Outputting aseg: {filename}")
+        mask = nib.MGHImage(_data, seg_affine, seg_header)
+        mask.to_filename(filename)
+    return _data
 
 
 if __name__ == "__main__":
     # Command Line options are error checking done here
     options = options_parse()
 
-    print(f"Reading in aparc+aseg: {options.input_seg} ...")
-    inseg = nib.load(options.input_seg)
+    setup_logging()
+
+    LOGGER.info(f"Reading in aparc+aseg: {options.input_seg} ...")
+    inseg = cast(nib.analyze.SpatialImage, nib.load(options.input_seg))
     inseg_data = np.asanyarray(inseg.dataobj)
     inseg_header = inseg.header
     inseg_affine = inseg.affine
@@ -242,22 +281,29 @@ if __name__ == "__main__":
 
     # get mask
     if options.output_mask:
-        bm = create_mask(copy.deepcopy(inseg_data), 5, 4)
-        print(f"Outputting mask: {options.output_mask}")
-        mask = nib.MGHImage(bm, inseg_affine, inseg_header)
-        mask.to_filename(options.output_mask)
+        io_fut_mask = thread_executor().submit(
+            create_mask_and_save,
+            inseg_data,
+            inseg_affine,
+            inseg_header,
+            options.output_mask,
+        )
+    else:
+        io_fut_mask = None
 
     # reduce aparc to aseg and mask regions
     aseg = reduce_to_aseg(inseg_data)
 
     if options.output_mask:
         # mask aseg also
+        # wait and report errors in saving the mask
+        bm = io_fut_mask.result()
         aseg[bm == 0] = 0
 
     if options.fix_wm:
         aseg = flip_wm_islands(aseg)
 
-    print(f"Outputting aseg: {options.output_seg}")
+    LOGGER.info(f"Outputting aseg: {options.output_seg}")
     aseg_fin = nib.MGHImage(aseg, inseg_affine, inseg_header)
     aseg_fin.to_filename(options.output_seg)
 

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -28,7 +28,7 @@ from skimage.measure import label
 from FastSurferCNN.utils import logging
 from FastSurferCNN.utils.brainvolstats import mask_in_array
 from FastSurferCNN.utils.logging import setup_logging
-from FastSurferCNN.utils.threads import thread_executor
+from FastSurferCNN.utils.parallel import thread_executor
 
 _T = TypeVar("_T", bound=np.number)
 _TDType = np.dtype[_T]
@@ -180,7 +180,7 @@ def create_mask(aseg_data: np.ndarray[_TShape, _TDType], dnum: int, enum: int) -
     return datab.astype(np.uint8)
 
 
-def flip_wm_islands(aseg_data : np.ndarray[_TShape, _TDType]) -> np.ndarray[_TShape, _TDType]:
+def flip_wm_islands(aseg_data: np.ndarray[_TShape, _TDType]) -> np.ndarray[_TShape, _TDType]:
     """
     Flip labels of disconnected white matter islands to the other hemisphere (works for all data orientations, LIA/etc).
 
@@ -204,7 +204,7 @@ def flip_wm_islands(aseg_data : np.ndarray[_TShape, _TDType]) -> np.ndarray[_TSh
     rh_wm = 41
     rh_gm = 42
 
-    def _islands(data: np.ndarray[_TShape, np.dtype], _label: int) -> np.ndarray[_TShape, np.dtype[bool]]:
+    def _islands(data: np.ndarray[_TShape, _TDType], _label: int) -> np.ndarray[_TShape, np.dtype[bool]]:
         # for lh get largest component and islands
         mask = data == _label
         labels = label(mask, background=0)
@@ -238,7 +238,7 @@ def create_mask_and_save(
         seg_affine: np.ndarray[tuple[int, int], np.dtype[float]],
         seg_header: nib.analyze.SpatialHeader,
         filename: Path | None = None,
-) -> np.ndarray[_TShape, np.dtype[bool]]:
+) -> np.ndarray[_TShape, np.dtype[np.uint8]]:
     """Convenience function for brainmask generation plus saving."""
     mask_data = create_mask(seg, 5, 4)
     if filename is not None:

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -23,7 +23,6 @@ See Also
 `run_prediction.py --help`
 """
 
-
 # IMPORTS
 import argparse
 import sys
@@ -49,8 +48,8 @@ from FastSurferCNN.utils.arg_types import vox_size as _vox_size
 from FastSurferCNN.utils.checkpoint import get_checkpoints, load_checkpoint_config_defaults
 from FastSurferCNN.utils.common import SubjectDirectory, SubjectList, find_device, handle_cuda_memory_exception
 from FastSurferCNN.utils.load_config import load_config
+from FastSurferCNN.utils.parallel import SerialExecutor, pipeline
 from FastSurferCNN.utils.parser_defaults import FASTSURFER_ROOT, SubjectDirectoryConfig
-from FastSurferCNN.utils.threads import SerialExecutor, pipeline
 
 LOGGER = logging.getLogger(__name__)
 CHECKPOINT_PATHS_FILE = FASTSURFER_ROOT / "FastSurferCNN/config/checkpoint_paths.yaml"

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -26,7 +26,6 @@ See Also
 
 # IMPORTS
 import argparse
-import copy
 import sys
 from collections.abc import Iterator, Sequence
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
@@ -48,20 +47,10 @@ from FastSurferCNN.utils import PLANES, Plane, logging, parser_defaults
 from FastSurferCNN.utils.arg_types import OrientationType, VoxSizeOption
 from FastSurferCNN.utils.arg_types import vox_size as _vox_size
 from FastSurferCNN.utils.checkpoint import get_checkpoints, load_checkpoint_config_defaults
-from FastSurferCNN.utils.common import (
-    SerialExecutor,
-    SubjectDirectory,
-    SubjectList,
-    find_device,
-    handle_cuda_memory_exception,
-    pipeline,
-)
+from FastSurferCNN.utils.common import SubjectDirectory, SubjectList, find_device, handle_cuda_memory_exception
 from FastSurferCNN.utils.load_config import load_config
-
-##
-# Global Variables
-##
 from FastSurferCNN.utils.parser_defaults import FASTSURFER_ROOT, SubjectDirectoryConfig
+from FastSurferCNN.utils.threads import SerialExecutor, pipeline
 
 LOGGER = logging.getLogger(__name__)
 CHECKPOINT_PATHS_FILE = FASTSURFER_ROOT / "FastSurferCNN/config/checkpoint_paths.yaml"
@@ -550,6 +539,10 @@ def make_parser():
         ["asegdkt_segfile", "conformed_name", "brainmask_name", "aseg_name", "sd", "seg_log", "qc_log"],
     )
 
+    def _add_sd_help(action: argparse.Action) -> None:
+        action.help += " Optional if full path is defined for --pred_name."
+    parser_defaults.modify_argument(parser, "--sd", _add_sd_help)
+
     # 3. Checkpoint to load
     files: dict[Plane, str | Path] = {k: "default" for k in PLANES}
     parser = parser_defaults.add_plane_flags(parser, "checkpoint", files, CHECKPOINT_PATHS_FILE)
@@ -683,7 +676,7 @@ def main(
             store_aseg = subject.can_resolve_filename(aseg_name)
             if store_brainmask or store_aseg:
                 LOGGER.info("Creating brainmask based on segmentation...")
-                bm = rta.create_mask(copy.deepcopy(pred_data), 5, 4)
+                bm = rta.create_mask(pred_data, 5, 4)
             if store_brainmask:
                 # get mask
                 mask_name = subject.filename_in_subject_folder(brainmask_name)

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -43,8 +43,8 @@ from FastSurferCNN.utils.arg_types import float_gt_zero_and_le_one as robust_thr
 from FastSurferCNN.utils.arg_types import int_ge_zero as id_type
 from FastSurferCNN.utils.arg_types import int_gt_zero as patch_size_type
 from FastSurferCNN.utils.brainvolstats import Manager, MeasureTuple, read_measure_file
+from FastSurferCNN.utils.parallel import get_num_threads
 from FastSurferCNN.utils.parser_defaults import add_arguments
-from FastSurferCNN.utils.threads import get_num_threads
 
 # Constants
 USAGE = ("python segstats.py (-norm|-pv) <input_norm> -i <input_seg> "

--- a/FastSurferCNN/utils/brainvolstats.py
+++ b/FastSurferCNN/utils/brainvolstats.py
@@ -25,10 +25,10 @@ if TYPE_CHECKING:
     import pandas as pd
     from numpy import typing as npt
 
-    from CerebNet.datasets.utils import LTADict
+    from CerebNet.datasets.utils import AffineMatrix4x4, LTADict
 
 MeasureTuple = tuple[str, str, int | float, str]
-ImageTuple = tuple["nib.analyze.SpatialImage", "np.ndarray"]
+ImageTuple = tuple["nib.analyze.SpatialImage", np.ndarray[tuple[int, ...], np.dtype[np.number]]]
 UnitString = Literal["unitless", "mm^3"]
 MeasureString = Union[str, "Measure"]
 AnyBufferType = Union[
@@ -51,18 +51,19 @@ DerivedAggOperation = Literal["sum", "ratio", "by_vox_vol"]
 AnyMeasure = Union["AbstractMeasure", str]
 PVMode = Literal["vox", "pv"]
 ClassesType = Sequence[int]
-ClassesOrCondType = ClassesType | Callable[["npt.NDArray[int]"], "npt.NDArray[bool]"]
+_TShape = TypeVar("_TShape", bound=tuple[int, ...])
+CondType = Callable[["np.ndarray[_TShape, np.dtype[np.number]]"], "np.ndarray[_TShape, np.dtype[bool]]"]
+ClassesOrCondType = ClassesType | CondType
 MaskSign = Literal["abs", "pos", "neg"]
-_ToBoolCallback = Callable[["npt.NDArray[int]"], "npt.NDArray[bool]"]
 
 
 class ReadFileHook(Protocol[T_BufferType]):
 
     @overload
-    def __call__(self, file: Path, blocking: True = True) -> T_BufferType: ...
+    def __call__(self, file: Path, blocking: Literal[True] = True) -> T_BufferType: ...
 
     @overload
-    def __call__(self, file: Path, blocking: False) -> None: ...
+    def __call__(self, file: Path, blocking: Literal[False]) -> None: ...
 
     def __call__(self, file: Path, b: bool = True) -> T_BufferType | None: ...
 
@@ -159,7 +160,7 @@ def read_mesh_file(path: Path) -> "lapy.TriaMesh":
     return mesh
 
 
-def read_lta_transform_file(path: Path) -> "npt.NDArray[float]":
+def read_lta_transform_file(path: Path) -> "AffineMatrix4x4":
     """
     Read and extract the first lta transform from an LTA file.
 
@@ -170,14 +171,14 @@ def read_lta_transform_file(path: Path) -> "npt.NDArray[float]":
 
     Returns
     -------
-    matrix : npt.NDArray[float]
+    matrix : AffineMatrix4x4
         Matrix of shape (4, 4).
     """
     from CerebNet.datasets.utils import read_lta
     return read_lta(path)["lta"][0, 0]
 
 
-def read_xfm_transform_file(path: Path) -> "npt.NDArray[float]":
+def read_xfm_transform_file(path: Path) -> "AffineMatrix4x4":
     """
     Read XFM talairach transform.
 
@@ -188,7 +189,7 @@ def read_xfm_transform_file(path: Path) -> "npt.NDArray[float]":
 
     Returns
     -------
-    tal
+    tal : AffineMatrix4x4
         The talairach transform matrix.
 
     Raises
@@ -211,7 +212,7 @@ def read_xfm_transform_file(path: Path) -> "npt.NDArray[float]":
         raise err from e
 
 
-def read_transform_file(path: Path) -> "npt.NDArray[float]":
+def read_transform_file(path: Path) -> "AffineMatrix4x4":
     """
     Read xfm or lta transform file.
 
@@ -234,20 +235,27 @@ def read_transform_file(path: Path) -> "npt.NDArray[float]":
             f"The extension {path.suffix} is not '.xfm' or '.lta' and not recognized.")
 
 
-def mask_in_array(arr: "npt.NDArray", items: "npt.ArrayLike") -> "npt.NDArray[bool]":
+def mask_in_array(
+        arr: np.ndarray[_TShape, np.dtype[np.unsignedinteger]],
+        items: "npt.ArrayLike",
+        /,
+        max_index: np.unsignedinteger | None = None,
+) -> np.ndarray[_TShape, np.dtype[bool]]:
     """
     Efficient function to generate a mask of elements in `arr`, which are also in items.
 
     Parameters
     ----------
-    arr : npt.NDArray
+    arr : ndarray of integer
         An array with data, most likely int.
     items : npt.ArrayLike
         Which elements of `arr` in arr should yield True.
+    max_index : integer, optional
+        The maximum value of `arr` and `items` for performance, uses maximum value if None.
 
     Returns
     -------
-    mask : npt.NDArray[bool]
+    mask : np.ndarray of boolean
         A binary array, true, where elements in `arr` are in `items`.
 
     See Also
@@ -260,33 +268,38 @@ def mask_in_array(arr: "npt.NDArray", items: "npt.ArrayLike") -> "npt.NDArray[bo
     elif _items.size == 1:
         return np.asarray(arr == _items.flat[0])
     else:
-        max_index = max(np.max(items), np.max(arr))
+        if max_index is None:
+            max_index = max(np.max(items), np.max(arr))
         if max_index >= 2 ** 16:
             logging.getLogger(__name__).warning(
                 f"labels in arr are larger than {2 ** 16 - 1}, this is not recommended!"
             )
         lookup = np.zeros(max_index + 1, dtype=bool)
-        lookup[_items] = True
+        lookup[np.asarray(_items)] = True
         return lookup[arr]
 
 
 def mask_not_in_array(
-        arr: "npt.NDArray",
+        arr: np.ndarray[_TShape, np.dtype[np.unsignedinteger]],
         items: "npt.ArrayLike",
+        /,
+        max_index: np.unsignedinteger | None = None,
 ) -> "npt.NDArray[bool]":
     """
     Inverse of mask_in_array.
 
     Parameters
     ----------
-    arr : npt.NDArray
+    arr : ndarray of integer
         An array with data, most likely int.
     items : npt.ArrayLike
-        Which elements of `arr` in arr should yield False.
+        Which elements of `arr` in arr should yield True.
+    max_index : integer, optional
+        The maximum value of `arr` and `items` for performance, uses maximum value if None.
 
     Returns
     -------
-    mask : npt.NDArray[bool]
+    mask : np.ndarray of boolean
         A binary array, true, where elements in `arr` are not in `items`.
 
     See Also
@@ -299,15 +312,56 @@ def mask_not_in_array(
     elif _items.size == 1:
         return np.asarray(arr != _items.flat[0])
     else:
-        max_index = max(np.max(items), np.max(arr))
+        if max_index is None:
+            max_index = max(np.max(items), np.max(arr))
         if max_index >= 2 ** 16:
             logging.getLogger(__name__).warning(
                 f"labels in arr are larger than {2 ** 16 - 1}, this is not recommended!"
             )
         lookup = np.ones(max_index + 1, dtype=bool)
-        lookup[_items] = False
+        lookup[np.asarray(_items)] = False
         return lookup[arr]
 
+
+def hemi_mask_aseg(
+        arr: np.ndarray[_TShape, np.dtype[np.integer]],
+        hemi : Literal["left", "right"],
+) -> np.ndarray[_TShape, np.dtype[bool]]:
+    """
+    Determine for each voxel if it is more likely left hemisphere or right hemisphere.
+
+    Parameters
+    ----------
+    arr : ndarray of integer
+        An array with data, most likely int.
+    hemi : "left", "right"
+        Whether to get the left or right hemisphere mask.
+
+    Returns
+    -------
+    mask : np.ndarray of boolean
+        A binary array, true, where elements in `arr` are not in `items`.
+
+    See Also
+    --------
+    mask_in_array
+    """
+    left_aseg = (2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 17, 18, 26, 28, 30, 31)
+    right_aseg = (41, 42, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 58, 60, 62, 63)
+
+    is_left = mask_in_array(arr, left_aseg)
+    is_right = mask_in_array(arr, right_aseg)
+    from scipy.ndimage import uniform_filter
+
+    _leftness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_left.astype(np.float32), size=7)
+    _rightness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_right.astype(np.float32), size=7)
+
+    if hemi.lower() in ("left", "lh"):
+        return np.greater(_leftness, _rightness)
+    elif hemi.lower() in ("right", "rh"):
+        return np.greater(_rightness, _leftness)
+
+    raise ValueError(f"Invalid hemisphere: {hemi}.")
 
 class AbstractMeasure(metaclass=abc.ABCMeta):
     """
@@ -722,6 +776,7 @@ class PVMeasure(AbstractMeasure):
         if unit != "mm^3":
             raise ValueError("unit must be mm^3 for PVMeasure!")
         self._classes = classes
+        self._vox_vol: float | None = None
         super().__init__(name, description, unit)
         self._pv_value = None
 
@@ -820,7 +875,7 @@ class VolumeMeasure(Measure[ImageTuple]):
     ):
         if callable(classes_or_cond):
             self._classes: ClassesType | None = None
-            self._cond: _ToBoolCallback = classes_or_cond
+            self._cond: CondType = classes_or_cond
         else:
             if len(classes_or_cond) == 0:
                 raise ValueError(f"No operation passed to {type(self).__name__}.")
@@ -828,8 +883,7 @@ class VolumeMeasure(Measure[ImageTuple]):
             from functools import partial
             self._cond = partial(mask_in_array, items=self._classes)
         if unit not in ["unitless", "mm^3"]:
-            raise ValueError("unit must be either 'mm^3' or 'unitless' for " +
-                             type(self).__name__)
+            raise ValueError(f"unit must be either 'mm^3' or 'unitless' for {type(self).__name__}!")
         super().__init__(segfile, name, description, unit,
                          self.read_file if read_file is None else read_file)
 
@@ -904,7 +958,7 @@ class MaskMeasure(VolumeMeasure):
         # self._erode: int = erode
         super().__init__(maskfile, self.mask, name, description, unit, read_file)
 
-    def mask(self, data: "npt.NDArray[int]") -> "npt.NDArray[bool]":
+    def mask(self, data: np.ndarray[_TShape, np.number]) -> np.ndarray[_TShape, np.dtype[bool]]:
         """Generates a mask from data similar to mri_binarize + erosion."""
         # if self._sign == "abs":
         #     data = np.abs(data)
@@ -2048,26 +2102,21 @@ class Manager(dict[str, AbstractMeasure]):
             )
         elif key in ("lhWM-hypointensities", "rhWM-hypointensities"):
             # lateralized counting of class 77 WM hypo intensities
-            def mask_77_lat(arr):
+            def mask_77_lat(arr: np.ndarray[_TShape, np.dtype[np.integer]]) -> np.ndarray[_TShape, np.dtype[bool]]:
                 """
                 This function returns a lateralized mask of hypo-WM (class 77).
 
                 This is achieved by looking at surrounding labels and associating them
                 with left or right (this is not 100% robust when there is no clear
-                classes with left aseg labels present, but it is cheap to perform.
+                classes with left aseg labels present, but it is cheap to perform).
                 """
                 mask = arr == 77
-                left_aseg = (2, 4, 5, 7, 8, 10, 11, 12, 13, 17, 18, 26, 28, 30, 31)
-                is_left = mask_in_array(arr, left_aseg)
-                from scipy.ndimage import uniform_filter
-                is_left = uniform_filter(is_left.astype(np.float32), size=7) > 0.2
-                is_side = np.logical_not(is_left) if hemi == "rh" else is_left
-                return np.logical_and(mask, is_side)
+                return np.logical_and(hemi_mask_aseg(arr, side), mask)
 
             return VolumeMeasure(
                 self._seg_from_file,
                 mask_77_lat,
-                f"{side}WhiteMatterHypoIntensities",
+                f"{hemi}WhiteMatterHypoIntensities",
                 f"Volume of {side} White matter hypointensities",
                 "mm^3"
             )
@@ -2277,6 +2326,8 @@ class Manager(dict[str, AbstractMeasure]):
                 measure_host=self,
                 operation="ratio",
             )
+        else:
+            raise NotImplementedError(f"The default value for key={key} is not implemented.")
 
     def __iter__(self) -> list[AbstractMeasure]:
         """

--- a/FastSurferCNN/utils/brainvolstats.py
+++ b/FastSurferCNN/utils/brainvolstats.py
@@ -19,6 +19,8 @@ from typing import (
 
 import numpy as np
 
+from FastSurferCNN.utils.common import update_docstring
+
 if TYPE_CHECKING:
     import lapy
     import nibabel as nib
@@ -55,6 +57,9 @@ _TShape = TypeVar("_TShape", bound=tuple[int, ...])
 CondType = Callable[["np.ndarray[_TShape, np.dtype[np.number]]"], "np.ndarray[_TShape, np.dtype[bool]]"]
 ClassesOrCondType = ClassesType | CondType
 MaskSign = Literal["abs", "pos", "neg"]
+
+ASEG_LEFT_CLASSES = (2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 17, 18, 26, 28, 30, 31)
+ASEG_RIGHT_CLASSES = (41, 42, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 58, 60, 62, 63)
 
 
 class ReadFileHook(Protocol[T_BufferType]):
@@ -269,7 +274,9 @@ def mask_in_array(
         return np.asarray(arr == _items.flat[0])
     else:
         if max_index is None:
-            max_index = max(np.max(items), np.max(arr))
+            # 2 ** 10 = 4096
+            max_index = np.iinfo(arr.dtype).max if np.iinfo(arr.dtype).max < 4096 else np.max(items)
+            max_index = max(max_index, np.max(arr))
         if max_index >= 2 ** 16:
             logging.getLogger(__name__).warning(
                 f"labels in arr are larger than {2 ** 16 - 1}, this is not recommended!"
@@ -312,21 +319,32 @@ def mask_not_in_array(
     elif _items.size == 1:
         return np.asarray(arr != _items.flat[0])
     else:
-        if max_index is None:
-            max_index = max(np.max(items), np.max(arr))
-        if max_index >= 2 ** 16:
-            logging.getLogger(__name__).warning(
-                f"labels in arr are larger than {2 ** 16 - 1}, this is not recommended!"
-            )
+        max_index = __infer_check_max_index(arr, items, max_index)
         lookup = np.ones(max_index + 1, dtype=bool)
         lookup[np.asarray(_items)] = False
         return lookup[arr]
 
 
-def hemi_mask_aseg(
+def __infer_check_max_index(
+        arr: np.ndarray[_TShape, np.dtype[np.unsignedinteger]],
+        items: "npt.ArrayLike",
+        max_index: int | None,
+) -> int:
+    if max_index is None:
+        # 2 ** 10 = 4096
+        _max_index = np.iinfo(arr.dtype).max if np.iinfo(arr.dtype).max < 4096 else np.max(arr)
+        _max_index = max(_max_index, np.max(items))
+        if _max_index >= 2**16:
+            logging.getLogger(__name__).warning(f"labels in arr are larger than {2**16 - 1}, this is not recommended!")
+        return _max_index
+    return max_index
+
+
+@update_docstring(left_classes=ASEG_LEFT_CLASSES, right_classes=ASEG_RIGHT_CLASSES)
+def hemi_masks_from_aseg(
         arr: np.ndarray[_TShape, np.dtype[np.integer]],
-        hemi: Literal["left", "right"],
-) -> np.ndarray[_TShape, np.dtype[bool]]:
+        window_size: int = 7,
+) -> tuple[np.ndarray[_TShape, np.dtype[bool]], np.ndarray[_TShape, np.dtype[bool]]]:
     """
     Determine for each voxel if it is more likely left hemisphere or right hemisphere.
 
@@ -334,35 +352,31 @@ def hemi_mask_aseg(
     ----------
     arr : ndarray of integer
         An array with segmentation labels.
-    hemi : {"left", "right"}
-        Which hemisphere mask to compute ("left" or "right").
+    window_size : int, default=7
+        The size of the smoothing filter to use for left/right voting.
 
     Returns
     -------
-    mask : np.ndarray of boolean
+    mask_left : np.ndarray of boolean
         A boolean array of the same shape as `arr`, where True indicates voxels that are more likely to belong to the
-        specified hemisphere (`hemi`).
+        left hemisphere.
+    mask_right : np.ndarray of boolean
+        A boolean array of the same shape as `arr`, where True indicates voxels that are more likely to belong to the
+        left hemisphere.
 
-    See Also
-    --------
-    mask_in_array
+    Notes
+    -----
+    Classes `{left_classes}` vote left and classes `{right_classes}` vote right.
     """
-    left_aseg = (2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 17, 18, 26, 28, 30, 31)
-    right_aseg = (41, 42, 43, 44, 46, 47, 49, 50, 51, 52, 53, 54, 58, 60, 62, 63)
-
-    is_left = mask_in_array(arr, left_aseg)
-    is_right = mask_in_array(arr, right_aseg)
+    is_left = mask_in_array(arr, ASEG_LEFT_CLASSES)
+    is_right = mask_in_array(arr, ASEG_RIGHT_CLASSES)
     from scipy.ndimage import uniform_filter
 
-    _leftness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_left.astype(np.float32), size=7)
-    _rightness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_right.astype(np.float32), size=7)
+    _leftness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_left.astype(np.float32), size=window_size)
+    _rightness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_right.astype(np.float32), size=window_size)
 
-    if hemi.lower() in ("left", "lh"):
-        return np.greater(_leftness, _rightness)
-    elif hemi.lower() in ("right", "rh"):
-        return np.greater(_rightness, _leftness)
+    return np.greater(_leftness, _rightness), np.greater(_rightness, _leftness)
 
-    raise ValueError(f"Invalid hemisphere: {hemi}.")
 
 class AbstractMeasure(metaclass=abc.ABCMeta):
     """
@@ -2112,7 +2126,8 @@ class Manager(dict[str, AbstractMeasure]):
                 classes with left aseg labels present, but it is cheap to perform).
                 """
                 mask = arr == 77
-                return np.logical_and(hemi_mask_aseg(arr, side), mask)
+                side_index = {"Left": 0, "Right": 1}[side]
+                return np.logical_and(hemi_masks_from_aseg(arr)[side_index], mask)
 
             return VolumeMeasure(
                 self._seg_from_file,

--- a/FastSurferCNN/utils/brainvolstats.py
+++ b/FastSurferCNN/utils/brainvolstats.py
@@ -293,7 +293,7 @@ def mask_not_in_array(
     arr : ndarray of integer
         An array with data, most likely int.
     items : npt.ArrayLike
-        Which elements of `arr` in arr should yield True.
+        Which elements of `arr` in arr should yield False.
     max_index : integer, optional
         The maximum value of `arr` and `items` for performance, uses maximum value if None.
 
@@ -325,7 +325,7 @@ def mask_not_in_array(
 
 def hemi_mask_aseg(
         arr: np.ndarray[_TShape, np.dtype[np.integer]],
-        hemi : Literal["left", "right"],
+        hemi: Literal["left", "right"],
 ) -> np.ndarray[_TShape, np.dtype[bool]]:
     """
     Determine for each voxel if it is more likely left hemisphere or right hemisphere.
@@ -333,14 +333,15 @@ def hemi_mask_aseg(
     Parameters
     ----------
     arr : ndarray of integer
-        An array with data, most likely int.
-    hemi : "left", "right"
-        Whether to get the left or right hemisphere mask.
+        An array with segmentation labels.
+    hemi : {"left", "right"}
+        Which hemisphere mask to compute ("left" or "right").
 
     Returns
     -------
     mask : np.ndarray of boolean
-        A binary array, true, where elements in `arr` are not in `items`.
+        A boolean array of the same shape as `arr`, where True indicates voxels that are more likely to belong to the
+        specified hemisphere (`hemi`).
 
     See Also
     --------

--- a/FastSurferCNN/utils/brainvolstats.py
+++ b/FastSurferCNN/utils/brainvolstats.py
@@ -362,18 +362,29 @@ def hemi_masks_from_aseg(
         left hemisphere.
     mask_right : np.ndarray of boolean
         A boolean array of the same shape as `arr`, where True indicates voxels that are more likely to belong to the
-        left hemisphere.
+        right hemisphere.
 
     Notes
     -----
     Classes `{left_classes}` vote left and classes `{right_classes}` vote right.
     """
-    is_left = mask_in_array(arr, ASEG_LEFT_CLASSES)
-    is_right = mask_in_array(arr, ASEG_RIGHT_CLASSES)
-    from scipy.ndimage import uniform_filter
+    import threading
 
-    _leftness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_left.astype(np.float32), size=window_size)
-    _rightness: np.ndarray[_TShape, np.dtype[np.float32]] = uniform_filter(is_right.astype(np.float32), size=window_size)
+    from scipy.ndimage import uniform_filter
+    # if we are currently already multi-threading, do not add more multi-threading
+    if threading.current_thread() != threading.main_thread():
+        from FastSurferCNN.utils.parallel import thread_executor
+        _map = thread_executor().map
+    else:
+        _map = map
+
+    def __ness(classes):
+        return uniform_filter(mask_in_array(arr, classes).astype(np.float32), size=window_size)
+
+    _leftness: np.ndarray[_TShape, np.dtype[np.float32]]
+    _rightness: np.ndarray[_TShape, np.dtype[np.float32]]
+
+    _leftness, _rightness = _map(__ness, (ASEG_LEFT_CLASSES, ASEG_RIGHT_CLASSES))
 
     return np.greater(_leftness, _rightness), np.greater(_rightness, _leftness)
 

--- a/FastSurferCNN/utils/common.py
+++ b/FastSurferCNN/utils/common.py
@@ -14,34 +14,53 @@
 
 # IMPORTS
 import os
-from collections.abc import Callable, Iterable, Iterator
-from concurrent.futures import Executor, Future
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import (
-    Any,
-    TypeVar,
-)
 
 import torch
 
 from FastSurferCNN.utils import logging, parser_defaults
+from FastSurferCNN.utils.parser_defaults import SubjectDirectoryConfig
+from FastSurferCNN.utils.threads import thread_executor
 
 __all__ = [
     "assert_no_root",
     "find_device",
     "handle_cuda_memory_exception",
-    "iterate",
-    "SerialExecutor",
-    "pipeline",
     "SubjectList",
     "SubjectDirectory",
+    "suppress_stdout",
+    "suppress_stderr",
+    "update_docstring",
 ]
 
-from FastSurferCNN.utils.parser_defaults import SubjectDirectoryConfig
-
 LOGGER = logging.getLogger(__name__)
-_T = TypeVar("_T")
-_Ti = TypeVar("_Ti")
+
+
+@contextmanager
+def suppress_stdout():
+    """
+    Contextmanager that suppresses all output on stdout.
+
+    Notes
+    -----
+    This Context Manager does not work with multiple threads, as `sys.stdout` is shared between threads.
+    """
+    with open(os.devnull, "w") as devnull, redirect_stdout(devnull) as rdo:
+        yield rdo
+
+
+@contextmanager
+def suppress_stderr():
+    """
+    Contextmanager that suppresses all output on stderr.
+
+    Notes
+    -----
+    This Context Manager does not work with multiple threads, as `sys.stdout` is shared between threads.
+    """
+    with open(os.devnull, "w") as devnull, redirect_stderr(devnull) as rdo:
+        yield rdo
 
 
 def find_device(
@@ -104,6 +123,17 @@ def find_device(
     # Define device and transfer model
     logger.info(f"Using {flag_name}: {device}")
     return device
+
+
+def update_docstring(**kwargs):
+    """
+    Make custom replacements in the docstring.
+    """
+
+    def stub(f):
+        f.__doc__ = f.__doc__.format(**kwargs)
+        return f
+    return stub
 
 
 def assert_no_root() -> bool:
@@ -171,80 +201,6 @@ def handle_cuda_memory_exception(exception: BaseException) -> bool:
         return False
 
 
-def pipeline(
-    pool: Executor,
-    func: Callable[[_Ti], _T],
-    iterable: Iterable[_Ti],
-    *,
-    pipeline_size: int = 1,
-) -> Iterator[tuple[_Ti, _T]]:
-    """
-    Pipeline a function to be executed in the pool.
-
-    Analogous to iterate, but run func in a different
-    thread for the next element while the current element is returned.
-
-    Parameters
-    ----------
-    pool : Executor
-        Thread pool executor for parallel execution.
-    func : callable
-        Function to use.
-    iterable : Iterable
-        Iterable containing input elements.
-    pipeline_size : int, default=1
-        Size of the processing pipeline.
-
-    Yields
-    ------
-    element : _Ti
-        Elements
-    _T
-        Results of func corresponding to element: func(element).
-    """
-    # do pipeline loading the next element
-    from collections import deque
-
-    futures_queue = deque()
-    import itertools
-
-    for i, element in zip(itertools.count(-pipeline_size), iterable):
-        # pre-load next element/data
-        futures_queue.append((element, pool.submit(func, element)))
-        if i >= 0:
-            element, future = futures_queue.popleft()
-            yield element, future.result()
-    while len(futures_queue) > 0:
-        element, future = futures_queue.popleft()
-        yield element, future.result()
-
-
-def iterate(
-    pool: Executor, func: Callable[[_Ti], _T], iterable: Iterable[_Ti],
-) -> Iterator[tuple[_Ti, _T]]:
-    """
-    Iterate over iterable, yield pairs of elements and func(element).
-
-    Parameters
-    ----------
-    pool : Executor
-        The Executor object (dummy object to have a common API with pipeline).
-    func : callable
-        Function to use.
-    iterable : Iterable
-        Iterable to draw objects to process with func from.
-
-    Yields
-    ------
-    element : _Ti
-        Elements
-    _T
-        Results of func corresponding to element: func(element).
-    """
-    for element in iterable:
-        yield element, func(element)
-
-
 class SubjectDirectory:
     """
     Represent a subject directory.
@@ -282,7 +238,7 @@ class SubjectDirectory:
         """
         self._subject_dir = Path.cwd() if subject_dir is None else Path(subject_dir)
         for k, v in kwargs.items():
-            if subject_dir is None and not Path(v).is_absolute() and not k == "id":
+            if subject_dir is None and not Path(v).is_absolute() and k != "id":
                 raise ValueError(f"subject/out directory not defined, but {k} ('{v}') is relative!")
             setattr(self, "_" + k, v)
 
@@ -1047,69 +1003,6 @@ class SubjectList:
 
         This is performed asynchronously internally.
         """
-        from concurrent.futures import ThreadPoolExecutor
-
         def is_file(p: Path):
             return p.is_file()
-        with ThreadPoolExecutor(len(self._subjects)) as pool:
-            return all(pool.map(is_file, self._subjects))
-
-
-class SerialExecutor(Executor):
-    """
-    Represent a serial executor.
-    """
-
-    def map(
-        self,
-        fn: Callable[..., _T],
-        *iterables: Iterable[Any],
-        timeout: float | None = None,
-        chunksize: int = -1,
-    ) -> Iterator[_T]:
-        """
-        The map function.
-
-        Parameters
-        ----------
-        fn : Callable[..., _T]
-            A callable function to be applied to the items in the iterables.
-        *iterables : Iterable[Any]
-            One or more iterable objects.
-        timeout : Optional[float]
-            Maximum number of seconds to wait for a result. Default is None.
-        chunksize : int
-            The size of the chunks, default value is -1.
-
-        Returns
-        -------
-        Iterator[_T]
-            An iterator that yields the results of applying 'fn' to the items of
-            'iterables'.
-        """
-        return map(fn, *iterables)
-
-    def submit(self, __fn: Callable[..., _T], *args, **kwargs) -> "Future[_T]":
-        """
-        A callable function that returns a Future representing the result.
-
-        Parameters
-        ----------
-        __fn : Callable[..., _T]
-            A callable function to be executed.
-        *args :
-            Potential arguments to be passed to the callable function.
-        **kwargs :
-            Keyword arguments to be passed to the callable function.
-
-        Returns
-        -------
-        "Future[_T]"
-            A Future object representing the execution result of the callable function.
-        """
-        f = Future()
-        try:
-            f.set_result(__fn(*args, **kwargs))
-        except Exception as e:
-            f.set_exception(e)
-        return f
+        return all(thread_executor().map(is_file, self._subjects))

--- a/FastSurferCNN/utils/common.py
+++ b/FastSurferCNN/utils/common.py
@@ -20,8 +20,8 @@ from pathlib import Path
 import torch
 
 from FastSurferCNN.utils import logging, parser_defaults
+from FastSurferCNN.utils.parallel import thread_executor
 from FastSurferCNN.utils.parser_defaults import SubjectDirectoryConfig
-from FastSurferCNN.utils.threads import thread_executor
 
 __all__ = [
     "assert_no_root",
@@ -57,7 +57,7 @@ def suppress_stderr():
 
     Notes
     -----
-    This Context Manager does not work with multiple threads, as `sys.stdout` is shared between threads.
+    This Context Manager does not work with multiple threads, as `sys.stderr` is shared between threads.
     """
     with open(os.devnull, "w") as devnull, redirect_stderr(devnull) as rdo:
         yield rdo

--- a/FastSurferCNN/utils/logging.py
+++ b/FastSurferCNN/utils/logging.py
@@ -14,12 +14,13 @@
 
 # IMPORTS
 import logging as _logging
-from collections.abc import Iterable
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING, FileHandler, Logger, StreamHandler, basicConfig, getLogger
 from logging import getLogger as get_logger
 from os import environ as _environ
 from pathlib import Path as _Path
 from sys import stdout as _stdout
+
+VALID_LOG_LEVEL_STRINGS = ("INFO", "DEBUG", "WARNING", "WARN", "ERROR", "CRITICAL", "FATAL")
 
 
 def setup_logging(log_file_path: _Path | str | None = None, log_level: int | None = None) -> None:
@@ -44,8 +45,12 @@ def setup_logging(log_file_path: _Path | str | None = None, log_level: int | Non
 
         handlers.append(FileHandler(filename=log_file_path, mode="a"))
 
-    log_level = _environ.get("FASTSURFER_LOG_LEVEL", "INFO").upper()
-    if log_level not in ("INFO", "DEBUG", "WARNING", "WARN", "ERROR", "CRITICAL", "FATAL"):
+    if log_level is None:
+        log_level = _environ.get("FASTSURFER_LOG_LEVEL", "INFO").upper()
+    if isinstance(log_level, str):
+        log_level = log_level.upper()
+
+    if not isinstance(log_level, str) or log_level not in VALID_LOG_LEVEL_STRINGS:
         try:
             log_number = int(log_level)
             if log_number < 0:

--- a/FastSurferCNN/utils/logging.py
+++ b/FastSurferCNN/utils/logging.py
@@ -14,6 +14,7 @@
 
 # IMPORTS
 import logging as _logging
+from collections.abc import Iterable
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING, FileHandler, Logger, StreamHandler, basicConfig, getLogger
 from logging import getLogger as get_logger
 from os import environ as _environ
@@ -21,14 +22,16 @@ from pathlib import Path as _Path
 from sys import stdout as _stdout
 
 
-def setup_logging(log_file_path: _Path | str):
+def setup_logging(log_file_path: _Path | str | None = None, log_level: int | None = None) -> None:
     """
     Set up the logging.
 
     Parameters
     ----------
-    log_file_path : Path, str
-        Path to the logfile.
+    log_file_path : Path, str, optional
+        Path to the logfile (only log to file if passed).
+    log_level : int, optional
+        Logging level defaults to environment variable FASTSURFER_LOG_LEVEL.
     """
     # Set up logging format.
     _FORMAT = "[%(levelname)s: %(filename)s: %(lineno)4d]: %(message)s"
@@ -43,6 +46,17 @@ def setup_logging(log_file_path: _Path | str):
 
     log_level = _environ.get("FASTSURFER_LOG_LEVEL", "INFO").upper()
     if log_level not in ("INFO", "DEBUG", "WARNING", "WARN", "ERROR", "CRITICAL", "FATAL"):
-        raise RuntimeError(f"Invalid log level: {log_level}")
+        try:
+            log_number = int(log_level)
+            if log_number < 0:
+                log_level = "ERROR"
+            elif log_number == 0:
+                log_level = "WARNING"
+            elif log_number == 1:
+                log_level = "INFO"
+            else: # > 1
+                log_level = "DEBUG"
+        except ValueError:
+            raise ValueError(f"Invalid log level: {log_level}") from None
 
     basicConfig(level=getattr(_logging, log_level), format=_FORMAT, handlers=handlers)

--- a/FastSurferCNN/utils/parallel.py
+++ b/FastSurferCNN/utils/parallel.py
@@ -21,11 +21,12 @@ from FastSurferCNN.utils import logging
 
 __all__ = [
     "iterate",
+    "get_num_threads",
+    "pipeline",
+    "process_executor",
     "serial_executor",
     "set_num_threads",
     "SerialExecutor",
-    "pipeline",
-    "process_executor",
     "thread_executor",
 ]
 
@@ -102,14 +103,22 @@ class ParallelConfig:
 
     @classmethod
     def shutdown(cls, wait = True, *, cancel_futures = False):
-        """This is a cleanup function and should only be called at the end of a script!"""
+        """
+        This is a cleanup function and should only be called at the end of a script!
+
+        This first shuts down the `process_executor` and then the `thread_executor`.
+
+        Notes
+        -----
+        The executors are not shut down at the same time, but rather, if wait is True, we first wait for the
+        `process_executor` to "finish" shutting down.
+        """
         if cls._process_pool is not None:
-            cls._process_pool.shutdown(wait=False, cancel_futures=cancel_futures)
+            cls._process_pool.shutdown(wait=wait, cancel_futures=cancel_futures)
+            cls._process_pool = None
         if cls._thread_pool is not None:
             cls._thread_pool.shutdown(wait=wait, cancel_futures=cancel_futures)
             cls._thread_pool = None
-        if cls._process_pool is not None:
-            cls._process_pool.shutdown(wait=wait, cancel_futures=cancel_futures)
 
 
 get_num_threads = ParallelConfig.get_num_threads

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -28,7 +28,8 @@ Values can also be extracted by
 
 import argparse
 import types
-from collections.abc import Iterable, Mapping
+from argparse import _ActionsContainer
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import Field, dataclass
 from pathlib import Path
 from typing import Literal, Optional, Protocol, TypeVar, get_args, get_origin
@@ -40,7 +41,7 @@ from FastSurferCNN.utils.arg_types import img_size as __image_size
 from FastSurferCNN.utils.arg_types import orientation as __orientation
 from FastSurferCNN.utils.arg_types import vox_size as __vox_size
 from FastSurferCNN.utils.dataclasses import field, get_field
-from FastSurferCNN.utils.threads import get_num_threads
+from FastSurferCNN.utils.threads import get_num_threads, set_num_threads
 
 FASTSURFER_ROOT = Path(__file__).parents[2]
 PLANE_SHORT = {"checkpoint": "ckpt", "config": "cfg"}
@@ -185,8 +186,9 @@ class SubjectDirectoryConfig:
     sid: Optional[str] = field(  # noqa: UP045
         flags=("--sid",),
         default=None,
-        help="Optional: directly set the subject id to use. Can be used for single subject input. For multi-subject "
-             "processing, use remove suffix if sid is not second to last element of input file passed to --t1",
+        help="The subject id to use, if not passed we try to extract the subject id from the path passed to --t1. "
+             "For multi-subject processing, use --remove_suffix if sid is not the second to last element of input file "
+             "passed to --t1.",
     )
     search_tag: str = field(
         flags=("--tag",),
@@ -209,8 +211,7 @@ class SubjectDirectoryConfig:
     )
     out_dir: Optional[Path] = field(  # noqa: UP045
         default=None,
-        help="Directory in which evaluation results should be written. Will be created if it does not exist. Optional "
-             "if full path is defined for --pred_name.",
+        help="Directory in which evaluation results should be written. Will be created if it does not exist.",
     )
 
 
@@ -340,7 +341,7 @@ ALL_FLAGS = {
         "--threads",
         dest="threads",
         default=get_num_threads(),
-        type=int,
+        type=set_num_threads,
         help=f"Number of threads to use (defaults to number of hardware threads: {get_num_threads()})",
     ),
     "async_io": __arg(
@@ -446,3 +447,31 @@ def add_plane_flags(
             default=path,
         )
     return parser
+
+
+def modify_argument(parser: _ActionsContainer, option_string: str, callback: Callable[[argparse.Action], None]) -> bool:
+    """
+    Modify the Action object of a specific action found by its options string.
+
+    Parameters
+    ----------
+    parser : argparse._ActionContainer
+        The Action container to find the action in.
+    option_string : str
+        The option string to find the action by.
+    callback : callable[[argparse.Action]]
+        The callback to modify the action.
+
+    Returns
+    -------
+    bool
+        Whether the action could be found.
+    """
+    for action in parser._actions:
+        if option_string in action.option_strings:
+            callback(action)
+            return True
+    for action_container in parser._action_groups:
+        if modify_argument(action_container, option_string, callback):
+            return True
+    return False

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -41,7 +41,7 @@ from FastSurferCNN.utils.arg_types import img_size as __image_size
 from FastSurferCNN.utils.arg_types import orientation as __orientation
 from FastSurferCNN.utils.arg_types import vox_size as __vox_size
 from FastSurferCNN.utils.dataclasses import field, get_field
-from FastSurferCNN.utils.threads import get_num_threads, set_num_threads
+from FastSurferCNN.utils.parallel import get_num_threads, set_num_threads
 
 FASTSURFER_ROOT = Path(__file__).parents[2]
 PLANE_SHORT = {"checkpoint": "ckpt", "config": "cfg"}

--- a/FastSurferCNN/utils/run_tools.py
+++ b/FastSurferCNN/utils/run_tools.py
@@ -84,7 +84,7 @@ class Popen(subprocess.Popen):
             Time in seconds to wait, before checking if the process is still alive.
 
         Yields
-        -------
+        ------
         MessageBuffer
             A MessageBuffer object with stdout and stderr information.
         """

--- a/FastSurferCNN/utils/threads.py
+++ b/FastSurferCNN/utils/threads.py
@@ -12,24 +12,255 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import Executor, Future, ProcessPoolExecutor, ThreadPoolExecutor
+from functools import lru_cache
+from typing import Any, TypeVar
 
-def get_num_threads():
+from FastSurferCNN.utils import logging
+
+__all__ = [
+    "iterate",
+    "serial_executor",
+    "set_num_threads",
+    "SerialExecutor",
+    "pipeline",
+    "process_executor",
+    "thread_executor",
+]
+
+_T = TypeVar("_T")
+_Ti = TypeVar("_Ti")
+
+LOGGER = logging.getLogger(__name__)
+
+class ParallelConfig:
+    _num_threads: int | None = None
+    _process_pool: ProcessPoolExecutor | None = None
+    _thread_pool: ThreadPoolExecutor | None = None
+
+    @classmethod
+    def process_executor(cls) -> ProcessPoolExecutor:
+        if cls._process_pool is None:
+            cls._process_pool = ProcessPoolExecutor(max_workers=cls.get_num_threads())
+        return cls._process_pool
+
+    @classmethod
+    def thread_executor(cls) -> ThreadPoolExecutor:
+        if cls._thread_pool is None:
+            cls._thread_pool = ThreadPoolExecutor(max_workers=cls.get_num_threads() + 4)
+        return cls._thread_pool
+
+    @classmethod
+    def get_num_threads(cls):
+        """
+        Determine the number of available threads.
+
+        Tries to get the process's CPU affinity for usable thread count; defaults
+        to total CPU count on failure.
+
+        Returns
+        -------
+        int
+            Number of threads available to the process or total CPU count.
+        """
+        if cls._num_threads is not None and cls._num_threads > 0:
+            return cls._num_threads
+        try:
+            from os import sched_getaffinity as __getaffinity
+
+            return len(__getaffinity(0))
+        except ImportError:
+            from os import cpu_count
+
+            return cpu_count()
+
+    @classmethod
+    def set_num_threads(cls, threads: int | str, wait_finish: bool = False) -> int:
+        """
+        Sets the number of threads to use.
+
+        Parameters
+        ----------
+        threads : int
+            The number of threads to use, values < 1 reset the thread count to automatically determined.
+        wait_finish : bool, default=False
+            Wait for the executor to finish current processing (warning, this may have side-effects!).
+
+        Returns
+        -------
+        int
+            The value as int.
+        """
+        value = int(threads)
+        # if has a pool object AND changing number of threads AND NOT changing between auto-values
+        if cls._process_pool is not None and value != cls._num_threads and (value > 1 or cls._num_threads > 1):
+            cls._process_pool.shutdown(wait=wait_finish)
+            cls._process_pool = None
+        cls._num_threads = value
+        return cls._num_threads
+
+    @classmethod
+    def shutdown(cls, wait = True, *, cancel_futures = False):
+        """This is a cleanup function and should only be called at the end of a script!"""
+        if cls._process_pool is not None:
+            cls._process_pool.shutdown(wait=False, cancel_futures=cancel_futures)
+        if cls._thread_pool is not None:
+            cls._thread_pool.shutdown(wait=wait, cancel_futures=cancel_futures)
+            cls._thread_pool = None
+        if cls._process_pool is not None:
+            cls._process_pool.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
+get_num_threads = ParallelConfig.get_num_threads
+set_num_threads = ParallelConfig.set_num_threads
+
+
+class SerialExecutor(Executor):
     """
-    Determine the number of available threads.
-
-    Tries to get the process's CPU affinity for usable thread count; defaults
-    to total CPU count on failure.
-
-    Returns
-    -------
-    int
-        Number of threads available to the process or total CPU count.
+    Represent a serial executor.
     """
-    try:
-        from os import sched_getaffinity as __getaffinity
 
-        return len(__getaffinity(0))
-    except ImportError:
-        from os import cpu_count
+    def map(
+        self,
+        fn: Callable[..., _T],
+        *iterables: Iterable[Any],
+        timeout: float | None = None,
+        chunksize: int = -1,
+    ) -> Iterator[_T]:
+        """
+        The map function.
 
-        return cpu_count()
+        Parameters
+        ----------
+        fn : Callable[..., _T]
+            A callable function to be applied to the items in the iterables.
+        *iterables : Iterable[Any]
+            One or more iterable objects.
+        timeout : Optional[float]
+            Maximum number of seconds to wait for a result. Default is None.
+        chunksize : int
+            The size of the chunks, default value is -1.
+
+        Returns
+        -------
+        Iterator[_T]
+            An iterator that yields the results of applying 'fn' to the items of
+            'iterables'.
+        """
+        return map(fn, *iterables)
+
+    def submit(self, __fn: Callable[..., _T], *args, **kwargs) -> "Future[_T]":
+        """
+        A callable function that returns a Future representing the result.
+
+        Parameters
+        ----------
+        __fn : Callable[..., _T]
+            A callable function to be executed.
+        *args :
+            Potential arguments to be passed to the callable function.
+        **kwargs :
+            Keyword arguments to be passed to the callable function.
+
+        Returns
+        -------
+        "Future[_T]"
+            A Future object representing the execution result of the callable function.
+        """
+        f = Future()
+        try:
+            f.set_result(__fn(*args, **kwargs))
+        except Exception as e:
+            f.set_exception(e)
+        return f
+
+    def shutdown(self, wait = True, *, cancel_futures = False):
+        return
+
+
+@lru_cache(maxsize=1)
+def serial_executor() -> SerialExecutor:
+    return SerialExecutor()
+
+thread_executor = ParallelConfig.thread_executor
+process_executor = ParallelConfig.process_executor
+
+
+def pipeline(
+    pool: Executor,
+    func: Callable[[_Ti], _T],
+    iterable: Iterable[_Ti],
+    *,
+    pipeline_size: int = 1,
+) -> Iterator[tuple[_Ti, _T]]:
+    """
+    Pipeline a function to be executed in the pool.
+
+    Analogous to iterate, but run func in a different
+    thread for the next element while the current element is returned.
+
+    Parameters
+    ----------
+    pool : Executor
+        Thread pool executor for parallel execution.
+    func : callable
+        Function to use.
+    iterable : Iterable
+        Iterable containing input elements.
+    pipeline_size : int, default=1
+        Size of the processing pipeline.
+
+    Yields
+    ------
+    element : _Ti
+        Elements
+    _T
+        Results of func corresponding to element: func(element).
+    """
+    # do pipeline loading the next element
+    from collections import deque
+
+    futures_queue = deque()
+    import itertools
+
+    for i, element in zip(itertools.count(-pipeline_size), iterable):
+        # pre-load next element/data
+        futures_queue.append((element, pool.submit(func, element)))
+        if i >= 0:
+            element, future = futures_queue.popleft()
+            yield element, future.result()
+    while len(futures_queue) > 0:
+        element, future = futures_queue.popleft()
+        yield element, future.result()
+
+
+def iterate(
+    pool: Executor, func: Callable[[_Ti], _T], iterable: Iterable[_Ti],
+) -> Iterator[tuple[_Ti, _T]]:
+    """
+    Iterate over iterable, yield pairs of elements and func(element).
+
+    Parameters
+    ----------
+    pool : Executor
+        The Executor object (dummy object to have a common API with pipeline).
+    func : callable
+        Function to use.
+    iterable : Iterable
+        Iterable to draw objects to process with func from.
+
+    Yields
+    ------
+    element : _Ti
+        Elements
+    _T
+        Results of func corresponding to element: func(element).
+    """
+    for element in iterable:
+        yield element, func(element)
+
+shutdown_executors = ParallelConfig.shutdown
+
+
+

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -30,7 +30,8 @@ from FastSurferCNN.utils.checkpoint import (
     get_checkpoints,
     load_checkpoint_config_defaults,
 )
-from FastSurferCNN.utils.common import SerialExecutor
+from FastSurferCNN.utils.common import update_docstring
+from FastSurferCNN.utils.threads import SerialExecutor
 from HypVINN.config.hypvinn_files import HYPVINN_MASK_NAME, HYPVINN_SEG_NAME
 from HypVINN.data_loader.data_utils import hypo_map_label2subseg, rescale_image
 from HypVINN.inference import Inference
@@ -138,18 +139,7 @@ def option_parse() -> argparse.ArgumentParser:
     return parser
 
 
-def _update_docstring(**kwargs):
-    """
-    Make custom replacements in the docstring.
-    """
-
-    def stub(f):
-        f.__doc__ = f.__doc__.format(**kwargs)
-        return f
-    return stub
-
-
-@_update_docstring(HYPVINN_SEG_NAME=HYPVINN_SEG_NAME, HYPVINN_MASK_NAME=HYPVINN_MASK_NAME)
+@update_docstring(HYPVINN_SEG_NAME=HYPVINN_SEG_NAME, HYPVINN_MASK_NAME=HYPVINN_MASK_NAME)
 def main(
         out_dir: Path,
         t2: Path | None,

--- a/HypVINN/run_prediction.py
+++ b/HypVINN/run_prediction.py
@@ -31,7 +31,7 @@ from FastSurferCNN.utils.checkpoint import (
     load_checkpoint_config_defaults,
 )
 from FastSurferCNN.utils.common import update_docstring
-from FastSurferCNN.utils.threads import SerialExecutor
+from FastSurferCNN.utils.parallel import SerialExecutor
 from HypVINN.config.hypvinn_files import HYPVINN_MASK_NAME, HYPVINN_SEG_NAME
 from HypVINN.data_loader.data_utils import hypo_map_label2subseg, rescale_image
 from HypVINN.inference import Inference

--- a/HypVINN/utils/preproc.py
+++ b/HypVINN/utils/preproc.py
@@ -67,8 +67,8 @@ def t1_to_t2_registration(
     """
     import shutil
 
+    from FastSurferCNN.utils.parallel import get_num_threads
     from FastSurferCNN.utils.run_tools import Popen
-    from FastSurferCNN.utils.threads import get_num_threads
 
     if threads <= 0:
         threads = get_num_threads()

--- a/doc/api/FastSurferCNN.utils.rst
+++ b/doc/api/FastSurferCNN.utils.rst
@@ -17,8 +17,8 @@ FastSurferCNN.utils
     meters
     metrics
     misc
+    parallel
     parser_defaults
     run_tools
-    threads
 
 

--- a/recon_surf/align_seg.py
+++ b/recon_surf/align_seg.py
@@ -397,7 +397,7 @@ if __name__ == "__main__":
 
     # write transform lta
     print(f"writing: {options.outlta}")
-    lta.writeLTA(
+    lta.write_lta(
         options.outlta, T, options.srcseg, srcheader, options.trgseg, trgheader
     )
 

--- a/recon_surf/lta.py
+++ b/recon_surf/lta.py
@@ -14,17 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import numpy.typing as npt
 
 # Collection of functions related to FreeSurfer's LTA (linear transform array) files:
 
 
 def writeLTA(
-        filename: str,
+        filename: Path | str,
         T: npt.ArrayLike,
-        src_fname: str,
+        src_fname: Path | str,
         src_header: dict,
-        dst_fname: str,
+        dst_fname: Path| str,
         dst_header: dict
 ) -> None:
     """
@@ -32,15 +34,15 @@ def writeLTA(
 
     Parameters
     ----------
-    filename : str
+    filename : Path, str
         File to write on.
     T : npt.ArrayLike
         Linear transform array to be saved.
-    src_fname : str
+    src_fname : Path, str
         Source filename.
     src_header : Dict
         Source header.
-    dst_fname : str
+    dst_fname : Path, str
         Destination filename.
     dst_header : Dict
         Destination header.
@@ -56,52 +58,47 @@ def writeLTA(
     fields = ("dims", "delta", "Mdc", "Pxyz_c")
     for field in fields:
         if field not in src_header:
-            raise ValueError(
-                f"writeLTA Error: src_header format missing field: {field}"
-            )
+            raise ValueError(f"writeLTA Error: src_header format missing field: {field}")
         if field not in dst_header:
-            raise ValueError(
-                f"writeLTA Error: dst_header format missing field: {field}"
-            )
+            raise ValueError(f"writeLTA Error: dst_header format missing field: {field}")
 
-    src_dims = str(src_header["dims"][0:3]).replace("[", "").replace("]", "")
-    src_vsize = str(src_header["delta"][0:3]).replace("[", "").replace("]", "")
+    src_dims = str(src_header["dims"][0:3])
+    src_vsize = str(src_header["delta"][0:3])
     src_v2r = src_header["Mdc"]
     src_c = src_header["Pxyz_c"]
 
-    dst_dims = str(dst_header["dims"][0:3]).replace("[", "").replace("]", "")
-    dst_vsize = str(dst_header["delta"][0:3]).replace("[", "").replace("]", "")
+    dst_dims = str(dst_header["dims"][0:3])
+    dst_vsize = str(dst_header["delta"][0:3])
     dst_v2r = dst_header["Mdc"]
     dst_c = dst_header["Pxyz_c"]
 
     f = open(filename, "w")
-    f.write(f"# transform file {filename}\n")
     f.write(
+        (f"# transform file {filename}\n"
         f"# created by {getpass.getuser()} on {datetime.now().ctime()}\n\n"
+        "type      = 1 # LINEAR_RAS_TO_RAS\n"
+        "nxforms   = 1\n"
+        "mean      = 0.0 0.0 0.0\n"
+        "sigma     = 1.0\n"
+        "1 4 4\n"
+        f"{T}\n"
+        "src volume info\n"
+        "valid = 1  # volume info valid\n"
+        f"filename = {src_fname}\n"
+        f"volume = {src_dims}\n"
+        f"voxelsize = {src_vsize}\n"
+        f"xras   = {src_v2r[0, :]}\n" 
+        f"yras   = {src_v2r[1, :]}\n"
+        f"zras   = {src_v2r[2, :]}\n"
+        f"cras   = {src_c}\n"
+        "dst volume info\n"
+        "valid = 1  # volume info valid\n"
+        f"filename = {dst_fname}\n"
+        f"volume = {dst_dims}\n"
+        f"voxelsize = {dst_vsize}\n"
+        f"xras   = {dst_v2r[0, :]}\n"
+        f"yras   = {dst_v2r[1, :]}\n"
+        f"zras   = {dst_v2r[2, :]}\n"
+        f"cras   = {dst_c}\n").replace("[", "").replace("]", "")
     )
-    f.write("type      = 1 # LINEAR_RAS_TO_RAS\n")
-    f.write("nxforms   = 1\n")
-    f.write("mean      = 0.0 0.0 0.0\n")
-    f.write("sigma     = 1.0\n")
-    f.write("1 4 4\n")
-    f.write(str(T).replace(" [", "").replace("[", "").replace("]", ""))
-    f.write("\n")
-    f.write("src volume info\n")
-    f.write("valid = 1  # volume info valid\n")
-    f.write(f"filename = {src_fname}\n")
-    f.write(f"volume = {src_dims}\n")
-    f.write(f"voxelsize = {src_vsize}\n")
-    f.write(f"xras   = {src_v2r[0, :]}\n".replace("[", "").replace("]", ""))
-    f.write(f"yras   = {src_v2r[1, :]}\n".replace("[", "").replace("]", ""))
-    f.write(f"zras   = {src_v2r[2, :]}\n".replace("[", "").replace("]", ""))
-    f.write(f"cras   = {src_c}\n".replace("[", "").replace("]", ""))
-    f.write("dst volume info\n")
-    f.write("valid = 1  # volume info valid\n")
-    f.write(f"filename = {dst_fname}\n")
-    f.write(f"volume = {dst_dims}\n")
-    f.write(f"voxelsize = {dst_vsize}\n")
-    f.write(f"xras   = {dst_v2r[0, :]}\n".replace("[", "").replace("]", ""))
-    f.write(f"yras   = {dst_v2r[1, :]}\n".replace("[", "").replace("]", ""))
-    f.write(f"zras   = {dst_v2r[2, :]}\n".replace("[", "").replace("]", ""))
-    f.write(f"cras   = {dst_c}\n".replace("[", "").replace("]", ""))
     f.close()

--- a/recon_surf/lta.py
+++ b/recon_surf/lta.py
@@ -20,13 +20,12 @@ import numpy.typing as npt
 
 # Collection of functions related to FreeSurfer's LTA (linear transform array) files:
 
-
-def writeLTA(
+def write_lta(
         filename: Path | str,
-        T: npt.ArrayLike,
+        affine: npt.ArrayLike,
         src_fname: Path | str,
         src_header: dict,
-        dst_fname: Path| str,
+        dst_fname: Path | str,
         dst_header: dict
 ) -> None:
     """
@@ -36,7 +35,7 @@ def writeLTA(
     ----------
     filename : Path, str
         File to write on.
-    T : npt.ArrayLike
+    affine : npt.ArrayLike
         Linear transform array to be saved.
     src_fname : Path, str
         Source filename.
@@ -58,9 +57,9 @@ def writeLTA(
     fields = ("dims", "delta", "Mdc", "Pxyz_c")
     for field in fields:
         if field not in src_header:
-            raise ValueError(f"writeLTA Error: src_header format missing field: {field}")
+            raise ValueError(f"write_lta Error: src_header format missing field: {field}")
         if field not in dst_header:
-            raise ValueError(f"writeLTA Error: dst_header format missing field: {field}")
+            raise ValueError(f"write_lta Error: dst_header format missing field: {field}")
 
     src_dims = str(src_header["dims"][0:3])
     src_vsize = str(src_header["delta"][0:3])
@@ -81,13 +80,13 @@ def writeLTA(
         "mean      = 0.0 0.0 0.0\n"
         "sigma     = 1.0\n"
         "1 4 4\n"
-        f"{T}\n"
+        f"{affine}\n"
         "src volume info\n"
         "valid = 1  # volume info valid\n"
         f"filename = {src_fname}\n"
         f"volume = {src_dims}\n"
         f"voxelsize = {src_vsize}\n"
-        f"xras   = {src_v2r[0, :]}\n" 
+        f"xras   = {src_v2r[0, :]}\n"
         f"yras   = {src_v2r[1, :]}\n"
         f"zras   = {src_v2r[2, :]}\n"
         f"cras   = {src_c}\n"


### PR DESCRIPTION
- move parallelization helpers into FastSurferCNN.utils.threads
- update typing to include better ndarray type hints: CerebNet.datasets.utils, FastSurferCNN.utils.brainvolstats
- update mask_in_array, mask_not_in_array, hemi_mask_from_aseg
- add suppress_stdout, suppress_stderr, move update_docstring to FastSurferCNN.utils.common
- expand logging module for more flexibility
- add helper functions and interface for arguments and argument parsers
- update reduce_to_aseg for inclusion in FastSurferCC
- fix dtype argument in is_conform
- fix docstrings