### PR TITLE
Add timeout to version.py execution

### DIFF
--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -870,7 +870,7 @@ trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" | tee -
 # create the build log, file with all version info in parallel
 # uses ${version_cache_args}, which is filled exactly if a build_cache file exists
 printf "%s %s\n%s\n" "$THIS_SCRIPT" "${inputargs[*]}" "$(date -R)" >> "$build_log"
-$python "$FASTSURFER_HOME/FastSurferCNN/version.py" --sections all -o "$build_log" "${version_cache_args[@]}" &
+timeout 20 $python "$FASTSURFER_HOME/FastSurferCNN/version.py" --sections all -o "$build_log" "${version_cache_args[@]}" &
 
 if [[ "$run_seg_pipeline" != "1" ]]
 then


### PR DESCRIPTION
version.py with ```--sections all```hangs on google collab. see #699 

Possible solutions:
- to not call all section, but e.g. only "+git"
- to fix whatever is hanging in version.py (if that is even possible as maybe the pip stuff is too slow on collab or the md5 computation)
- put a timeout to ensure that the background process is terminated eventually (this is what I do here as a quick fix)

