### PR TITLE
Change error message to warning in link_fs.sh

### DIFF
--- a/tools/build/link_fs.sh
+++ b/tools/build/link_fs.sh
@@ -59,7 +59,7 @@ if [ "$1" == "-all-info" ]; then
   exit 0
 fi
 echo
-echo "ERROR: The binary $0 is not included, your call is forwarded to not-here.sh"
+echo "WARNING: The binary $0 is not included, your call is forwarded to not-here.sh"
 echo
 exit 1
 ' > $ltrg


### PR DESCRIPTION
Avoid unnecessary ERROR messages when recon-all checks for files that we don't need. See for example #770 