### PR TITLE
Fix version info

### DIFF
--- a/FastSurferCNN/version.py
+++ b/FastSurferCNN/version.py
@@ -287,9 +287,11 @@ def main(
         futures["version"] = pool.submit(read_and_close_version, project_file)
         # if we do not have git, try VERSION file else git sha and branch
         if has_git() and not prefer_cache:
-            futures["git_hash"] = Popen(["git", "rev-parse", "--short", "HEAD"], **kw_root).as_future(pool)
+            git_rev_parse_cmd = ["git", "rev-parse", "--short", "HEAD"]
+            futures["git_hash"] = Popen(git_rev_parse_cmd, **kw_root).as_future(pool, timeout=10.0)
             if sections != "":
-                futures["git_branch"] = Popen(["git", "branch", "--show-current"], **kw_root).as_future(pool)
+                git_branch_current_cmd = ["git", "branch", "--show-current"]
+                futures["git_branch"] = Popen(git_branch_current_cmd, **kw_root).as_future(pool, timeout=10.0)
             if "+git" in sections:
                 futures["git_status"] = pool.submit(filter_git_status, Popen(["git", "status", "-s", "-b"], **kw_root))
         else:
@@ -302,18 +304,16 @@ def main(
         if "+checkpoints" in sections and not prefer_cache:
 
             def calculate_md5_for_checkpoints() -> "MessageBuffer":
-                from glob import glob
-
-                files = glob(str(DEFAULTS.PROJECT_ROOT / "checkpoints" / "*"))
-                shorten = len(str(DEFAULTS.PROJECT_ROOT)) + 1
-                files = [f[shorten:] for f in files]
-                return Popen(["md5sum"] + files, **kw_root).finish()
+                files = list(map(str, DEFAULTS.PROJECT_ROOT.glob("checkpoints/*")))
+                if len(files) == 0:
+                    return MessageBuffer(out=b"", err=b"No checkpoints found.", retcode=0, runtime=0.0)
+                return Popen(["md5sum"] + files, **kw_root).finish(timeout=10.0)
 
             futures["checkpoints"] = pool.submit(calculate_md5_for_checkpoints)
 
         if "+pip" in sections and not prefer_cache:
             pip_command = "-m pip list --verbose --no-cache-dir --no-color --disable-pip-version-check"
-            futures["pypackages"] = PyPopen(pip_command.split(" "), **kw_root).as_future(pool)
+            futures["pypackages"] = PyPopen(pip_command.split(" "), **kw_root).as_future(pool, timeout=10.0)
 
     if build_cache_required and build_cache is not False:
         build_cache: VersionDict = futures.pop("build_cache").result()
@@ -334,9 +334,7 @@ def main(
             if isinstance(returnmsg, str):
                 return returnmsg
             elif returnmsg.retcode != 0:
-                raise RuntimeError(
-                    f"The calculation/determination of {key} has failed."
-                )
+                raise RuntimeError(f"The calculation/determination of {key} has failed.")
             return returnmsg.out_str("utf-8").strip()
         elif key in cache:
             # fill from cache
@@ -497,7 +495,7 @@ def filter_git_status(git_process) -> str:
     str
         The git status string filtered to exclude lines containing "__pycache__".
     """
-    finished_process = git_process.finish()
+    finished_process = git_process.finish(timeout=10.0)
     if finished_process.retcode != 0:
         raise RuntimeError("Failed git status command")
     git_status_text = finished_process.out_str("utf-8")


### PR DESCRIPTION
This PR fixes version.py (and FastSurferCNN.version.main()) not returning, if there are no checkpoints in the checkpoints folder.

This may happen for native installations, if the checkpoints have not manually been downloaded. The cause was that md5sum was called with no arguments, which expects the file/data to be passed from STDIN, which may not be connected, thus blocking further execution.

This PR is related to #699 and #774.