### PR TITLE
Documentation better linking of symbols to files and cleanup

### DIFF
--- a/FastSurferCNN/version.py
+++ b/FastSurferCNN/version.py
@@ -1,6 +1,7 @@
 #!/bin/python
 
 import argparse
+import io
 import re
 import shutil
 import subprocess
@@ -242,21 +243,17 @@ def main(
     Parameters
     ----------
     sections : str
-        String describing which sections the output should include. Can be 'all' or a
-        concatenated list of '+branch', '+checkpoints', '+git', and '+pip', e.g.
-        '+git+checkpoints'.
-        The order does not matter, '+checkpoints', '+git' or '+pip' also implicitly
-        activate '+branch'.
+        String describing which sections the output should include. Can be 'all' or a concatenated list of '+branch',
+        '+checkpoints', '+git', and '+pip', e.g. '+git+checkpoints'.
+        The order does not matter, '+checkpoints', '+git' or '+pip' also implicitly activate '+branch'.
     project_file : TextIO, optional
         A file-like object to read the projects toml file, with the '[project]' section
         with a 'version' attribute. Defaults to $PROJECT_ROOT/pyproject.toml.
     build_cache : False, TextIO, optional
-        A file-like object to read cached version information, the format should be
-        formatted like the output of `main`. Defaults to $PROJECT_ROOT/BUILD.info.
-        If build_cache is False, it is ignored.
+        A file-like object to read cached version information, the format should be formatted like the output of `main`.
+        If build_cache is None, it defaults to $PROJECT_ROOT/BUILD.info; if it is False, it is ignored.
     file : TextIO, optional
-        A file-like object to write the output to, defaults to stdout if None or not
-        passed.
+        A file-like object to write the output to, defaults to stdout if None or not passed.
     prefer_cache : bool, default=False
         Whether to prefer information from the `build_cache` over online generation.
 
@@ -273,9 +270,8 @@ def main(
 
     if prefer_cache and not has_build_cache:
         return (
-            "Trying to force the use of cached version information (--prefer_cache), "
-            "but no build information file was passed found at the default location "
-            f"({DEFAULTS.BUILD_TXT})."
+            "Trying to force the use of cached version information (--prefer_cache), but no build information file was "
+            f"passed found at the default location ({DEFAULTS.BUILD_TXT})."
         )
 
     if sections == "all":
@@ -291,17 +287,11 @@ def main(
         futures["version"] = pool.submit(read_and_close_version, project_file)
         # if we do not have git, try VERSION file else git sha and branch
         if has_git() and not prefer_cache:
-            futures["git_hash"] = Popen(
-                ["git", "rev-parse", "--short", "HEAD"], **kw_root
-            ).as_future(pool)
+            futures["git_hash"] = Popen(["git", "rev-parse", "--short", "HEAD"], **kw_root).as_future(pool)
             if sections != "":
-                futures["git_branch"] = Popen(
-                    ["git", "branch", "--show-current"], **kw_root
-                ).as_future(pool)
+                futures["git_branch"] = Popen(["git", "branch", "--show-current"], **kw_root).as_future(pool)
             if "+git" in sections:
-                futures["git_status"] = pool.submit(
-                    filter_git_status, Popen(["git", "status", "-s", "-b"], **kw_root)
-                )
+                futures["git_status"] = pool.submit(filter_git_status, Popen(["git", "status", "-s", "-b"], **kw_root))
         else:
             # we go not have git, try loading the build cache
             build_cache_required = True
@@ -337,9 +327,7 @@ def main(
     except OSError:
         version = build_cache["version"]
 
-    def __future_or_cache(
-        key: VersionDictKeys, futures: dict[str, Future[Any]], cache: VersionDict,
-    ) -> str:
+    def __future_or_cache(key: VersionDictKeys, futures: dict[str, Future[Any]], cache: VersionDict) -> str:
         future: None | Future[Any] = futures.get(key, None)
         if future is not None:
             returnmsg = future.result()
@@ -364,13 +352,9 @@ def main(
             raise RuntimeError(f"Could not find a valid value for {key}!" + add_msg)
 
     try:
-        build_file_kwargs["git_hash"] = __future_or_cache(
-            "git_hash", futures, build_cache
-        )
+        build_file_kwargs["git_hash"] = __future_or_cache("git_hash", futures, build_cache)
         if sections != "":
-            build_file_kwargs["git_branch"] = __future_or_cache(
-                "git_branch", futures, build_cache
-            )
+            build_file_kwargs["git_branch"] = __future_or_cache("git_branch", futures, build_cache)
         keys: Sequence[VersionDictKeys] = ("git_status", "checkpoints", "pypackages")
         for key in keys:
             if DEFAULTS.VERSION_SECTIONS[key][0] in sections:
@@ -401,7 +385,7 @@ def get_default_version_info() -> VersionDict:
     }
 
 
-def parse_build_file(build_file: TextIO | None) -> VersionDict:
+def parse_build_file(build_file: TextIO | io.StringIO | None) -> VersionDict:
     """Read and parse a build file (same as output of `main`).
 
     Read and parse a file with version information in the format that is also the
@@ -409,7 +393,7 @@ def parse_build_file(build_file: TextIO | None) -> VersionDict:
 
     Parameters
     ----------
-    build_file : TextIO, optional
+    build_file : TextIO, io.StringIO, optional
         File-like object, will be closed.
 
     Returns
@@ -423,43 +407,34 @@ def parse_build_file(build_file: TextIO | None) -> VersionDict:
     -----
     See also main.
     """
-    file_cache: VersionDict = {}
+    file_cache: VersionDict = get_default_version_info()
     if build_file is None:
         try:
             build_file = open(DEFAULTS.BUILD_TXT)
         except FileNotFoundError:
             return get_default_version_info()
-    file_cache["content"] = "".join(build_file.readlines())
+    file_cache["content"] = build_file.getvalue() if hasattr(build_file, "getvalue") else "".join(build_file.read())
     if not build_file.closed:
         build_file.close()
     section_pattern = re.compile("\n={3,}\n")
     file_cache["version_line"], *rest = section_pattern.split(file_cache["content"], 1)
-    version_regex = re.compile(
-        "([a-zA-Z.0-9\\-]+)(\\+([0-9A-Fa-f]+))?(\\s+\\(([^)]+)\\))?\\s*"
-    )
+    version_regex = re.compile("([a-zA-Z.0-9\\-]+)(\\+([0-9A-Fa-f]+))?(\\s+\\(([^)]+)\\))?\\s*")
     hits = version_regex.search(file_cache["version_line"])
     if hits is None:
+        filename = getattr(build_file, "name", "<unnamed file>")
         raise RuntimeError(
-            f"The build file {build_file.name} has invalid formatting, version tag not "
-            f"recognized! First line was '{file_cache['version_line']}' and did "
-            f"not fit the pattern '{version_regex.pattern}'.",
+            f"The build file {filename} has invalid formatting, version tag not recognized! First line was "
+            f"'{file_cache['version_line']}' and did not fit the pattern '{version_regex.pattern}'.",
         )
-    (
-        file_cache["version"],
-        _,
-        file_cache["git_hash"],
-        _,
-        file_cache["git_branch"],
-    ) = hits.groups("")
-    if file_cache["git_hash"]:
-        file_cache["version_tag"] = file_cache["version"] + "+" + file_cache["git_hash"]
-    else:
-        file_cache["version_tag"] = file_cache["version"]
+    file_cache["version"], _, file_cache["git_hash"], _, file_cache["git_branch"] = hits.groups("")
+
+    file_cache["version_tag"] = file_cache["version"] + (f"+{file_cache['git_hash']}" if file_cache["git_hash"] else "")
 
     def get_section_name_by_header(header: str) -> str | None:
         for name, info in DEFAULTS.VERSION_SECTIONS.items():
             if info[1] == header:
                 return name
+        return None
 
     while len(rest) > 0:
         section_header, section_content, *rest = section_pattern.split(rest[0], 2)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,13 +2,12 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
+import importlib
+import io
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 
-import inspect
-from importlib import import_module
 import sys
 import os
 from pathlib import Path
@@ -19,11 +18,21 @@ sys.path.append(os.path.dirname(__file__) + "/..")
 sys.path.append(os.path.dirname(__file__) + "/../recon_surf")
 sys.path.append(os.path.dirname(__file__) + "/sphinx_ext")
 
+from resolve_links import LinkCodeResolver
+from FastSurferCNN.version import main as _version_info, parse_build_file
+
 project = "FastSurfer"
 author = "FastSurfer Developers"
-copyright = f"2020, {author}"
-gh_url = "https://github.com/deep-mi/FastSurfer"
+copyright = f"2020-2026, {author}"
+gh_url = "https://github.com/Deep-MI/FastSurfer"
 
+# run the version script and save in build dir
+_streambuf = io.StringIO()
+_version_info(file=_streambuf)
+_version_dict = parse_build_file(_streambuf)
+
+branch = _version_dict["git_branch"]
+version = _version_dict["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -209,60 +218,20 @@ bibtex_bibfiles = ["./references.bib"]
 # -- sphinx.ext.linkcode -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html
 
-#  Alternative method for linking to code by Osama, not sure which one is better
-from urllib.parse import quote
+def import_from_path(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
-# https://github.com/python-websockets/websockets/blob/e217458ef8b692e45ca6f66c5aeb7fad0aee97ee/docs/conf.py#L102-L134
-def linkcode_resolve(domain, info):
-    # Check if the domain is Python, if not return None
-    if domain != "py":
-        return None
-    if not info["module"]:
-        return None
-
-    # Import the module using the module information
-    mod = import_module(info["module"])
-
-    # Check if the fullname contains a ".", indicating it's a method or attribute of
-    # a class
-    if "." in info["fullname"]:
-        objname, attrname = info["fullname"].split(".")
-        # Get the object from the module
-        obj = getattr(mod, objname)
-        try:
-            # Try to get the attribute from the object
-            obj = getattr(obj, attrname)
-        except AttributeError:
-            # If the attribute doesn't exist, return None
-            return None
-    else:
-        # If the fullname doesn't contain a ".", get the object directly from the module
-        obj = getattr(mod, info["fullname"])
-
-    try:
-        # Try to get the source file and line numbers of the object
-        lines, first_line = inspect.getsourcelines(obj)
-    except TypeError:
-        # If the object is not a Python object that has a source file, return None
-        return None
-
-    # Replace "." with "/" in the module name to construct the file path
-    filename = quote(info["module"].replace(".", "/"))
-    # If the filename doesn't start with "tests", add a "/" at the beginning
-    if not filename.startswith("tests"):
-        filename = "/" + filename
-
-    # Construct the URL that points to the source code of the object on GitHub
-    return f"{gh_url}/blob/dev{filename}.py#L{first_line}-L{first_line + len(lines) - 1}"
-
-# Which domains to search in to create links in markdown texts
-# myst_ref_domains = ["myst", "std", "py"]
-
+linkcode_resolve = LinkCodeResolver(gh_url, branch)
 
 _re_script_dirs = "fastsurfercnn|cerebnet|recon_surf|hypvinn"
 _up = "^/\\.\\./"
 _end = "(\\.md)?(#.*)?$"
 
+# -- sphinx_ext.fix_links -----------------------------------------------------
 # re_reference_target=(regex) => used in missing-reference
 fix_links_target = {
     # all regexpr are ignorecase, individual replacements are applied until no further

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,5 @@
-.. FastSurfer documentation master file, created by
-   sphinx-quickstart on Thu Nov 30 15:48:44 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-   Modified and updated by the David Kügler of the FastSurfer Team.
+.. FastSurfer documentation master file; modified and updated by
+   David Kügler of the FastSurfer Team.
 
 .. image:: images/teaser.png
    :alt: FastSurfer Teaser Image

--- a/doc/sphinx_ext/fix_links/resolve.py
+++ b/doc/sphinx_ext/fix_links/resolve.py
@@ -2,7 +2,7 @@
 import re
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import Any
+from typing import Any, Generator
 
 from docutils import nodes
 from sphinx.domains import Domain
@@ -28,7 +28,7 @@ def resolve_included(
         included: dict[str, set[str]],
         found_docs: set[str],
         uri_path: str,
-) -> str:
+) -> Generator[str, None, None]:
     """
     Iterate through including files resolved via inclusion links.
 
@@ -41,12 +41,12 @@ def resolve_included(
     uri_path : str
         The path to the included file
 
-    Returns
-    -------
+    Yields
+    ------
     str
         The resolved path.
     """
-    def __resolve_all(path, include_tree=()):
+    def __resolve_all(path, include_tree=()) -> Generator[str, None, None]:
         for src, inc in included.items():
             if path in inc:
                 if src in found_docs:

--- a/doc/sphinx_ext/resolve_links.py
+++ b/doc/sphinx_ext/resolve_links.py
@@ -1,0 +1,80 @@
+from urllib.parse import quote
+import inspect
+import logging
+from importlib import import_module
+
+_logger = logging.getLogger("fastsurfer.doc.linkcode_resolve")
+
+class LinkCodeResolver:
+
+    def __init__(self, url, branch="dev"):
+        self._gh_url = url
+        self._branch = branch
+
+    @property
+    def base_path(self):
+        # Base URL to the GitHub repository where the source code is hosted
+        return f"{self._gh_url}/blob/{self._branch}"
+
+    def __call__(self, domain, info):
+        # Check if the domain is Python, if not return None
+        if domain != "py":
+            return None
+        if not info["module"]:
+            return None
+
+        # Import the module using the module information
+        mod = import_module(info["module"])
+
+        # Check if the fullname contains a ".", indicating it's a method or attribute of a class
+        if "." in info["fullname"]:
+            objname, attrname = info["fullname"].split(".")
+            # Get the object from the module
+            _mod = getattr(mod, objname)
+            try:
+                # Try to get the attribute from the object
+                obj = getattr(_mod, attrname)
+            except AttributeError:
+                # If the attribute doesn't exist, return None
+                return None
+        else:
+            # If the fullname doesn't contain a ".", get the object directly from the module
+            obj = getattr(mod, info["fullname"])
+            _mod = mod
+
+        # If the object is a property, try to link to the getter or setter method
+        if isinstance(obj, property):
+            obj = obj.fget or obj.fset
+        try:
+            # Try to get the source file and line numbers of the object
+            lines, first_line = inspect.getsourcelines(obj)
+        except (TypeError, OSError) as e:
+            lines, first_line = [], -1
+            # if the obj is a variable, try to find it in the parent object
+            try:
+                _lines, _first_line = inspect.getsourcelines(_mod)
+                from re import match, escape
+                # try to find the line this was defined in
+                for idx, line in enumerate(_lines):
+                    if match(f"\\s*{escape(info['fullname'])}\\s*[:=]", line):
+                        first_line = _first_line + idx
+                        lines = [_lines[idx]]
+                        break
+            except (OSError, TypeError):
+                # if this was unsuccessful, give up
+                pass
+
+            if first_line == -1 and isinstance(e, OSError):
+                # If the object is not a Python object that has a source file, return None
+                _suffix = "" if str(obj).startswith("<") else f" ({obj})"
+                _logger.info(f"Could not find source for {info['module']}.{info['fullname']}{_suffix}.")
+                return None
+
+        # Replace "." with "/" in the module name to construct the file path
+        filename = quote(info["module"].replace(".", "/"))
+        # If the filename doesn't start with "tests", add a "/" at the beginning
+        if not filename.startswith("tests"):
+            filename = "/" + filename
+
+        # Construct the URL that points to the source code of the object on GitHub
+        return f"{self.base_path}{filename}.py#L{first_line}-L{first_line + len(lines) - 1}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,13 @@ dependencies = [
     'torchvision>=0.15.2',
     'tqdm>=4.65',
     'yacs>=0.1.8',
+    'pip>=25.0',
 ]
 
 [project.optional-dependencies]
 doc = [
     'furo!=2023.8.17',
-    'matplotlib',
+    'whippersnappy>=1.3.1',
     'memory-profiler',
     'myst-parser',
     'numpydoc',
@@ -73,9 +74,6 @@ doc = [
     'nbsphinx',
     'IPython', # For syntax highlighting in notebooks
     'ipykernel',
-    'scikit-image',
-    'torchvision',
-    'scikit-learn',
 ]
 style = [
     'bibclean',


### PR DESCRIPTION
This PR fixes an issue with the doc build, where symbols could not be found/links could not be created in the CC documentation.
As a side effect, this PR also fixes some other minor things in the documentation build, including linking to the correct branch in the stable doc, getting rid of extra dependencies in the doc optional dependencies, and adding links in other spots when possible.