### PR TITLE
Quick fix to address warning in run_prediction.py

### DIFF
--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -240,7 +240,7 @@ class RunModelOnData:
                 f"Could not find the ColorLUT in {lut}, please make sure the --lut argument is valid."
             ) from err
         self.labels = self.lut["ID"].values
-        self.torch_labels = torch.from_numpy(self.lut["ID"].values)
+        self.torch_labels = torch.from_numpy(np.asarray(self.lut["ID"].values))
         self.names = ["SubjectName", "Average", "Subcortical", "Cortical"]
         self.cfg_fin, cfg_cor, cfg_sag, cfg_ax = args2cfg(cfg_ax, cfg_cor, cfg_sag, batch_size=batch_size)
         # the order in this dictionary dictates the order in the view aggregation


### PR DESCRIPTION
This PR fixes the following warning by manually converting to an ndarray
```
/fastsurfer/FastSurferCNN/run_prediction.py:243: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)
```