### PR TITLE
FastSurfer-CC bugfixes

### DIFF
--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -841,7 +841,7 @@ def main(
     # Process slices based on selection mode
 
     logger.info(f"Processing slices with selection mode: {slice_selection}")
-    slice_results, slice_io_futures, cc_contours, cc_mesh = recon_cc_surf_measures_multi(
+    slice_results, slice_io_futures, cc_contours = recon_cc_surf_measures_multi(
         segmentation=cc_fn_seg_labels,
         slice_selection=slice_selection,
         upright_header=fsavg_header,
@@ -883,8 +883,8 @@ def main(
         if len(middle_slice_result["split_contours"]) <= 5:
             cc_subseg_midslice = make_subdivision_mask(
                 (cc_fn_seg_labels.shape[1], cc_fn_seg_labels.shape[2]),
-                middle_slice_result["split_contours"],
-                vox2ras=fsavg_vox2ras @ np.linalg.inv(fsavg2midslice_vox2vox),
+                middle_slice_result["subdivision_lines"],
+                vox2ras=fsavg_vox2ras @ np.linalg.inv(fsavg2midslice_vox2vox)
             )
         else:
             logger.warning("Too many subsegments for lookup table, skipping sub-division of output segmentation.")
@@ -928,8 +928,8 @@ def main(
         additional_metrics["cc_5mm_volume_pv_corrected"] = cc_volume_contour
 
     # get ac and pc in all spaces
-    ac_coords_3d = np.hstack((FSAVERAGE_MIDDLE, ac_coords_vox))
-    pc_coords_3d = np.hstack((FSAVERAGE_MIDDLE, pc_coords_vox))
+    ac_coords_3d = np.hstack((FSAVERAGE_MIDDLE / vox_size[0], ac_coords_vox))
+    pc_coords_3d = np.hstack((FSAVERAGE_MIDDLE / vox_size[0], pc_coords_vox))
     standardized2orig_vox2vox, ac_coords_standardized, pc_coords_standardized, ac_coords_orig, pc_coords_orig = (
         calc_mapping_to_standard_space(orig, ac_coords_3d, pc_coords_3d, orig2fsavg_vox2vox)
     )

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -914,17 +914,19 @@ def main(
 
     ########## Save outputs ##########
     additional_metrics = {}
-    if len(outer_contours) > 1:
-        cc_volume_voxel = segmentation_postprocessing.get_cc_volume_voxel(
+
+    cc_volume_voxel = segmentation_postprocessing.get_cc_volume_voxel(
             desired_width_mm=5,
             cc_mask=np.equal(cc_fn_seg_labels, CC_LABEL),
             voxel_size=vox_size, # in LIA order
         )
+    additional_metrics["cc_5mm_volume"] = cc_volume_voxel
+
+
+    if len(outer_contours) > 1:
         logger.info(f"CC volume voxel: {cc_volume_voxel}")
         cc_volume_contour = calculate_cc_volume_contour(cc_contours, width=5.0)
         logger.info(f"CC volume contour: {cc_volume_contour}")
-
-        additional_metrics["cc_5mm_volume"] = cc_volume_voxel
         additional_metrics["cc_5mm_volume_pv_corrected"] = cc_volume_contour
 
     # get ac and pc in all spaces

--- a/CorpusCallosum/localization/inference.py
+++ b/CorpusCallosum/localization/inference.py
@@ -189,7 +189,7 @@ def predict(
 
     crop_left, crop_top = cast(tuple[int, int], t_dict["crop_left"]), cast(tuple[int, int], t_dict["crop_top"])
     t_crops = [(crop_left + crop_top) * 2]
-    outs: np.ndarray[tuple[int, Literal[4]], np.dtype[np.float_]]
+    outs: np.ndarray[tuple[int, Literal[4]], np.dtype[np.float64]]
     outs = outputs.cpu().numpy() + np.asarray(t_crops, dtype=float)
     crop_offsets: tuple[int, int] = (crop_left[0], crop_top[0])
     return outs[:, :2], outs[:, 2:], crop_offsets

--- a/CorpusCallosum/shape/contour.py
+++ b/CorpusCallosum/shape/contour.py
@@ -78,7 +78,7 @@ class CCContour:
     def __init__(
         self,
         points: Points2dType,
-        thickness_values: np.ndarray[tuple[int], np.dtype[np.float_]] | None,
+        thickness_values: np.ndarray[tuple[int], np.dtype[np.float64]] | None,
         endpoint_idxs: tuple[int, int] | None = None,
         z_position: float = 0.0
     ):
@@ -740,7 +740,7 @@ class CCContour:
         contour: Points2dType,
         original_thickness_vertices: np.ndarray[tuple[int], np.dtype[np.signedinteger]] | None,
         input_path: str | Path,
-    ) -> np.ndarray[tuple[int], np.dtype[np.float_]]:
+    ) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
         """See load_thickness_values.
 
         Ignore shape of thickness values if original_thickness_vertices is None.

--- a/CorpusCallosum/shape/curvature.py
+++ b/CorpusCallosum/shape/curvature.py
@@ -61,7 +61,7 @@ def compute_mean_curvature(path: Points2dType) -> float:
 
 def calculate_curvature_metrics(
     midline: Points2dType,
-    split_points: np.ndarray | None = None,
+    split_points: np.ndarray,
 ) -> tuple[float, float, np.ndarray]:
     """
     Calculate curvature metrics for the CC midline, including overall mean,
@@ -71,10 +71,8 @@ def calculate_curvature_metrics(
     ----------
     midline : Points2dType
         Equidistant points along the midline.
-    split_points : np.ndarray, optional
+    split_points : np.ndarray
         Points on the midline where it was split (for orthogonal subdivision).
-    split_contours : ContourList, optional
-        List of split contours (for other subdivision methods).
 
     Returns
     -------
@@ -95,10 +93,9 @@ def calculate_curvature_metrics(
 
     # Find split indices on the midline for subsegment curvature
     split_indices_midline = [0]
-    if split_points is not None:
-        for sp in split_points:
-            idx = np.argmin(np.linalg.norm(midline - sp, axis=1))
-            split_indices_midline.append(idx)
+    for sp in split_points:
+        idx = np.argmin(np.linalg.norm(midline - sp, axis=1))
+        split_indices_midline.append(idx)
 
     split_indices_midline.append(len(midline) - 1)
     split_indices_midline.sort()

--- a/CorpusCallosum/shape/curvature.py
+++ b/CorpusCallosum/shape/curvature.py
@@ -17,7 +17,7 @@ import numpy as np
 from CorpusCallosum.utils.types import Points2dType
 
 
-def compute_curvature(path: Points2dType) -> np.ndarray[tuple[int], np.dtype[np.float_]]:
+def compute_curvature(path: Points2dType) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
     """Compute curvature by computing edge angles.
 
     Parameters

--- a/CorpusCallosum/shape/curvature.py
+++ b/CorpusCallosum/shape/curvature.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 
-from CorpusCallosum.utils.types import ContourList, Points2dType
+from CorpusCallosum.utils.types import Points2dType
 
 
 def compute_curvature(path: Points2dType) -> np.ndarray[tuple[int], np.dtype[np.float_]]:
@@ -62,7 +62,6 @@ def compute_mean_curvature(path: Points2dType) -> float:
 def calculate_curvature_metrics(
     midline: Points2dType,
     split_points: np.ndarray | None = None,
-    split_contours: ContourList | None = None,
 ) -> tuple[float, float, np.ndarray]:
     """
     Calculate curvature metrics for the CC midline, including overall mean,
@@ -100,16 +99,6 @@ def calculate_curvature_metrics(
         for sp in split_points:
             idx = np.argmin(np.linalg.norm(midline - sp, axis=1))
             split_indices_midline.append(idx)
-    elif split_contours is not None:
-        from CorpusCallosum.shape.subsegment_contour import get_unique_contour_points
-        unique_points = get_unique_contour_points(split_contours)
-        for line_pts in unique_points[1:]:
-            if len(line_pts) == 2:
-                # find where this line crosses the midline
-                # use the average of the two points and find closest point on midline
-                mid_pt = np.mean(line_pts, axis=0)
-                idx = np.argmin(np.linalg.norm(midline - mid_pt, axis=1))
-                split_indices_midline.append(idx)
 
     split_indices_midline.append(len(midline) - 1)
     split_indices_midline.sort()

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -427,9 +427,8 @@ def recon_cc_surf_measure(
     
     # NOTE: areas, subdivision_lines, and split_points_midline are all ordered Anterior to Posterior
 
-    total_area = np.sum(areas)
-    contour_closed = np.concatenate([contour_as, contour_as[:, :1]], axis=1)
-    total_perimeter = np.sum(np.linalg.norm(np.diff(contour_closed, axis=1), axis=0))
+    total_area = _contour.area
+    total_perimeter = np.sum(_contour.get_contour_edge_lengths())
     circularity = 4 * np.pi * total_area / (total_perimeter**2)
 
     # Transform split contours back to original space (from ACPC to RAS)

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -31,7 +31,6 @@ from CorpusCallosum.shape.metrics import calculate_cc_index
 from CorpusCallosum.shape.subsegment_contour import (
     ContourList,
     get_primary_eigenvector,
-    get_unique_contour_points,
     hampel_subdivide_contour,
     subdivide_contour,
     subsegment_midline_orthogonal,
@@ -141,8 +140,6 @@ def recon_cc_surf_measures_multi(
         List of background IO processes.
     list of CCContour
         List of CC contours.
-    CCMesh, None
-        The CC mesh or None if no mesh was created.
     """
     slice_cc_measures: list[CCMeasuresDict] = []
     io_futures = []
@@ -206,7 +203,7 @@ def recon_cc_surf_measures_multi(
 
         slice_cc_measures.append(cc_measures)
         is_debug = logger.getEffectiveLevel() <= logging.DEBUG
-        is_midslice = slice_idx == num_slices // 2
+        is_midslice = i == num_slices // 2
         if wants_output("cc_qc_image") and (is_debug or is_midslice):
             qc_imgs: list[Path] = [output_path("cc_qc_image")]
             if is_debug:
@@ -289,7 +286,7 @@ def recon_cc_surf_measures_multi(
             logger.error("Error: No valid slices were found for postprocessing")
             raise ValueError("No valid slices were found for postprocessing")
 
-    return slice_cc_measures, io_futures, cc_contours, cc_mesh if len(cc_contours) > 1 else None
+    return slice_cc_measures, io_futures, cc_contours
 
 
 def _resample_thickness(contour: CCContour) -> CCContour:
@@ -384,50 +381,68 @@ def recon_cc_surf_measure(
 
     # Apply different subdivision methods based on user choice
     split_contours: ContourList
+    subdivision_lines: list[Points2dType]
     split_points_midline: np.ndarray | None = None
     if subdivision_method == "shape":
         _subdivisions = np.asarray(subdivisions)
-        areas, split_contours, split_points_midline = subsegment_midline_orthogonal(
+        areas, split_contours, split_points_midline, subdivision_lines = subsegment_midline_orthogonal(
             midline_equi, _subdivisions, contour_as, plot=False
         )
         split_contours = [
             transform_to_acpc_standard(split_contour, *acpc_contour_coords_as)[0]
             for split_contour in split_contours
         ]
+        subdivision_lines = [
+            transform_to_acpc_standard(line.T, *acpc_contour_coords_as)[0].T
+            for line in subdivision_lines
+        ]
     elif subdivision_method == "vertical":
-        areas, split_contours = subdivide_contour(contour_in_acpc_space, subdivisions, plot=False)
+        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour(
+            contour_in_acpc_space, subdivisions, plot=False
+        )
     elif subdivision_method == "angular":
         if not np.allclose(np.diff(subdivisions), np.diff(subdivisions)[0]):
             raise ValueError(
                 f"Angular subdivision method (Hampel) only supports equidistant subdivision, "
                 f"but got: {subdivisions}. No measures are computed.",
             )
-        areas, split_contours = hampel_subdivide_contour(contour_in_acpc_space, num_rays=len(subdivisions), plot=False)
+        areas, split_contours, split_points_midline, subdivision_lines = hampel_subdivide_contour(
+            contour_in_acpc_space, num_rays=len(subdivisions), plot=False
+        )
     elif subdivision_method == "eigenvector":
         pt0, pt1 = get_primary_eigenvector(contour_in_acpc_space)
         contour_eigen, _, _, rotate_back_eigen = transform_to_acpc_standard(contour_in_acpc_space, pt0, pt1)
         ac_pt_eigen, _, _, _ = transform_to_acpc_standard(ac_pt_acpc[:, None], pt0, pt1)
         ac_pt_eigen = ac_pt_eigen[:, 0]
-        areas, split_contours = subdivide_contour(contour_eigen, subdivisions, oriented=True, hline_anchor=ac_pt_eigen)
+        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour(
+            contour_eigen, subdivisions, oriented=True, hline_anchor=ac_pt_eigen
+        )
+        
+        # Transform from the outputs back to the input space
         split_contours = [rotate_back_eigen(split_contour) for split_contour in split_contours]
+        subdivision_lines = [rotate_back_eigen(line.T).T for line in subdivision_lines]
+        split_points_midline = rotate_back_eigen(np.asarray(split_points_midline).T).T
     else:
         raise ValueError(f"Invalid subdivision method {subdivision_method}")
     
-    # order areas anterior to posterior
-    areas = areas[::-1]
+    # NOTE: areas, subdivision_lines, and split_points_midline are all ordered Anterior to Posterior
 
     total_area = np.sum(areas)
-    # total_perimeter should include the edge from last to first point
     contour_closed = np.concatenate([contour_as, contour_as[:, :1]], axis=1)
     total_perimeter = np.sum(np.linalg.norm(np.diff(contour_closed, axis=1), axis=0))
     circularity = 4 * np.pi * total_area / (total_perimeter**2)
 
-    # Transform split contours back to original space
+    # Transform split contours back to original space (from ACPC to RAS)
+    # Note: for 'shape' method, split_points_midline is already in RAS space,
+    # while the others are in ACPC and need rotate_back_acpc.
     split_contours = [rotate_back_acpc(split_contour) for split_contour in split_contours]
+    subdivision_lines = [rotate_back_acpc(line.T).T for line in subdivision_lines]
+    if subdivision_method != "shape":
+        split_points_midline = rotate_back_acpc(np.asarray(split_points_midline).T).T
 
     # Calculate curvature metrics
     curvature, curvature_body, curvature_subsegments = calculate_curvature_metrics(
-        midline_equi, split_points=split_points_midline, split_contours=split_contours
+        midline_equi, split_points=split_points_midline
     )
 
     measures: CCMeasuresDict = {
@@ -443,6 +458,7 @@ def recon_cc_surf_measure(
         "total_area": total_area,
         "total_perimeter": total_perimeter,
         "split_contours": split_contours,
+        "subdivision_lines": subdivision_lines,
         "midline_equidistant": midline_equi,
         "levelpaths": levelpaths,
         "slice_index": slice_idx
@@ -450,7 +466,7 @@ def recon_cc_surf_measure(
     return measures, _contour
 
 
-def test_right_of_line(
+def test_left_of_line(
         coords: Points2dType,
         line_start: Vector2d,
         line_end: Vector2d,
@@ -486,7 +502,7 @@ def test_right_of_line(
 
 def make_subdivision_mask(
     slice_shape: Shape2d,
-    split_contours: ContourList,
+    subdivision_lines: list[Points2dType],
     vox2ras: AffineMatrix4x4,
     plot: bool = False,
 ) -> np.ndarray[Shape2d, np.dtype[np.int_]]:
@@ -496,9 +512,8 @@ def make_subdivision_mask(
     ----------
     slice_shape : pair of ints
         Shape of the slice (rows, cols).
-    split_contours : ContourList
-        List of contours defining the subdivisions.
-        Each contour is a tuple of x and y coordinates.
+    subdivision_lines : list[np.ndarray]
+        List of pairs of points defining the subdivision lines.
     vox2ras : AffineMatrix4x4
         The vox2ras transformation matrix for the requested shape.
     plot : bool, default=False
@@ -513,20 +528,15 @@ def make_subdivision_mask(
     Notes
     -----
     The function:
-    1. Extracts unique contour points at subdivision boundaries.
-    2. Creates coordinate grids for all points in the slice.
-    3. Initializes mask with first segment label.
-    4. For each subdivision line:
+    1. Creates coordinate grids for all points in the slice.
+    2. Initializes mask with first segment label.
+    3. For each subdivision line:
     - Tests which points lie to the right of the line.
     - Updates labels for those points.
     """
     from nibabel.affines import apply_affine
 
-    # unique_contour_points are the points where sub-division lines were inserted
-    unique_contour_points: list[Points2dType] = get_unique_contour_points(split_contours)  # shape (N, 2)
-    subdivision_segments = unique_contour_points[1:]
-
-    for s in subdivision_segments:
+    for s in subdivision_lines:
         if len(s) != 2:
             logger.error(f"Subdivision segment {s} has {len(s)} points, expected 2")
  
@@ -537,40 +547,40 @@ def make_subdivision_mask(
 
     # Use only as many labels as needed based on the number of subdivisions
     # Number of regions = number of division lines + 1
-    num_labels_needed = len(subdivision_segments) + 1
+    num_labels_needed = len(subdivision_lines) + 1
     cc_labels_posterior_to_anterior = SUBSEGMENT_LABELS[:num_labels_needed]
 
     # Initialize with first segment label
     subdivision_mask = np.full(slice_shape, cc_labels_posterior_to_anterior[0], dtype=np.int32)
 
-    # Process each subdivision line, subdivision_segments has for each division line the two points that are on the
+    # Process each subdivision line, subdivision_lines has for each division line the two points that are on the
     # contour and divide the subsegments
-    for label, segment_points in zip(cc_labels_posterior_to_anterior[1:], reversed(subdivision_segments), strict=True):
+    for label, segment_points in zip(cc_labels_posterior_to_anterior[1:], subdivision_lines, strict=True):
         # line_start and line_end are the intersection points of the CC subsegmentation boundary and the contour line
         line_start, line_end = segment_points
 
         # --> find all voxels posterior to the line in question
         # Vectorized test: find all points to the right of line (line_start->line_end)
         # right_of_line == posterior to line
-        points_right_of_line = test_right_of_line(coords_ras[0, ..., 1:], line_start, line_end)
+        points_left_of_line = test_left_of_line(coords_ras[0, ..., 1:], line_start, line_end)
         
         # All points to the right of this line belong to the next segment or beyond
-        subdivision_mask[points_right_of_line] = label
+        subdivision_mask[points_left_of_line] = label
         
-    if plot: # interactive debug plot
-        import matplotlib
-        import matplotlib.pyplot as plt
-        curr_backend = matplotlib.get_backend()
-        plt.switch_backend("qtagg")
-        plt.figure(figsize=(10, 8))
-        plt.imshow(subdivision_mask, cmap='tab10')
-        plt.colorbar(label='Subdivision')
-        plt.title('CC Subdivision Mask')
-        plt.xlabel('X')
-        plt.ylabel('Y')
-        plt.tight_layout()
-        plt.show()
-        plt.switch_backend(curr_backend)
+        if plot: # interactive debug plot
+            import matplotlib
+            import matplotlib.pyplot as plt
+            curr_backend = matplotlib.get_backend()
+            plt.switch_backend("qtagg")
+            plt.figure(figsize=(10, 8))
+            plt.imshow(subdivision_mask, cmap='tab10')
+            plt.colorbar(label='Subdivision')
+            plt.title('CC Subdivision Mask')
+            plt.xlabel('X')
+            plt.ylabel('Y')
+            plt.tight_layout()
+            plt.show()
+            plt.switch_backend(curr_backend)
     return subdivision_mask
 
 

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -600,7 +600,11 @@ def check_area_changes(contours: list[np.ndarray], threshold: float = 0.3) -> bo
         True if no large area changes are detected, False otherwise.
     """
 
-    areas = np.asarray([np.abs(np.trapz(c[1], c[0])) for c in contours])
+    # support numpy <2 and >=2
+    if hasattr(np, 'trapezoid'):
+        areas = np.asarray([np.abs(np.trapezoid(c[1], c[0])) for c in contours])
+    else:
+        areas = np.asarray([np.abs(np.trapz(c[1], c[0])) for c in contours])
 
     assert len(areas) > 1, "At least two areas are required to check for area changes"
 

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -304,14 +304,15 @@ def subdivide_contour(
     subdivision_method: SubdivisionMethod,
 ) -> tuple[list[float], ContourList, np.ndarray, list[Points2dType]]:
     """Subdivide the contour based on the subdivision method.
+
     Parameters
     ----------
     midline_equi : Points2dType
         The midline equidistant points.
     subdivisions : list[float]
         The subdivisions.
-    ac_pt_acpc: Vector2d
-        The AC point in ACPC space. (Needed for eigenvector subdivision.)
+    ac_pt_acpc : Vector2d
+        The AC point in ACPC space (needed for eigenvector subdivision).
     contour_in_acpc_space : Points2dType
         The contour in ACPC space.
     subdivision_method : SubdivisionMethod

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -31,8 +31,8 @@ from CorpusCallosum.shape.metrics import calculate_cc_index
 from CorpusCallosum.shape.subsegment_contour import (
     ContourList,
     get_primary_eigenvector,
-    hampel_subdivide_contour,
-    subdivide_contour,
+    subdivide_contour_hampel,
+    subdivide_contour_vertical,
     subsegment_midline_orthogonal,
     transform_to_acpc_standard,
 )
@@ -98,7 +98,7 @@ def recon_cc_surf_measures_multi(
     subdivision_method: SubdivisionMethod,
     contour_smoothing: int,
     subject_dir: SubjectDirectory,
-) -> tuple[list[CCMeasuresDict], list[concurrent.futures.Future], list[CCContour], CCMesh | None]:
+) -> tuple[list[CCMeasuresDict], list[concurrent.futures.Future], list[CCContour]]:
     """Surface reconstruction and metrics computation of corpus callosum slices based on selection mode.
 
     Parameters
@@ -296,6 +296,69 @@ def _resample_thickness(contour: CCContour) -> CCContour:
     return _c
 
 
+def subdivide_contour(
+    midline_equi: Points2dType,
+    subdivisions: list[float],
+    ac_pt_acpc: Vector2d,
+    contour_in_acpc_space: Points2dType,
+    subdivision_method: SubdivisionMethod,
+) -> tuple[list[float], ContourList, np.ndarray, list[Points2dType]]:
+    """Subdivide the contour based on the subdivision method.
+    Parameters
+    ----------
+    midline_equi : Points2dType
+        The midline equidistant points.
+    subdivisions : list[float]
+        The subdivisions.
+    ac_pt_acpc: Vector2d
+        The AC point in ACPC space. (Needed for eigenvector subdivision.)
+    contour_in_acpc_space : Points2dType
+        The contour in ACPC space.
+    subdivision_method : SubdivisionMethod
+        The subdivision method. One of "shape", "vertical", "angular", or "eigenvector".
+
+    Returns
+    -------
+    tuple[list[float], ContourList, np.ndarray, list[Points2dType]]
+        The areas, split contours, split points midline, and subdivision lines.
+    """
+    if subdivision_method == "shape":
+        _subdivisions = np.asarray(subdivisions)
+        areas, split_contours, split_points_midline, subdivision_lines = subsegment_midline_orthogonal(
+            midline_equi, _subdivisions, contour_in_acpc_space, plot=False
+        )
+    elif subdivision_method == "vertical":
+        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour_vertical(
+            contour_in_acpc_space, subdivisions, plot=False
+        )
+    elif subdivision_method == "angular":
+        if not np.allclose(np.diff(subdivisions), np.diff(subdivisions)[0]):
+            raise ValueError(
+                f"Angular subdivision method (Hampel) only supports equidistant subdivision, "
+                f"but got: {subdivisions}. No measures are computed.",
+            )
+        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour_hampel(
+            contour_in_acpc_space, num_rays=len(subdivisions), plot=False
+        )
+    elif subdivision_method == "eigenvector":
+        pt0, pt1 = get_primary_eigenvector(contour_in_acpc_space)
+        contour_eigen, _, _, rotate_back_eigen = transform_to_acpc_standard(contour_in_acpc_space, pt0, pt1)
+        ac_pt_eigen, _, _, _ = transform_to_acpc_standard(ac_pt_acpc[:, None], pt0, pt1)
+        ac_pt_eigen = ac_pt_eigen[:, 0]
+        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour_vertical(
+            contour_eigen, subdivisions, oriented=True, hline_anchor=ac_pt_eigen
+        )
+        
+        # Transform from the outputs back to the input space
+        split_contours = [rotate_back_eigen(split_contour) for split_contour in split_contours]
+        subdivision_lines = [rotate_back_eigen(line.T).T for line in subdivision_lines]
+        split_points_midline = rotate_back_eigen(np.asarray(split_points_midline).T).T
+    else:
+        raise ValueError(f"Invalid subdivision method {subdivision_method}")
+
+    return areas, split_contours, split_points_midline, subdivision_lines
+
+
 def recon_cc_surf_measure(
     segmentation: np.ndarray[Shape3d, np.dtype[np.int_]],
     slice_idx: int,
@@ -383,49 +446,12 @@ def recon_cc_surf_measure(
     split_contours: ContourList
     subdivision_lines: list[Points2dType]
     split_points_midline: np.ndarray | None = None
-    if subdivision_method == "shape":
-        _subdivisions = np.asarray(subdivisions)
-        areas, split_contours, split_points_midline, subdivision_lines = subsegment_midline_orthogonal(
-            midline_equi, _subdivisions, contour_as, plot=False
-        )
-        split_contours = [
-            transform_to_acpc_standard(split_contour, *acpc_contour_coords_as)[0]
-            for split_contour in split_contours
-        ]
-        subdivision_lines = [
-            transform_to_acpc_standard(line.T, *acpc_contour_coords_as)[0].T
-            for line in subdivision_lines
-        ]
-    elif subdivision_method == "vertical":
-        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour(
-            contour_in_acpc_space, subdivisions, plot=False
-        )
-    elif subdivision_method == "angular":
-        if not np.allclose(np.diff(subdivisions), np.diff(subdivisions)[0]):
-            raise ValueError(
-                f"Angular subdivision method (Hampel) only supports equidistant subdivision, "
-                f"but got: {subdivisions}. No measures are computed.",
-            )
-        areas, split_contours, split_points_midline, subdivision_lines = hampel_subdivide_contour(
-            contour_in_acpc_space, num_rays=len(subdivisions), plot=False
-        )
-    elif subdivision_method == "eigenvector":
-        pt0, pt1 = get_primary_eigenvector(contour_in_acpc_space)
-        contour_eigen, _, _, rotate_back_eigen = transform_to_acpc_standard(contour_in_acpc_space, pt0, pt1)
-        ac_pt_eigen, _, _, _ = transform_to_acpc_standard(ac_pt_acpc[:, None], pt0, pt1)
-        ac_pt_eigen = ac_pt_eigen[:, 0]
-        areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour(
-            contour_eigen, subdivisions, oriented=True, hline_anchor=ac_pt_eigen
-        )
-        
-        # Transform from the outputs back to the input space
-        split_contours = [rotate_back_eigen(split_contour) for split_contour in split_contours]
-        subdivision_lines = [rotate_back_eigen(line.T).T for line in subdivision_lines]
-        split_points_midline = rotate_back_eigen(np.asarray(split_points_midline).T).T
-    else:
-        raise ValueError(f"Invalid subdivision method {subdivision_method}")
+
+    areas, split_contours, split_points_midline, subdivision_lines = subdivide_contour(
+        midline_equi, subdivisions, ac_pt_acpc, contour_in_acpc_space, subdivision_method
+    )
     
-    # NOTE: areas, subdivision_lines, and split_points_midline are all ordered Anterior to Posterior
+    
 
     total_area = _contour.area
     total_perimeter = np.sum(_contour.get_contour_edge_lengths())
@@ -470,7 +496,7 @@ def test_left_of_line(
         line_start: Vector2d,
         line_end: Vector2d,
 ) -> np.ndarray[tuple[int], np.dtype[np.bool_]]:
-    """Test whether points in coords are to the right of the line (line_start->line_end).
+    """Test whether points in coords are to the left of the line (line_start->line_end).
 
     Parameters
     ----------

--- a/CorpusCallosum/shape/subsegment_contour.py
+++ b/CorpusCallosum/shape/subsegment_contour.py
@@ -100,7 +100,12 @@ def calc_subsegment_areas(split_contours: ContourList) -> np.ndarray[tuple[int],
     """
     # calculate area of each split contour using the shoelace formula
     # we use the absolute value because the orientation of the contour may vary
-    areas_cum = np.abs([np.trapz(c[1], c[0]) for c in split_contours])
+    # support numpy <2 and >=2
+    if hasattr(np, 'trapezoid'):
+        areas_cum = np.abs([np.trapezoid(c[1], c[0]) for c in split_contours])
+    else:
+        areas_cum = np.abs([np.trapz(c[1], c[0]) for c in split_contours])
+
     if len(areas_cum) == 1:
         return np.asarray(areas_cum[0])
     
@@ -115,7 +120,7 @@ def calc_subsegment_areas(split_contours: ContourList) -> np.ndarray[tuple[int],
 
 def subsegment_midline_orthogonal(
         midline: Points2dType,
-        area_weights: np.ndarray[tuple[int], np.dtype[np.float_]],
+        area_weights: np.ndarray[tuple[int], np.dtype[np.float64]],
         contour: Polygon2dType,
         plot: bool = True,
         ax=None,
@@ -346,7 +351,7 @@ def subsegment_midline_orthogonal(
 
 
 def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool = False, ax=None) \
-        -> tuple[np.ndarray[tuple[int], np.dtype[np.float_]], ContourList, list[Vector2d], list[Points2dType]]:
+        -> tuple[np.ndarray[tuple[int], np.dtype[np.float64]], ContourList, list[Vector2d], list[Points2dType]]:
     """Subdivide contour based on area weights using equally spaced rays.
 
     Parameters
@@ -535,7 +540,7 @@ def subdivide_contour(
     plot_transform: Callable | None = None,
     oriented: bool = False,
     hline_anchor: np.ndarray | None = None
-) -> tuple[np.ndarray[tuple[int], np.dtype[np.float_]], ContourList, list[Vector2d], list[Points2dType]]:
+) -> tuple[np.ndarray[tuple[int], np.dtype[np.float64]], ContourList, list[Vector2d], list[Points2dType]]:
     """Subdivide contour based on area weights using vertical lines.
 
     Divides the contour into segments by drawing vertical lines at positions

--- a/CorpusCallosum/shape/subsegment_contour.py
+++ b/CorpusCallosum/shape/subsegment_contour.py
@@ -120,7 +120,7 @@ def subsegment_midline_orthogonal(
         plot: bool = True,
         ax=None,
         extremes=None,
-) -> tuple[np.ndarray[tuple[int], np.dtype[ScalarType]], ContourList, np.ndarray]:
+) -> tuple[np.ndarray[tuple[int], np.dtype[ScalarType]], ContourList, np.ndarray, list[Points2dType]]:
     """Subsegment contour orthogonally to the midline based on area weights.
 
     Parameters
@@ -152,12 +152,10 @@ def subsegment_midline_orthogonal(
     Subsegments include all previous segments. This means subsegment contour two is the outline of the union
     of subsegment one and subsegment two.
     """
-    # FIXME: Here and in other places, the order of dimensions is pretty inconsistent, for example: midline is (N, 2),
-    #        but contours are (2, N)...
-
-    midline_end_idx = np.argmin(np.linalg.norm(contour.T - midline[-1], axis=1))
-    # roll contour start to midline end
-    contour = np.roll(contour, -midline_end_idx, axis=1)
+    # midline[0] is Anterior (max X), midline[-1] is Posterior (min X)
+    midline_start_idx = np.argmin(np.linalg.norm(contour.T - midline[0], axis=1))
+    # roll contour start to midline anterior end
+    contour = np.roll(contour, -midline_start_idx, axis=1)
 
     # Calculate edge indices and fractions for splitting the midline
     # We use len(midline) - 1 because we are looking for intervals between points
@@ -191,7 +189,8 @@ def subsegment_midline_orthogonal(
     side_wrapped = np.hstack([side, side[:, 0:1]])
     sign_change = (side_wrapped[:, :-1] * side_wrapped[:, 1:]) <= 0
 
-    split_contours: ContourList = [contour]
+    split_contours: ContourList = []
+    subdivision_lines: list[Points2dType] = []
 
     for pt_idx, split_point in enumerate(split_points):
         # Indices of contour segments that have sign changes for this split point
@@ -226,6 +225,7 @@ def subsegment_midline_orthogonal(
                 first_index, second_index = second_index, first_index
                 first_intersection, second_intersection = second_intersection, first_intersection
 
+            subdivision_lines.append(np.stack([first_intersection, second_intersection], axis=0))
             first_index += 1
 
             # connect first and second half
@@ -339,50 +339,14 @@ def subsegment_midline_orthogonal(
             ax.axis("equal")
             plt.show()
 
-    return calc_subsegment_areas(split_contours), split_contours, split_points
+    # add original contour to split_contours to be the union of all subsegments
+    split_contours.append(contour)
 
-
-def get_unique_contour_points(split_contours: ContourList) -> list[Points2dType]:
-    """Get unique contour points from the split contours.
-
-    Parameters
-    ----------
-    split_contours : ContourList
-        List of split contours (subsegmentations), each containing x and y coordinates, each of shape (2, N).
-
-    Returns
-    -------
-    list[np.ndarray]
-        List of unique contour points for each subsegment, each of shape (N, 2).
-
-    Notes
-    -----
-    This is a workaround to retrospectively add voxel-based subdivision.
-    In the future, we could keep track of the subdivision lines for
-    every subdivision scheme.
-
-    The function:
-    1. Processes each contour point.
-    2. Checks if it appears in other contours (with small tolerance).
-    3. Collects points unique to each subsegment.
-    """
-    # For each contour point, check if it appears in other contours
-    # initialize with values for first_contour, which are by definition just "the contour" (empty)
-    unique_contour_points: list[Points2dType] = [np.zeros((0, 2))]
-    first_contour = split_contours[0]
-    # Check each point against all other contours
-    for contour in split_contours[1:]:
-        # 0: coord-axis, 1: contour-axis, 2: first_contour_axis
-        contour_comparison = np.isclose(first_contour[:, None], contour[:, :, None], atol=1e-6)
-        # mask of contour points, that are also in first_contour (axis 1 after all)
-        contour_points_in_first_contour_mask = np.any(np.all(contour_comparison, axis=0), axis=1)
-        unique_contour_points.append(contour[:, ~contour_points_in_first_contour_mask].T)
-
-    return unique_contour_points
+    return calc_subsegment_areas(split_contours), split_contours, split_points, subdivision_lines
 
 
 def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool = False, ax=None) \
-        -> tuple[np.ndarray[tuple[int], np.dtype[np.float_]], ContourList]:
+        -> tuple[np.ndarray[tuple[int], np.dtype[np.float_]], ContourList, list[Vector2d], list[Points2dType]]:
     """Subdivide contour based on area weights using equally spaced rays.
 
     Parameters
@@ -415,8 +379,9 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
     """
     
     # Find the extreme points in the x-direction
-    min_x_index = np.argmin(contour[0])
-    contour = np.roll(contour, -min_x_index, axis=1)
+    # Anterior end (max X)
+    max_x_index = np.argmax(contour[0])
+    contour = np.roll(contour, -max_x_index, axis=1)
 
     # get minimal bounding box around contour
     min_bounding_rectangle = minimum_bounding_rectangle(contour)
@@ -467,6 +432,8 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
 
     # Subdivision logic
     split_contours: ContourList = []
+    subdivision_lines: list[Points2dType] = []
+    split_points: list[Vector2d] = []
     num_points = contour.shape[1]
     for ray_vector in ray_vectors.T:
         intersections = []
@@ -500,6 +467,8 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
             first_index, first_intersection = intersections[0]
             second_index, second_intersection = intersections[-1]
 
+            subdivision_lines.append(np.stack([first_intersection, second_intersection], axis=0))
+            split_points.append(np.mean([first_intersection, second_intersection], axis=0))
             start_to_cutoff = np.hstack(
                 (
                     contour[:, :first_index],
@@ -550,7 +519,12 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
             ax.axis("equal")
             plt.show()
 
-    return calc_subsegment_areas(split_contours), split_contours
+    # order all anterior to posterior
+    split_contours = split_contours[::-1]
+    subdivision_lines = subdivision_lines[::-1]
+    split_points = split_points[::-1]
+
+    return calc_subsegment_areas(split_contours), split_contours, split_points, subdivision_lines
 
 
 def subdivide_contour(
@@ -561,7 +535,7 @@ def subdivide_contour(
     plot_transform: Callable | None = None,
     oriented: bool = False,
     hline_anchor: np.ndarray | None = None
-) -> tuple[np.ndarray[tuple[int], np.dtype[np.float_]], ContourList]:
+) -> tuple[np.ndarray[tuple[int], np.dtype[np.float_]], ContourList, list[Vector2d], list[Points2dType]]:
     """Subdivide contour based on area weights using vertical lines.
 
     Divides the contour into segments by drawing vertical lines at positions
@@ -670,7 +644,7 @@ def subdivide_contour(
 
     # Split the contour at the calculated split points
     split_contours = []
-    split_contours.append(contour)
+    subdivision_lines: list[Points2dType] = []
     for split_point in split_points:
         intersections = []
         for i in range(contour.shape[1] - 1):
@@ -704,6 +678,7 @@ def subdivide_contour(
                 first_index, second_index = second_index, first_index
                 first_intersection, second_intersection = second_intersection, first_intersection
 
+            subdivision_lines.append(np.stack([first_intersection, second_intersection], axis=0))
             first_index += 1
 
             # connect first and second half to create a closed cumulative loop
@@ -830,7 +805,19 @@ def subdivide_contour(
             ax.axis("equal")
             plt.show()
 
-    return calc_subsegment_areas(split_contours), split_contours
+
+    # add original contour to split_contours to be the union of all subsegments
+    split_contours.append(contour)
+
+    # order all anterior to posterior
+    split_contours = split_contours[::-1]
+    subdivision_lines = subdivision_lines[::-1]
+    split_points = split_points[::-1]
+
+    # swap subdivision_lines start and end points
+    subdivision_lines = [np.flip(subdivision_line, axis=0) for subdivision_line in subdivision_lines]
+
+    return calc_subsegment_areas(split_contours), split_contours, split_points, subdivision_lines
 
 
 def transform_to_acpc_standard(

--- a/CorpusCallosum/shape/subsegment_contour.py
+++ b/CorpusCallosum/shape/subsegment_contour.py
@@ -100,11 +100,14 @@ def calc_subsegment_areas(split_contours: ContourList) -> np.ndarray[tuple[int],
     """
     # calculate area of each split contour using the shoelace formula
     # we use the absolute value because the orientation of the contour may vary
-    # support numpy <2 and >=2
-    if hasattr(np, 'trapezoid'):
-        areas_cum = np.abs([np.trapezoid(c[1], c[0]) for c in split_contours])
-    else:
-        areas_cum = np.abs([np.trapz(c[1], c[0]) for c in split_contours])
+    areas_cum = []
+    for c in split_contours:
+        # c is (2, N)
+        x = c[0]
+        y = c[1]
+        area = 0.5 * np.abs(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+        areas_cum.append(area)
+    areas_cum = np.asarray(areas_cum)
 
     if len(areas_cum) == 1:
         return np.asarray(areas_cum[0])

--- a/CorpusCallosum/shape/subsegment_contour.py
+++ b/CorpusCallosum/shape/subsegment_contour.py
@@ -576,22 +576,25 @@ def subdivide_contour(
     
     """
     # Find the extreme points in the x-direction
-    min_x_index = np.argmin(contour[0])
-    contour = np.roll(contour, -min_x_index, axis=1)
-
-    min_x_index = 0
+    # standard ACPC orientation: Anterior has larger X, Posterior has smaller X
     max_x_index = np.argmax(contour[0])
+    contour = np.roll(contour, -max_x_index, axis=1)
+
+    max_x_index = 0
+    min_x_index = np.argmin(contour[0])
 
     if oriented:
         contour_x_sorted = np.sort(contour[0])
         min_x = contour_x_sorted[0]
         max_x = contour_x_sorted[-1]
-        extremes = (np.array([min_x, 0]), np.array([max_x, 0]))
+        # order extremes A to P
+        extremes = (np.array([max_x, 0]), np.array([min_x, 0]))
 
         if hline_anchor is not None:
-            extremes = (np.array([min_x, hline_anchor[1]]), np.array([max_x, hline_anchor[1]]))
+            extremes = (np.array([max_x, hline_anchor[1]]), np.array([min_x, hline_anchor[1]]))
     else:
-        extremes = (contour[:, min_x_index].copy(), contour[:, max_x_index].copy())
+        # order extremes A to P
+        extremes = (contour[:, max_x_index].copy(), contour[:, min_x_index].copy())
         # Calculate the line between the extreme points
         start_point, end_point = extremes
         line_vector = end_point - start_point
@@ -682,8 +685,8 @@ def subdivide_contour(
             first_index += 1
 
             # connect first and second half to create a closed cumulative loop
-            # that includes the start point of the contour (Posterior end)
-            start_to_cutoff = np.hstack(
+            # starting from the Anterior end (start of the rolled contour)
+            anterior_to_cutoff = np.hstack(
                 (
                     contour[:, :first_index],
                     first_intersection[:, None],
@@ -692,8 +695,8 @@ def subdivide_contour(
                 )
             )
 
-            # add cumulative subsegment
-            split_contours.append(start_to_cutoff)
+            # add cumulative subsegment (Anterior -> Current Split)
+            split_contours.append(anterior_to_cutoff)
         else:
             raise ValueError("No intersections found, this should not happen")
 
@@ -806,16 +809,10 @@ def subdivide_contour(
             plt.show()
 
 
-    # add original contour to split_contours to be the union of all subsegments
+    
+
+    # add original contour as the final element (Full CC)
     split_contours.append(contour)
-
-    # order all anterior to posterior
-    split_contours = split_contours[::-1]
-    subdivision_lines = subdivision_lines[::-1]
-    split_points = split_points[::-1]
-
-    # swap subdivision_lines start and end points
-    subdivision_lines = [np.flip(subdivision_line, axis=0) for subdivision_line in subdivision_lines]
 
     return calc_subsegment_areas(split_contours), split_contours, split_points, subdivision_lines
 

--- a/CorpusCallosum/shape/subsegment_contour.py
+++ b/CorpusCallosum/shape/subsegment_contour.py
@@ -154,6 +154,8 @@ def subsegment_midline_orthogonal(
         List of contour arrays for each subsegment.
     split_points : np.ndarray
         Array of shape (K, 2) containing points where the midline was split.
+    subdivision_lines : list of np.ndarray
+        List of contour arrays for each subdivision line.
 
     Notes
     -----
@@ -247,7 +249,7 @@ def subsegment_midline_orthogonal(
             )
             split_contours.append(start_to_cutoff)
         else:
-            raise ValueError(f"No intersections found for split point {pt_idx}, this should not happen")
+            raise ValueError("No intersections found in subdivision, is the contour valid?")
 
         # plot contour to first index, then split point, then contour to second index
 
@@ -353,7 +355,7 @@ def subsegment_midline_orthogonal(
     return calc_subsegment_areas(split_contours), split_contours, split_points, subdivision_lines
 
 
-def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool = False, ax=None) \
+def subdivide_contour_hampel(contour: Polygon2dType, num_rays: int, plot: bool = False, ax=None) \
         -> tuple[np.ndarray[tuple[int], np.dtype[np.float64]], ContourList, list[Vector2d], list[Points2dType]]:
     """Subdivide contour based on area weights using equally spaced rays.
 
@@ -374,6 +376,10 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
         Array of areas for each subsegment.
     split_contours : list[np.ndarray]
         List of contour arrays for each subsegment.
+    split_points : list[Vector2d]
+        List of split points for each subsegment.
+    subdivision_lines : list[Points2dType]
+        List of contour arrays for each subdivision line.
 
     Notes
     -----
@@ -489,7 +495,7 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
             # connect first and second half
             split_contours.append(start_to_cutoff)
         else:
-            raise ValueError("No intersections found, this should not happen")
+            raise ValueError("No intersections found in subdivision, is the contour valid?")
 
     split_contours = [contour] + split_contours
 
@@ -535,7 +541,7 @@ def hampel_subdivide_contour(contour: Polygon2dType, num_rays: int, plot: bool =
     return calc_subsegment_areas(split_contours), split_contours, split_points, subdivision_lines
 
 
-def subdivide_contour(
+def subdivide_contour_vertical(
     contour: Polygon2dType,
     area_weights: list[float],
     plot: bool = False,
@@ -573,6 +579,10 @@ def subdivide_contour(
         Array of areas for each subsegment.
     split_contours : list[np.ndarray]
         List of contour arrays for each subsegment.
+    split_points : list[Vector2d]
+        List of split points for each subsegment.
+    subdivision_lines : list[Points2dType]
+        List of contour arrays for each subdivision line.
 
     Notes
     -----
@@ -706,7 +716,7 @@ def subdivide_contour(
             # add cumulative subsegment (Anterior -> Current Split)
             split_contours.append(anterior_to_cutoff)
         else:
-            raise ValueError("No intersections found, this should not happen")
+            raise ValueError("No intersections found in subdivision, is the contour valid?")
 
     if plot:
         # make vline at every split point

--- a/CorpusCallosum/shape/thickness.py
+++ b/CorpusCallosum/shape/thickness.py
@@ -164,7 +164,7 @@ def make_mesh_from_contour(
     max_volume: float = 0.5,
     min_angle: float = 25,
     verbose: bool = False
-) -> tuple[Points2dType[np.float_], np.ndarray[tuple[int, Literal[3]], np.dtype[np.int_]]]:
+) -> tuple[Points2dType[np.float64], np.ndarray[tuple[int, Literal[3]], np.dtype[np.int_]]]:
     """Create a triangular mesh from a 2D contour.
 
     Parameters
@@ -200,7 +200,7 @@ def make_mesh_from_contour(
     # NOTE: crashes if contour has duplicate points !!
     mesh = triangle.build(info, max_volume=max_volume, min_angle=min_angle, verbose=verbose)
 
-    mesh_points: Points2dType[np.float_] = np.array(mesh.points, dtype=float)
+    mesh_points: Points2dType[np.float64] = np.array(mesh.points, dtype=float)
     mesh_trias: np.ndarray[tuple[int, Literal[3]], np.dtype[np.int_]] = np.array(mesh.elements, dtype=int)
 
     return mesh_points, mesh_trias

--- a/CorpusCallosum/utils/mapping_helpers.py
+++ b/CorpusCallosum/utils/mapping_helpers.py
@@ -218,7 +218,7 @@ def apply_transform_to_volume(
     output_path: str | Path | None = None,
     output_size: np.ndarray | None = None,
     order: int = 1
-) -> Image3d[np.float_]:
+) -> Image3d[np.float64]:
     """Apply transformation to a volume and save the result.
 
     Parameters

--- a/CorpusCallosum/utils/types.py
+++ b/CorpusCallosum/utils/types.py
@@ -1,6 +1,6 @@
 from typing import Literal, TypedDict
 
-from numpy import dtype, float_, ndarray
+from numpy import dtype, float64, ndarray
 
 from FastSurferCNN.utils import ScalarType
 
@@ -63,7 +63,7 @@ class CCMeasuresDict(TypedDict):
     midline_length: float
     thickness: float
     curvature: float
-    thickness_profile: ndarray[tuple[int], dtype[float_]]
+    thickness_profile: ndarray[tuple[int], dtype[float64]]
     total_area: float
     total_perimeter: float
     split_contours: ContourList

--- a/CorpusCallosum/utils/types.py
+++ b/CorpusCallosum/utils/types.py
@@ -71,4 +71,5 @@ class CCMeasuresDict(TypedDict):
     curvature_subsegments: ndarray
     curvature_body: float
     levelpaths: list[ndarray]
+    subdivision_lines: list[Points2dType]
     slice_index: int

--- a/CorpusCallosum/utils/visualization.py
+++ b/CorpusCallosum/utils/visualization.py
@@ -215,6 +215,9 @@ def plot_contours(
     # NOTE: For all plots imshow shows y inverted
     current_plot = 0
 
+    if _split_contours:
+        reference_contour = _split_contours[-1]
+
     # This visualization uses voxel coordinates in fsaverage space...
     if has_first_plot:
         ax[current_plot].imshow(slice_or_slab[slice_or_slab.shape[0] // 2], cmap="gray")
@@ -237,7 +240,6 @@ def plot_contours(
     if _midline_equi.shape[0] > 0:
         ax[current_plot].plot(_midline_equi[:, 1], _midline_equi[:, 0], color="red")
     if _split_contours:
-        reference_contour = _split_contours[0]
         ax[current_plot].plot(reference_contour[1, :], reference_contour[0, :], color="red", linewidth=0.5)
 
     padding = 30
@@ -245,7 +247,6 @@ def plot_contours(
         a.set_aspect("equal", adjustable="box")
         a.axis("off")
         if _split_contours:
-            reference_contour = _split_contours[0]
             # get bounding box of contours
             a.set_xlim(reference_contour[1, :].min() - padding, reference_contour[1, :].max() + padding)
             a.set_ylim((reference_contour[0, :]).max() + padding, (reference_contour[0, :]).min() - padding)

--- a/CorpusCallosum/utils/visualization.py
+++ b/CorpusCallosum/utils/visualization.py
@@ -45,16 +45,36 @@ def plot_standardized_space(
     Notes
     -----
     Creates three views:
-    - Axial (top view)
-    - Sagittal (side view)
-    - Coronal (front view)
+    - Sagittal
+    - Coronal
+    - Axial
     """
-    ax_row[0].set_title("Standardized")
+    # View configuration for LIA orientation (0:L, 1:I, 2:A)
+    # Each entry: (slice_axis, x_plot_idx, y_plot_idx, origin, transpose, view_name)
+    view_configs = [
+        (0, 2, 1, 'upper', False, "Sagittal"), # Slice L, plot (A, I)
+        (2, 0, 1, 'upper', True,  "Coronal"),  # Slice A, plot (L, I)
+        (1, 0, 2, 'lower', True,  "Axial")     # Slice I, plot (L, A)
+    ]
 
-    for i, (a, b, _) in ((2, 1, "Axial"), (2, 0, "Sagittal"), (1, 0, "Coronal")):
-        ax_row[i].scatter(ac_coords[a], ac_coords[b], color="red", marker="x")
-        ax_row[i].scatter(pc_coords[a], pc_coords[b], color="blue", marker="x")
-        ax_row[i].imshow(vol[(slice(None),) * i + (vol.shape[i] // 2,)], cmap="gray")
+    for i, (slice_axis, x_idx, y_idx, origin, do_transpose, name) in enumerate(view_configs):
+        slice_idx = vol.shape[slice_axis] // 2
+        
+        # Extract slice
+        if slice_axis == 0:
+            slice_data = vol[slice_idx, :, :]
+        elif slice_axis == 1:
+            slice_data = vol[:, slice_idx, :]
+        else:
+            slice_data = vol[:, :, slice_idx]
+
+        if do_transpose:
+            slice_data = slice_data.T
+
+        ax_row[i].imshow(slice_data, cmap="gray", origin=origin)
+        ax_row[i].scatter(ac_coords[x_idx], ac_coords[y_idx], color="red", marker="x", s=20)
+        ax_row[i].scatter(pc_coords[x_idx], pc_coords[y_idx], color="blue", marker="x", s=20)
+        ax_row[i].set_ylabel(name)
 
 
 def visualize_coordinate_spaces(
@@ -105,27 +125,26 @@ def visualize_coordinate_spaces(
     3. standardized image space
     as a single image named 'ac_pc_spaces.png' in `output_dir`.
     """
-    fig, ax = plt.subplots(3, 4)
-    ax = ax.T
+    fig, ax = plt.subplots(3, 3, figsize=(12, 12))
 
-    # Original space - using plot_standardized_space
-    plot_standardized_space(ax[0], np.asarray(orig.dataobj), ac_coords_orig, pc_coords_orig)
+    # Original space (Column 0)
+    plot_standardized_space(ax[:, 0], np.asarray(orig.dataobj), ac_coords_orig, pc_coords_orig)
     ax[0, 0].set_title("Orig")
 
-    # Fsaverage space
-    plot_standardized_space(ax[1], upright, ac_coords_3d, pc_coords_3d)
-    ax[1, 0].set_title("Fsaverage")
+    # Fsaverage space (Column 1)
+    plot_standardized_space(ax[:, 1], upright, ac_coords_3d, pc_coords_3d)
+    ax[0, 1].set_title("Fsaverage")
 
-    # Standardized space
-    plot_standardized_space(ax[2], standardized, ac_coords_standardized, pc_coords_standardized)
-    ax[2, 0].set_title("Standardized")
+    # Standardized space (Column 2)
+    plot_standardized_space(ax[:, 2], standardized, ac_coords_standardized, pc_coords_standardized)
+    ax[0, 2].set_title("Standardized")
+
     # Format all subplots
     for a in ax.flatten():
         a.set_aspect("equal", adjustable="box")
         a.axis("off")
 
     plt.savefig(output_plot_path, dpi=300, bbox_inches="tight")
-    plt.show()
     plt.close()
 
 

--- a/FastSurferCNN/utils/__init__.py
+++ b/FastSurferCNN/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+# Copyright 2025 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,17 +54,17 @@ from typing import Literal, TypeVar
 # including nibabel does not overly drag down performance
 from nibabel.analyze import SpatialHeader as nibabelHeader
 from nibabel.analyze import SpatialImage as nibabelImage
-from numpy import bool_, dtype, float_, ndarray, number
+from numpy import bool_, dtype, float64, ndarray, number
 
-AffineMatrix4x4 = ndarray[tuple[Literal[4], Literal[4]], dtype[float_]]
+AffineMatrix4x4 = ndarray[tuple[Literal[4], Literal[4]], dtype[float64]]
 PlaneAxial = Literal["axial"]
 PlaneCoronal = Literal["coronal"]
 PlaneSagittal = Literal["sagittal"]
 Plane = PlaneAxial | PlaneCoronal | PlaneSagittal
 PLANES: tuple[PlaneAxial, PlaneCoronal, PlaneSagittal] = ("axial", "coronal", "sagittal")
 ScalarType = TypeVar("ScalarType", bound=number)
-Vector2d = ndarray[tuple[Literal[2]], dtype[float_]]
-Vector3d = ndarray[tuple[Literal[3]], dtype[float_]]
+Vector2d = ndarray[tuple[Literal[2]], dtype[float64]]
+Vector3d = ndarray[tuple[Literal[3]], dtype[float64]]
 Shape2d = tuple[int, int]
 Shape3d = tuple[int, int, int]
 Shape4d = tuple[int, int, int, int]
@@ -75,4 +75,4 @@ Image4d = ndarray[Shape4d, dtype[ScalarType]]
 Mask2d = ndarray[Shape2d, dtype[bool_]]
 Mask3d = ndarray[Shape3d, dtype[bool_]]
 Mask4d = ndarray[Shape4d, dtype[bool_]]
-RotationMatrix3x3 = ndarray[tuple[Literal[3], Literal[3]], dtype[float_]]
+RotationMatrix3x3 = ndarray[tuple[Literal[3], Literal[3]], dtype[float64]]

--- a/doc/overview/modules/CC.md
+++ b/doc/overview/modules/CC.md
@@ -102,8 +102,9 @@ This file contains measurements from the middle sagittal slice and includes:
 - `cc_5mm_volume_pv_corrected`: Volume with partial volume correction using CC contours (mm³)
 
 **Anatomical Landmarks:**
-- `ac_center`: Anterior commissure coordinates in original image space
-- `pc_center`: Posterior commissure coordinates in original image space
+All anatomical landmarks are given image voxel coordinates (LIA orientation)
+- `ac_center`: Anterior commissure coordinates in original image space (orig.mgz)
+- `pc_center`: Posterior commissure coordinates in original image space (orig.mgz)
 - `ac_center_oriented_volume`: AC coordinates in standardized space (orient_volume.lta) 
 - `pc_center_oriented_volume`: PC coordinates in standardized space (orient_volume.lta)
 - `ac_center_upright`: AC coordinates in upright space (cc_up.lta)


### PR DESCRIPTION
This PR fixes multiple bugs in the corpus callosum module.

One critical bug was in the AC/PC localization, where the AC/PC was never correctly placed on the midslice.

Other bugs are mainly related to visualization and alternate subdivision schemes (not run in the default run_fastsurfer.sh configuration).