### PR TITLE
Change and harmonize 0 or 1 as boolean values to "true"/"false" in bash scripts

### DIFF
--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -418,8 +418,8 @@ function run_single()
   # |
   # *: POSITIONAL_FASTSURFER
 
-  local subject_id="<undefined>" mode="" args=() do_seg=1 do_surf=1 skip=0 parallel cmd status=unknown statustext
-  local debug="$2" statusfile="$3" parallel_pipelines="$4" num_parallel_seg="$5" num_parallel_surf="$6"
+  local subject_id="<undefined>" mode="" args=() do_seg="true" do_surf="true" skip="false" parallel cmd status=unknown
+  local debug="$2" statusfile="$3" parallel_pipelines="$4" num_parallel_seg="$5" num_parallel_surf="$6" statustext
   local run_fastsurfer=() POSITIONAL_FASTSURFER=()
   local position=0 arg image_path="<undefined>" returncode=0
   local regex="\(\(\\\\.\|[^'\"[:space:]\\\\]\+\|'\([^']*\|''\)*'\|\"\([^\"\\\\]\+\|\\\\.\)*\"\)\+\).*"
@@ -440,7 +440,7 @@ function run_single()
       echo "ERROR: Could not parse the line ${image_parameters:$position}, maybe incorrect quoting or escaping?"
       exit 1
     else
-      # arg parsed
+      # arg parsed, position is an integer
       if [[ "$position" == "0" ]]; then image_path=$arg ; else args+=("$arg") ; fi
       position=$((position + ${#arg}))
     fi
@@ -454,16 +454,18 @@ function run_single()
       exit 1
     fi
   done
+  # check if --seg_only or --surf_only are in the general or the subject-specific arguments, set mode, do_seg and
+  # do_surf accordingly
   for i in "${POSITIONAL_FASTSURFER[@]}" "${args[@]}"; do
-    if [[ "$i" == "--seg_only" ]] ; then mode="$i" ; do_surf=0
-    elif [[ "$i" == "--surf_only" ]] ; then mode="$i" ; do_seg=0
+    if [[ "$i" == "--seg_only" ]] ; then mode="$i" ; do_surf="false"
+    elif [[ "$i" == "--surf_only" ]] ; then mode="$i" ; do_seg="false"
     fi
   done
-  if [[ "$do_seg" == 0 ]] && [[ "$do_surf" == 0 ]]
+  if [[ "$do_seg" == "false" ]] && [[ "$do_surf" == "false" ]]
   then
     echo "INFO: Skipping subject_id $subject_id (deselected)"
     skip=1
-  elif [[ -n "$statusfile" ]] && [[ "$do_surf" == 1 ]] && [[ "$do_seg" == 0 ]]
+  elif [[ -n "$statusfile" ]] && [[ "$do_surf" == "true" ]] && [[ "$do_seg" == "false" ]]
   then
     ## if status in statusfile is "Failed" last, skip this
     prev_ifs="$IFS" ; IFS=''
@@ -472,9 +474,9 @@ function run_single()
       subject="$(echo "$line" | cut -d" " -f1)"
       if [[ "$subject" == "$subject_id:" ]] ; then
         statustext="${line:$((${#subject} + 1))}"
-        if [[ "${statustext}" =~ ^Failed[[:space:]](--seg_only|seg|both) ]] ; then status=failed
+        if [[ "${statustext}" =~ ^Failed[[:space:]](--seg_only|seg|both) ]] ; then status="failed"
         elif [[ "${statustext}" =~ ^Finished[[:space:]](--seg_only|seg|both)[[:space:]]success ]] ; then
-          status=success
+          status="success"
         fi
       fi
       IFS=""
@@ -484,30 +486,33 @@ function run_single()
     then
       echo "INFO: Skipping $subject_id's surface recon because the segmentation failed."
       echo "$subject_id: Skipping surface recon (failed segmentation)" >> "$statusfile"
-      skip=1
+      skip="true"
     fi
   fi
   # if we are not skipping this, process
-  if [[ "$skip" == 0 ]]
+  if [[ "$skip" == "false" ]]
   then
     cmd=("${run_fastsurfer[@]}" --t1 "$image_path" "${POSITIONAL_FASTSURFER[@]}" "${args[@]}")
     if [[ "$debug" == "true" ]] ; then echo "DEBUG:" "${cmd[@]}" ; fi
-    # multiple subjects in parallel is possible, then parallel = 1, else parallel = 0
+    # multiple subjects in parallel is possible, then parallel = "true", else parallel = "false"
     if [[ "$num_parallel_seg" == "max" ]] || [[ "$parallel_pipelines" == 2 ]] && [[ "$num_parallel_surf" == "max" ]]
-    then parallel=1 # one of "running pipeline" is max
-    else parallel=$([[ $((num_parallel_seg + (parallel_pipelines - 1) * num_parallel_surf)) == 2 ]] && echo 0 || echo 1)
+    then parallel="true" # one of "running pipeline" is max
+    else parallel=$([[ $((num_parallel_seg + (parallel_pipelines - 1) * num_parallel_surf)) == 2 ]] && echo "false" || echo "true")
     fi
-    if [[ "$parallel" == 1 ]] ; then "${cmd[@]}" | prepend "$subject_id: " ; else "${cmd[@]}" ; fi
+    if [[ "$parallel" == "true" ]] ; then "${cmd[@]}" | prepend "$subject_id: " ; else "${cmd[@]}" ; fi
     returncode="${PIPESTATUS[0]}"
     if [[ -n "$statusfile" ]] ; then print_status "$subject_id" "$mode" "$returncode" >> "$statusfile"; fi
     if [[ "$returncode" != 0 ]]; then echo "WARNING: $subject_id finished with exit code $returncode!" ; fi
   fi
+  # print the #@#!NEXT-SUBJECT token for the processing loop to trigger the next subject's processing
+  # also include subject_id and image_parameters for debugging and verbosity
   echo "#@#!NEXT-SUBJECT:$subject_id=$image_parameters"
 }
 
+# this function returns an integer, with 1 meaning "is not a numbered device" (to be used in if statements)
 function is_numbered_device() { if [[ "$1" =~ ^auto|cpu|mps|cuda$ ]] ; then return 1 ; else return 0 ; fi }
 
-# this is a handler to convert the device name to a number
+# this is a handler to convert the device name to a number, effectively only removing the "cuda:" prefix
 function device2number() { echo "${1:5}" ; }
 
 timeout_read_token=5
@@ -526,9 +531,10 @@ function process_by_token()
   # |
   # *: POSITIONAL_FASTSURFER
 
-  local subject_id max_processes subject_buffer=() read_in=1 returncode spawn_task=1 mode="$1" line device_ready=0
+  local subject_id max_processes subject_buffer=() read_in="true" returncode spawn_task="true" mode="$1" line
   local timeout_read_token="$2" debug="$3" statusfile="$4" parallel_pipelines="$5" num_parallel_seg="$6" this_args=()
-  local num_parallel_surf="$7" device=() vdevice=() regx="^cuda:[0-9]+," parallel_warn=0 res_args=() prev_ifs="$IFS"
+  local num_parallel_surf="$7" device=() vdevice=() regx="^cuda:[0-9]+," parallel_warn="false" res_args=()
+  local device_ready=0 prev_ifs="$IFS"
   IFS=","
   if [[ "$8" =~ $regx ]] ; then for e in ${8:5} ; do device+=("${8:0:5}$e") ; done ; else device=("$8") ; fi
   if [[ "$9" =~ $regx ]] ; then for e in ${9:5} ; do vdevice+=("${9:0:5}$e") ; done ; else vdevice=("$9") ; fi
@@ -538,16 +544,29 @@ function process_by_token()
   local run_single_args=("$debug" "$statusfile" "$parallel_pipelines" "$num_parallel_seg" "$num_parallel_surf" "$@")
 
   if [[ "$mode" == "surf" ]] ; then max_processes="$num_parallel_surf" ; else max_processes="$num_parallel_seg" ; fi
-  while [[ "$read_in" == 1 ]] || [[ "${#subject_buffer[@]}" -gt 0 ]]
+  while [[ "$read_in" == "true" ]] || [[ "${#subject_buffer[@]}" -gt 0 ]]
   do
+    # this loop performs three tasks/main steps as long as i. we are still reading input (read_in) or ii. have subjects
+    # in the buffer:
+    # 1. read input and add to subject_buffer,
+    # 2. check if we are at the process limit (if we want to process the next case),
+    # 3. process the next case from the buffer.
+
     # initialize res_args
     res_args=()
-    if [[ "$read_in" == 1 ]]
+    # 1. read input and add to subject_buffer
+    #    we read from stdin (piping in input from iterate_subjects_with_token) or other process_by_token processes,
+    #    if the input "sends" EOF, we stop reading (read_in="false"),
+    #    if the input line starts with the token "#@#!NEXT-SUBJECT:", we extract the case data, which follows after the
+    #    token, and add it to the subject_buffer -- the queue of cases waiting to be processed.
+    #    if the line does not start with the token, we print it directly to stdout, making sure the output of a "parent"
+    #    process_by_token gets forwarded to the console output for debugging and logging purposes.
+    if [[ "$read_in" == "true" ]]
     then
       IFS=""
       read -r -t "$timeout_read_token" line
       returncode="$?"
-      if [[ "$returncode" == 1 ]] ; then read_in=0 # EOF, terminate looking at for input
+      if [[ "$returncode" == 1 ]] ; then read_in="false" # EOF, terminate looking at for input
       elif [[ "$returncode" == 0 ]] ; then # successfully read a line
         if [[ "${line:0:17}" == "#@#!NEXT-SUBJECT:" ]] ; then
           if [[ "$debug" == "true" ]] ; then echo "DEBUG: $mode-subject ${line:17}" ; fi
@@ -558,44 +577,74 @@ function process_by_token()
       fi
     fi
 
+    # 2. check if we are at the process limit (if we want to process the next case)
+    #    check the number of child processes with jobs -pr,
+    #    if the child process count is below the limit (max_processes), we want to spawn a new process, i.e. set
+    #    spawn_task="true"
+    #    if the child process count is at the limit and we are still reading input (read_in="true"), we do not spawn a
+    #    new process, i.e. set spawn_task="false", but return to step 1: keep reading the input.
+    #    if the child process count is at the limit, but we are no longer reading the input (read_in="false"), we first
+    #    want to wait for a currently running child process to finish and then spawn the next process.
     # check job count
-    if [[ "$max_processes" == "max" ]] ; then spawn_task=1
+    if [[ "$max_processes" == "max" ]] ; then spawn_task="true"
     else
       fail_bash_version_lt4
       mapfile -t running_jobs < <(jobs -pr)
-      if [[ "${#running_jobs[@]}" -lt "$max_processes" ]] ; then spawn_task=1
-      elif [[ "$read_in" == 0 ]] ; then wait "${running_jobs[@]}" # wait for any task to finish (std is already closed)
-      else spawn_task=0
+      if [[ "${#running_jobs[@]}" -lt "$max_processes" ]] ; then spawn_task="true"
+      elif [[ "$read_in" == "false" ]] ; then wait "${running_jobs[@]}" # wait for any task to finish (stdin is closed)
+      else spawn_task="false"
       fi
     fi
 
-    # if can spawn and has job in queue, start a job
-    if [[ "$spawn_task" == 1 ]] && [[ "${#subject_buffer[@]}" -gt 0 ]]
+    # 3. process the next case from the buffer
+    #    if we want to spawn a new process (spawn_task="true") and we have cases in the subject_buffer, we need to
+    #    find an available device (if we have multiple devices) and then spawn a new process for the next case in the
+    #    buffer with the appropriate device assignment. So Substep 3.1 is to find an available device and substep 3.2 is
+    #    to spawn the next process with the appropriate device assignment.
+    if [[ "$spawn_task" == "true" ]] && [[ "${#subject_buffer[@]}" -gt 0 ]]
     then
+      # Substep 3.1: find an available device (if we have multiple devices)
+      # if mode is surf, we do not need to check for device availability, surface processing is only CPU-based.
+      # if mode is seg, need to find an available device for both per-view inference and the view aggregation
+      #   in both cases, have the list of available devices in the device and vdevice arrays, and we keep track of the
+      #   device assignments to child processes in the used_device and used_vdevice arrays. If the child process exists,
+      #   the device is still in use. If the child process does not exist, the device is available, and we remove the
+      #   assignment.
       if [[ "$mode" == "surf" ]] ; then device_ready=2 ; dev="cpu" ; vdev="cpu"
       else
         device_ready=0
+        # Substep 3.1a: Find a device for per-view inference, if device are available, we increase device_ready by 1.
         if [[ "${#device[@]}" -gt 1 ]] ; then
           # go through device assignments, if the processes finished, release the device assignment
           for name in "${device[@]}" ; do
             i="$(device2number "$name")"
             if [[ -z "${used_device[i]}" ]] || [[ -z "$(ps --no-headers "${used_device[i]}")" ]] ; then
-              res_args+=("--device" "$name") ; used_device[i]=""; device_ready=$((device_ready + 1)) ; dev="$name" ; break
+              res_args+=("--device" "$name")
+              used_device[i]=""
+              device_ready=$((device_ready + 1))
+              dev="$name"
+              break
             fi
           done
         else device_ready=$((device_ready + 1)) ; res_args+=("--device" "${device[0]}") ; dev="${device[0]}"
         fi
+        # Substep 3.1b: Find a device for view aggregation, if device are available, we increase device_ready by 1.
         if [[ "${#vdevice[@]}" -gt 1 ]] ; then
           # go through viewagg device assignments, if the processes finished, release the device assignment
           for name in "${vdevice[@]}" ; do
             i="$(device2number "$name")"
             if [[ -z "${used_vdevice[i]}" ]] || [[ -z "$(ps --no-headers "${used_vdevice[i]}")" ]] ; then
-              res_args+=("--viewagg_device" "$name") ; used_vdevice[i]="" ; device_ready=$((device_ready + 1)) ; vdev="$name" ; break
+              res_args+=("--viewagg_device" "$name")
+              used_vdevice[i]=""
+              device_ready=$((device_ready + 1))
+              vdev="$name"
+              break
             fi
           done
         else device_ready=$((device_ready + 1)) ; res_args+=("--viewagg_device" "${vdevice[0]}") ; vdev="${vdevice[0]}"
         fi
       fi
+      # at this point, device_ready is greater than 1, we have sufficient resources to start the next process.
       if [[ "$device_ready" -gt 1 ]]
       then
         subject_id=$(echo "${subject_buffer[0]}" | cut -d= -f1)
@@ -608,24 +657,26 @@ function process_by_token()
         else run_single "${subject_buffer[0]}" "${this_args[@]}" &
         fi
         pid=$!
-        # if dev or vdev is a numbered device, add it to the used devices list (multiple devices)
+        # if dev or vdev is a numbered device, add the child process id to the used devices list (multiple devices)
         if is_numbered_device "$dev" ; then i=$(device2number "$dev") ; used_device[i]="$pid" ; fi
         if is_numbered_device "$vdev" ; then i=$(device2number "$vdev") ; used_vdevice[i]="$pid" ; fi
+        # remove the first item from the subject_buffer
         subject_buffer=("${subject_buffer[@]:1}")
       else
-        if [[ $parallel_warn == 1 ]] ; then
+        # we have not reached the process limit, but could not find available devices...
+        if [[ $parallel_warn == "true" ]] ; then
           echo "WARNING: All devices are in use for parallel seg processing!"
         else
-          echo "WARNING: All devices are in use, make sure you are trying to use more parallel seg processes than"
+          echo "WARNING: All devices are in use, make sure you are not trying to use more parallel seg processes than"
           echo "  you have devices passed in --device AND --viewagg_device., e.g. '--device cuda:0,1 --viewagg_device"
           echo "  cpu --parallel_seg 2' is fine, but '--device cuda:0,1 --parallel_seg 3' or"
           echo "  '--viewagg_device cuda:0,1 --parallel_seg 3' will cause issues."
-          parallel_warn=1
+          parallel_warn="true"
         fi
         # wait for a device to become available
         sleep 5
       fi
-    fi
+    fi # if can spawn and has job in queue
   done
   if [[ "$(bash --version | head -n 1)" =~ [vV]ersion[[:space:]][4-9] ]] ; then mapfile -t running_jobs < <(jobs -pr)
   else running_jobs=()
@@ -645,6 +696,7 @@ function process_by_token()
 
 function filter_token()
 {
+  # just remove the lines with the #@#!NEXT-SUBJECT: token from the output.
   IFS=""
   while read -r line ; do if [[ "${line:0:17}" != "#@#!NEXT-SUBJECT:" ]] ; then echo "$line" ; fi ; done
 }

--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -464,7 +464,7 @@ function run_single()
   if [[ "$do_seg" == "false" ]] && [[ "$do_surf" == "false" ]]
   then
     echo "INFO: Skipping subject_id $subject_id (deselected)"
-    skip=1
+    skip="true"
   elif [[ -n "$statusfile" ]] && [[ "$do_surf" == "true" ]] && [[ "$do_seg" == "false" ]]
   then
     ## if status in statusfile is "Failed" last, skip this
@@ -495,7 +495,8 @@ function run_single()
     cmd=("${run_fastsurfer[@]}" --t1 "$image_path" "${POSITIONAL_FASTSURFER[@]}" "${args[@]}")
     if [[ "$debug" == "true" ]] ; then echo "DEBUG:" "${cmd[@]}" ; fi
     # multiple subjects in parallel is possible, then parallel = "true", else parallel = "false"
-    if [[ "$num_parallel_seg" == "max" ]] || [[ "$parallel_pipelines" == 2 ]] && [[ "$num_parallel_surf" == "max" ]]
+    if [[ "$num_parallel_seg" == "max" ]] || \
+       { [[ "$parallel_pipelines" == 2 ]] && [[ "$num_parallel_surf" == "max" ]] ; }
     then parallel="true" # one of "running pipeline" is max
     else parallel=$([[ $((num_parallel_seg + (parallel_pipelines - 1) * num_parallel_surf)) == 2 ]] && echo "false" || echo "true")
     fi

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -22,9 +22,9 @@ t1=""                 # Path and name of T1 input
 asegdkt_segfile=""    # Path and name of segmentation
 mask=""               # Path and name of the brainmask (defaults to $SUBJECTS_DIR/$SID/mri/mask.mgz)
 subject=""            # Subject name
-fstess="false"        # run mri_tesselate (FS way), if true = run mri_mc
-fsqsphere="false"     # run inflate1 and qsphere (FSway), if false run spectral projection
-fsaparc="false"       # run FS aparc (and cortical ribbon), if false map aparc from asegdkt_segfile
+fstess="false"        # if true: use FreeSurfer tessellation (mri_tesselate); if false: use mri_mc tessellation
+fsqsphere="false"     # if true: run FreeSurfer inflate1 + qsphere; if false: run FastSurfer spectral surface projection
+fsaparc="false"       # if true: run FreeSurfer aparc (and cortical ribbon); if false: map aparc from asegdkt_segfile
 fssurfreg="true"      # run FS surface registration to fsaverage, if false omit this step
 python="python3 -s"   # python version
 ParallelFlag="false"  # "true", if --parallel passed

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -22,25 +22,24 @@ t1=""                 # Path and name of T1 input
 asegdkt_segfile=""    # Path and name of segmentation
 mask=""               # Path and name of the brainmask (defaults to $SUBJECTS_DIR/$SID/mri/mask.mgz)
 subject=""            # Subject name
-fstess=0              # run mri_tesselate (FS way), if 0 = run mri_mc
-fsqsphere=0           # run inflate1 and qsphere (FSway), if 0 run spectral projection
-fsaparc=0             # run FS aparc (and cortical ribbon), if 0 map aparc from asegdkt_segfile
-fssurfreg=1           # run FS surface registration to fsaverage, if 0 omit this step
+fstess="false"        # run mri_tesselate (FS way), if true = run mri_mc
+fsqsphere="false"     # run inflate1 and qsphere (FSway), if false run spectral projection
+fsaparc="false"       # run FS aparc (and cortical ribbon), if false map aparc from asegdkt_segfile
+fssurfreg="true"      # run FS surface registration to fsaverage, if false omit this step
 python="python3 -s"   # python version
-DoParallel=0          # if 1, run hemispheres in parallel
-DoParallelFlag=0      # 1, if --parallel passed
+ParallelFlag="false"  # "true", if --parallel passed
 threads="1"           # number of threads to use for running FastSurfer
 edits="false"         # flag for inclusion/exclusion of edits
                       #   (also ability to run on top of existing recon-surf.sh output)
 atlas3T="false"       # flag to use/do not use the 3t atlas for talairach registration/etiv
 segstats_legacy="false" # flag to enable segstats legacy mode
-base=0                # flag for longitudinal template (base) run
-long=0                # flag for longitudinal time point run
-baseid=""             # baseid for logitudinal time point run
+base="false"          # flag for longitudinal template (base) run
+long="false"          # flag for longitudinal time point run
+baseid=""             # baseid for longitudinal time point run
 
 # Dev flags default
-check_version=1       # Check for supported FreeSurfer version (terminate if not detected)
-get_t1=1              # Generate T1.mgz from nu.mgz and brainmask from it (default)
+check_version="true"  # Check for supported FreeSurfer version (terminate if not detected)
+get_t1="true"         # Generate T1.mgz from nu.mgz and brainmask from it (default)
 hires_voxsize_threshold=0.999  # Threshold below which the hires options are passed
 
 if [[ -z "$FASTSURFER_HOME" ]]
@@ -186,12 +185,12 @@ case $key in
     ;;
   --edits) edits="true" ;;
   --segstats_legacy) segstats_legacy="true" ;;
-  --fstess) fstess=1 ;;
-  --fsqsphere) fsqsphere=1 ;;
-  --fsaparc) fsaparc=1 ;;
-  --no_surfreg) fssurfreg=0 ;;
+  --fstess) fstess="true" ;;
+  --fsqsphere) fsqsphere="true" ;;
+  --fsaparc) fsaparc="true" ;;
+  --no_surfreg) fssurfreg="false" ;;
   --3t) atlas3T="true" ;;
-  --parallel) DoParallelFlag=1 ; echo "WARNING: The --parallel flag is obsolete and will be removed in FastSurfer 3!" ;;
+  --parallel) ParallelFlag="true" ; echo "WARNING: The --parallel flag is obsolete and will be removed in FastSurfer 3!" ;;
   --threads) threads="$1" ; shift ;;
   --py) python="$1" ; shift ;;
   --fs_license)
@@ -204,10 +203,10 @@ case $key in
     fi
     shift # past value
     ;;
-  --ignore_fs_version) check_version=0 ;;
-  --no_fs_t1 ) get_t1=0 ;;
-  --base) base=1 ;;
-  --long) long=1 ; baseid="$1" ; shift ;;
+  --ignore_fs_version) check_version="false" ;;
+  --no_fs_t1 ) get_t1="false" ;;
+  --base) base="true" ;;
+  --long) long="true" ; baseid="$1" ; shift ;;
   -h|--help) usage ; exit ;;
   # unknown option
   *) echo "ERROR: Flag $key unrecognized." ; exit 1 ;;
@@ -241,7 +240,7 @@ fi
 # needed in FS72 due to a bug in recon-all --fill using FREESURFER instead of FREESURFER_HOME
 export FREESURFER=$FREESURFER_HOME   
 
-if [[ "$check_version" == "1" ]] && grep -q -v "${FS_VERSION_SUPPORT}" "$FREESURFER_HOME/build-stamp.txt"
+if [[ "$check_version" == "true" ]] && grep -q -v "${FS_VERSION_SUPPORT}" "$FREESURFER_HOME/build-stamp.txt"
 then
   echo "ERROR: You are trying to run recon-surf with FreeSurfer version $(cat "$FREESURFER_HOME/build-stamp.txt")."
   echo "  We are currently supporting only FreeSurfer $FS_VERSION_SUPPORT."
@@ -254,14 +253,14 @@ fi
 
 if [[ -z "$PYTHONUNBUFFERED" ]] ; then export PYTHONUNBUFFERED=0 ; fi
 
-if [[ "$long" == "1" ]] && [[ "$base" == "1" ]]
+if [[ "$long" == "true" ]] && [[ "$base" == "true" ]]
 then
   echo "ERROR: You specified both --long and --base. You need to setup and then run base template first,"
   echo "before you can run any longitudinal time points."
   exit 1
 fi
 
-if [[ "$base" == "1" ]] && [[ ! -f "$SUBJECTS_DIR/$subject/base-tps.fastsurfer" ]]
+if [[ "$base" == "true" ]] && [[ ! -f "$SUBJECTS_DIR/$subject/base-tps.fastsurfer" ]]
 then
   echo "ERROR: $subject is either not found in SUBJECTS_DIR"
   echo "or it is not a longitudinal template directory (base),"
@@ -271,7 +270,7 @@ then
 fi
 
 basedir=""
-if [[ "$long" == "1" ]]
+if [[ "$long" == "true" ]]
 then
   basedir="$SUBJECTS_DIR/$baseid"
   if [[ ! -f "$basedir/base-tps.fastsurfer" ]] ; then
@@ -317,9 +316,9 @@ then
   exit 1
 fi
 
-if [[ "$DoParallelFlag" == 1 ]] ; then threads_hemi=$threads ; DoParallel=1
-elif [[ "$threads" -gt 1 ]]; then DoParallel=1 ; threads_hemi=$((threads / 2))
-else DoParallel=0 ; threads_hemi="$threads"
+if [[ "$ParallelFlag" == "true" ]] ; then ParallelHemi="true" ; threads_hemi=$threads
+elif [[ "$threads" -gt 1 ]]; then ParallelHemi="true" ; threads_hemi=$((threads / 2))
+else ParallelHemi="false" ; threads_hemi="$threads"
 fi
 
 # set threads for openMP and itk
@@ -329,7 +328,7 @@ export OMP_NUM_THREADS=$threads
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=$threads
 
 # define the fsthreads variable for the joint section
-if [[ "$threads" -gt "1" ]] ; then fsthreads="-threads $threads -itkthreads $threads" ; else fsthreads="" ; fi
+if [[ "$threads" -gt 1 ]] ; then fsthreads="-threads $threads -itkthreads $threads" ; else fsthreads="" ; fi
 
 if [[ "$(echo -n "${SUBJECTS_DIR}/${subject}" | wc -m)" -gt 185 ]]
 then
@@ -398,16 +397,16 @@ echo "Log file for recon-surf.sh" >> "$LF"
     echo "Running on top of an existing subject directory with edits=$edits!"
   fi
   echo " "
-  if [[ "$base" == "1" ]] ; then
+  if [[ "$base" == "true" ]] ; then
     echo "================== BASE - Longitudinal Template Creation ========================="
     echo " "
-  elif [[ "$long" == "1" ]] ; then
+  elif [[ "$long" == "true" ]] ; then
     echo "================== LONG - Longitudinal Timpe Point Creation ======================"
     echo "long: using template directory (base) $baseid"
     echo " "
   fi
   # Print parallelization parameters
-  if [[ "$DoParallel" == "1" ]]
+  if [[ "$ParallelHemi" == "true" ]]
   then
     echo " RUNNING both hemis in PARALLEL"
   else
@@ -484,7 +483,7 @@ popd > /dev/null || ( echo "Could not change to subject_dir" ; exit 1 )
 
 # ============================= MASK & ASEG_noCC ========================================
 
-if [[ "$long" == "1" ]] ; then
+if [[ "$long" == "true" ]] ; then
   # for long we copy mask from base
   cmda=(cp "$basedir/mri/mask.mgz" "$mask")
   run_it "$LF" "${cmda[@]}"
@@ -508,11 +507,11 @@ if [[ ! -f "$mask" ]] || [[ ! -f "$mdir/$aseg_nocc" ]] ; then
   cmda=($python "$FASTSURFER_HOME/FastSurferCNN/reduce_to_aseg.py" -i "$mdir/aparc.DKTatlas+aseg.orig.mgz"
         -o "$mdir/$aseg_nocc" --fixwm)
 
-  if [[ "$base" == "1" ]] && [[ ! -f "$mask" ]] ; then
+  if [[ "$base" == "true" ]] && [[ ! -f "$mask" ]] ; then
     # for base we build union of mapped masks beforehand so it should be available
     echo "ERROR: $mask missing, but base run requires $mask!" | tee -a "$LF"
     exit 1
-  elif [[ "$long" != "1" ]] && [[ "$base" != 1 ]] ; then
+  elif [[ "$long" != "true" ]] && [[ "$base" != "true" ]] ; then
     # cross-sectional processing, add outmask to cmd (not for or base long stream)
     cmda+=(--outmask "$mask")
   fi
@@ -563,8 +562,8 @@ if [[ ! -f "$mdir/transforms/talairach.lta" ]] || [[ ! -f "$mdir/transforms/tala
   # all transforms (also ltas) are the same
   cmda=("$binpath/talairach-reg.sh" "$LF"
         --dir "$mdir" --conformed_name "$mdir/orig.mgz" --norm_name "$mdir/orig_nu.mgz")
-  if [[ "$long" == "1" ]] ; then cmda+=(--long "$basedir") ; fi
-  if [[ "$edits" == "1" ]] ; then cmda+=(--edits) ; fi
+  if [[ "$long" == "true" ]] ; then cmda+=(--long "$basedir") ; fi
+  if [[ "$edits" == "true" ]] ; then cmda+=(--edits) ; fi
   if [[ "$atlas3T" == "true" ]] ; then cmda+=(--3T) ; fi
 
   {
@@ -588,7 +587,7 @@ fi
 # create norm by masking nu (supports manedit-ed mask)
 cmda=(mri_mask "$mdir/nu.mgz" "$mask" "$mdir/norm.mgz")
 run_it "$LF" "${cmda[@]}"
-if [[ "$get_t1" == "1" ]]
+if [[ "$get_t1" == "true" ]]
 then
   # create T1.mgz from nu (!! here we could also try passing aseg?)
   # T1.mgz was needed by some 3rd party downstream tools such as fmriprep, so we provide it
@@ -599,7 +598,7 @@ then
   # it is unclear what effect it would even have, given that segmentations come
   # from the FastSurferVINN. It could affect surface placement or partial volumes.
   #base_flags=""
-  #if [ "$base" == "1" ]
+  #if [ "$base" == "true" ]
   #then
   #  base_flags="-w $mdir/ctrl_vol.mgz $mdir/bias_vol.mgz"
   #fi
@@ -625,8 +624,8 @@ callosum_seg="callosum_seg_aseg_space.mgz"
 callosum_seg_manedit="$(add_file_suffix "$callosum_seg" "manedit")"
 aseg_auto="aseg.auto.mgz"
 CorpusCallosumDir="$FASTSURFER_HOME/CorpusCallosum"
-updated_cc_seg=0
-if [[ ! -e "$mdir/$aseg_auto" ]] || [[ ! -e "$mdir/$callosum_seg" ]] || [[ "$edits" == 1 ]]
+updated_cc_seg="false"
+if [[ ! -e "$mdir/$aseg_auto" ]] || [[ ! -e "$mdir/$callosum_seg" ]] || [[ "$edits" == "true" ]]
 then
   {
     echo " "
@@ -636,14 +635,14 @@ then
 fi
 # here, in edits mode we also check, if the corpus callosum should be updated based on an updated aseg.nocc
 if [[ ! -e "$mdir/$callosum_seg" ]] || \
-  { [[ "$edits" == 1 ]] && [[ "$(date -r "$mdir/$aseg_nocc" "+%s")" -gt "$(date -r "$mdir/$callosum_seg" "+%s")" ]] ; }
+  { [[ "$edits" == "true" ]] && [[ "$(date -r "$mdir/$aseg_nocc" "+%s")" -gt "$(date -r "$mdir/$callosum_seg" "+%s")" ]] ; }
 then
   {
     echo "Segmenting the corpus callosum, so mri/$aseg_nocc exists. If you are interested in detailed"
     echo "  and extended analysis and statistics of the Corpus Callosum, use the corpus callosum pipeline"
     echo "  of the segmentation pipeline (in run_fastsurfer.sh, i.e. run without --no_cc)."
   }
-  updated_cc_seg=1
+  updated_cc_seg="true"
   # create aseg.auto including corpus callosum segmentation and 46 sec, requires norm.mgz
   # Note: if original input segmentation already contains CC, this will exit with ERROR
   # in the future maybe check and skip this step (and next)
@@ -657,9 +656,9 @@ then
   run_it "$LF" "${cmda[@]}"
 fi
 # do not move below statement up, fastsurfer_cc.py uses the $callosum_seg variable
-if [[ "$edits" == 1 ]] && [[ -e "$mdir/$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
+if [[ "$edits" == "true" ]] && [[ -e "$mdir/$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
 cmd_paint_cc_into_pred=($python "$CorpusCallosumDir/paint_cc_into_pred.py" -in_cc "$mdir/$callosum_seg" -in_pred)
-if [[ ! -e "$mdir/$aseg_auto" ]] || [[ "$updated_cc_seg" == 1 ]]
+if [[ ! -e "$mdir/$aseg_auto" ]] || [[ "$updated_cc_seg" == "true" ]]
 then
   # add CC into aseg.auto.mgz as mri_cc did before. Not sure where this is used.
   cmda=("${cmd_paint_cc_into_pred[@]}" "$mdir/$aseg_nocc" "-out" "$mdir/$aseg_auto")
@@ -673,7 +672,7 @@ fi
   echo " "
 } | tee -a "$LF"
 
-if [[ "$long" == "1" ]] ; then
+if [[ "$long" == "true" ]] ; then
   # in long we can skip fill as surfaces come from base
   # it would be great to also skip WM, but it is needed in place_surface to clip bright
   # maybe later add code to copy edits from base in maskbfs and wm segmentation, currently not supported!
@@ -700,7 +699,7 @@ export OMP_NUM_THREADS=$threads_hemi
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=$threads_hemi
 
 # define the fsthreads variable for the joint section
-if [[ "$threads_hemi" -gt "1" ]] ; then fsthreads="-threads $threads_hemi -itkthreads $threads_hemi"
+if [[ "$threads_hemi" -gt 1 ]] ; then fsthreads="-threads $threads_hemi -itkthreads $threads_hemi"
 else fsthreads=""
 fi
 
@@ -720,7 +719,7 @@ for hemi in lh rh ; do
 # ============================= TESSELLATE - SMOOTH =====================================================
 
   # In Long stream we skip these
-  if [[ "$long" == "0" ]]
+  if [[ "$long" == "false" ]]
   then
 
     {
@@ -729,7 +728,7 @@ for hemi in lh rh ; do
       echo "echo \" \""
     } | tee -a "$CMDF"
 
-    if [[ "$fstess" == "1" ]]
+    if [[ "$fstess" == "true" ]]
     then
       cmd="recon-all -subject $subject -hemi $hemi -tessellate -smooth1 -no-isrunning -umask $(umask) $hiresflag $fsthreads"
       RunIt "$cmd" "$LF" "$CMDF"
@@ -793,7 +792,7 @@ for hemi in lh rh ; do
 # ============================= INFLATE1 - QSPHERE =====================================================
 
   # In Long stream we skip these
-  if [[ "$long" == "0" ]]
+  if [[ "$long" == "false" ]]
   then
 
     {
@@ -806,7 +805,7 @@ for hemi in lh rh ; do
     cmd="recon-all -subject $subject -hemi $hemi -inflate1 -no-isrunning -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF" "$CMDF"
 
-    if [ "$fsqsphere" == "1" ]
+    if [ "$fsqsphere" == "true" ]
     then
       # quick spherical mapping (2min48sec)
       cmd="recon-all -subject $subject -hemi $hemi -qsphere -no-isrunning -umask $(umask) $hiresflag $fsthreads"
@@ -822,7 +821,7 @@ for hemi in lh rh ; do
 # ============================= FIX - WHITEPREAPARC ==================================================
 
   # In Long stream we skip topo fix
-  if [ "$long" == "0" ]
+  if [ "$long" == "false" ]
   then
     # longitudinal base and cross-sectional
 
@@ -899,7 +898,7 @@ for hemi in lh rh ; do
 # ============================= SPHERE - SURFREG (optional) ==============================================
 
   # if we segment with FS or if surface registration is requested do it here:
-  if [[ "$fsaparc" == "1" ]] || [[ "$fssurfreg" == "1" ]]
+  if [[ "$fsaparc" == "true" ]] || [[ "$fssurfreg" == "true" ]]
   then
     {
       echo "echo \" \""
@@ -907,7 +906,7 @@ for hemi in lh rh ; do
       echo "echo \" \""
     } | tee -a "$CMDF"
 
-    if [[ "$long" == "0" ]]
+    if [[ "$long" == "false" ]]
     then
 
       # SPHERE: Inflate to sphere with minimal metric distortion
@@ -976,8 +975,8 @@ for hemi in lh rh ; do
   # aparc only takes 20 seconds, and is created when -fsaparc is passed
   # it is then used also below for surface placement.
   # we should consider, always computing it (when surfreg is available) -> test later what consequences this has
-  #if [ "$fsaparc" == "1" ] || [ "$fssurfreg" == "1" ] ; then
-  if [[ "$fsaparc" == "1" ]]
+  #if [ "$fsaparc" == "true" ] || [ "$fssurfreg" == "true" ] ; then
+  if [[ "$fsaparc" == "true" ]]
   then
     {
       echo "echo \" \""
@@ -986,7 +985,7 @@ for hemi in lh rh ; do
     } | tee -a "$CMDF"
 
     longflag=""
-    if [[ "$long" == "1" ]]
+    if [[ "$long" == "true" ]]
     then
       # recon-all has different treatment for cortparc:
       # initialize with aparc.annot from base
@@ -1004,7 +1003,7 @@ for hemi in lh rh ; do
 
   # first select what cortical parcellation to use to guide surface placement:
   aparc=""
-  if [[ "$fsaparc" == "1" ]]
+  if [[ "$fsaparc" == "true" ]]
   then
     {
       echo "echo \" \""
@@ -1033,7 +1032,7 @@ for hemi in lh rh ; do
     --threads $threads_hemi --wm wm.mgz --invol brain.finalsurfs.mgz --$hemi --o ../surf/${hemi}.white \
     --white --nsmooth 0 --rip-label ../label/${hemi}.cortex.label \
     --rip-bg --rip-surf ../surf/${hemi}.white.preaparc --aparc $aparc"
-  if [[ "$long" == "0" ]] ; then cmd="$cmd --i ../surf/$hemi.white.preaparc" # cross/regular/base
+  if [[ "$long" == "false" ]] ; then cmd="$cmd --i ../surf/$hemi.white.preaparc" # cross/regular/base
   else cmd="$cmd --i ../surf/$hemi.orig_white --max-cbv-dist 3.5" # longitudinal processing ; also adds longmaxdist
   fi
   RunIt "$cmd" "$LF" "$CMDF"
@@ -1045,7 +1044,7 @@ for hemi in lh rh ; do
     --pial --nsmooth 0 --rip-label ../label/${hemi}.cortex+hipamyg.label \
     --pin-medial-wall ../label/${hemi}.cortex.label --aparc $aparc \
     --repulse-surf ../surf/${hemi}.white --white-surf ../surf/${hemi}.white"
-  if [ "$long" == "0" ] ; then cmd="$cmd --i ../surf/$hemi.white" # cross/regular/base
+  if [ "$long" == "false" ] ; then cmd="$cmd --i ../surf/$hemi.white" # cross/regular/base
   else  # longitudinal processing ; also adds longmaxdist
     cmd="$cmd --i ../surf/$hemi.orig_pial --max-cbv-dist 3.5 --blend-surf .25 ../surf/$hemi.white"
   fi
@@ -1081,15 +1080,15 @@ for hemi in lh rh ; do
   cmd="recon-all -subject $subject -hemi $hemi -curvstats -no-isrunning -umask $(umask) $hiresflag $fsthreads"
   RunIt "$cmd" "$LF" "$CMDF"
 
-  if [[ "$DoParallel" == "0" ]]
+  if [[ "$ParallelHemi" == "false" ]]
   then
     {
       echo " "
       echo " RUNNING $hemi sequentially ... "
       echo " "
     } | tee -a "$LF"
-    chmod u+x $CMDF
-    RunIt "$CMDF" $LF
+    chmod u+x "$CMDF"
+    RunIt "$CMDF" "$LF"
   fi
 
 
@@ -1100,9 +1099,9 @@ export OMP_NUM_THREADS=$threads
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=$threads
 
 # define the fsthreads variable for the joint section (again)
-if [[ "$threads" -gt "1" ]] ; then fsthreads="-threads $threads -itkthreads $threads" ; else fsthreads="" ; fi
+if [[ "$threads" -gt 1 ]] ; then fsthreads="-threads $threads -itkthreads $threads" ; else fsthreads="" ; fi
 
-if [[ "$DoParallel" == 1 ]] ; then
+if [[ "$ParallelHemi" == "true" ]] ; then
   {
     echo ""
     echo " RUNNING HEMIs in PARALLEL !!! "
@@ -1115,7 +1114,7 @@ fi
 # ============================= RIBBON ===============================================
 
 # Skip RIBBON in base
-if [[ "$base" != "1" ]]
+if [[ "$base" != "true" ]]
 then
 
   {
@@ -1134,7 +1133,7 @@ fi # skip in base
 
 # ============================= FSAPARC - parc23 surfcon hypo ... =========================================
 
-if [[ "$fsaparc" == "1" ]] ; then
+if [[ "$fsaparc" == "true" ]] ; then
 
     # this per-hemi section does not get parallelized
   for hemi in lh rh
@@ -1148,7 +1147,7 @@ if [[ "$fsaparc" == "1" ]] ; then
 
     # Destrieux Atlas (recon-all -cortparc2):
     longflag=""
-    if [[ "$long" == "1" ]]
+    if [[ "$long" == "true" ]]
     then
       # recon-all has different treatment for cortparc:
       # initialize with destrieux annot from base
@@ -1162,7 +1161,7 @@ if [[ "$fsaparc" == "1" ]] ; then
     # DKT Atlas (recon-all -cortparc3):
     longflag=""
     # recon-all has different treatment for cortparc: initialize with destrieux annot from base
-    if [[ "$long" == "1" ]] ; then longflag="-long -R $basedir/label/${hemi}.DKTatlas.annot" ; fi
+    if [[ "$long" == "true" ]] ; then longflag="-long -R $basedir/label/${hemi}.DKTatlas.annot" ; fi
     CPAtlas="$FREESURFER_HOME/average/${hemi}.DKTaparc.atlas.acfb40.noaparc.i12.2016-08-02.gcs"
     annot="$ldir/${hemi}.aparc.DKTatlas.annot"
     cmd="mris_ca_label -l $ldir/${hemi}.cortex.label -aseg $mdir/aseg.presurf.mgz -seed 1234 $longflag $subject $hemi $sdir/${hemi}.sphere.reg $CPAtlas $annot"
@@ -1171,7 +1170,7 @@ if [[ "$fsaparc" == "1" ]] ; then
   done # hemi loop
 
   # skip in base
-  if [[ "$base" != "1" ]]
+  if [[ "$base" != "true" ]]
   then
     cmd="recon-all -subject $subject -pctsurfcon -hyporelabel -apas2aseg -aparc2aseg -wmparc -parcstats -parcstats2 -parcstats3 -umask $(umask) $hiresflag $fsthreads"
     RunIt "$cmd" "$LF"
@@ -1183,7 +1182,7 @@ fi  # (FS-APARC)
 
 
 # Skip rest in case we have a base run, we are done here (probably we can skip stuff already in surface creation above)
-if [[ "$base" != "1" ]]
+if [[ "$base" != "true" ]]
 then
 
 # ============================= MAPPED SURF-STATS =========================================
@@ -1203,7 +1202,7 @@ then
 
 # ============================= FASTSURFER - surfcon hypo stats =========================================
 
-  if [[ "$fsaparc" == "0" ]]
+  if [[ "$fsaparc" == "false" ]]
   then
     {
       echo ""
@@ -1271,7 +1270,7 @@ then
                              "SupraTentorialNotVent" "Mask($mask)"
                              "BrainSegVol-to-eTIV" "MaskVol-to-eTIV")
     # in long we do not have orig_nofix for surface hole computation as surfaces are inherited from base/template
-    if [[ "$long" == "0" ]] ; then cmda+=("lhSurfaceHoles" "rhSurfaceHoles" "SurfaceHoles") ; fi
+    if [[ "$long" == "false" ]] ; then cmda+=("lhSurfaceHoles" "rhSurfaceHoles" "SurfaceHoles") ; fi
     cmda+=("EstimatedTotalIntraCranialVol")
     run_it "$LF" "${cmda[@]}"
 
@@ -1357,7 +1356,7 @@ then
 # ============================= FASTSURFER - SYMLINKS =========================================
 
   # Create symlinks for downstream analysis (sub-segmentations, TRACULA, etc.)
-  if [[ "$fsaparc" == "0" ]]
+  if [[ "$fsaparc" == "false" ]]
   then
     # Symlink of aparc.DKTatlas+aseg.mapped.mgz
     pushd "$mdir" > /dev/null || (echo "Could not cd to $mdir" ; exit 1)
@@ -1379,7 +1378,7 @@ then
 # ============================= BALABELS =========================================
 
   # balabels need sphere.reg
-  if [[ "$fssurfreg" == "1" ]]
+  if [[ "$fssurfreg" == "true" ]]
   then
     # can be produced if surf registration exists
     #cmd="recon-all -subject $subject -balabels $hiresflag $fsthreads"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -62,17 +62,17 @@ edits="false"
 viewagg="auto"
 device="auto"
 batch_size="1"
-run_seg_pipeline="1"
-run_biasfield="1"
-run_surf_pipeline="1"
+run_seg_pipeline="true"
+run_biasfield="true"
+run_surf_pipeline="true"
 surf_flags=()
-legacy_parallel_hemi=0
+legacy_parallel_hemi="false"
 vox_size="min"
 native_image="false"
-run_asegdkt_module="1"
-run_cereb_module="1"
-run_hypvinn_module="1"
-run_cc_module="1"
+run_asegdkt_module="true"
+run_cereb_module="true"
+run_hypvinn_module="true"
+run_cc_module="true"
 threads_seg="1"
 threads_surf="1"
 # python3 -s excludes user-directory package inclusion
@@ -421,7 +421,7 @@ case $key in
   --py) python="$1" ; shift ;;
   -h|--help) usage ; exit ;;
   --version)
-    if [[ "$#" -lt 1 ]] || [[ "$1" =~ ^-- ]]; then version_and_quit="1" # no more args or next arg starts with --
+    if [[ "$#" -lt 1 ]] || [[ "$1" =~ ^-- ]]; then version_and_quit="true" # no more args or next arg starts with --
     else
       case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
         all) version_and_quit="+checkpoints+git+pip" ;;
@@ -438,8 +438,8 @@ case $key in
 
   # common options for seg
   #=============================================================
-  --surf_only) run_seg_pipeline="0" ;;
-  --no_biasfield) run_biasfield="0" ;;
+  --surf_only) run_seg_pipeline="false" ;;
+  --no_biasfield) run_biasfield="false" ;;
   --keepgeom|--native_image) native_image="true" ;;
   --tal_reg) run_talairach_registration="true" ;;
   --device) device="$1" ; shift ;;
@@ -468,7 +468,7 @@ case $key in
     then
       echo "WARNING: --no_aparc is deprecated and will be removed, use --no_asegdkt."
     fi
-    run_asegdkt_module="0"
+    run_asegdkt_module="false"
     ;;
   --asegdkt_statsfile) asegdkt_vinn_statsfile="$1" ; shift ;;
   --aseg_statsfile) aseg_vinn_statsfile="$1" ; shift ;;
@@ -478,18 +478,18 @@ case $key in
 
   # corupus callosum module options
   #=============================================================
-  --no_cc) run_cc_module="0" ;;
+  --no_cc) run_cc_module="false" ;;
 
   # cereb module options
   #=============================================================
-  --no_cereb) run_cereb_module="0" ;;
+  --no_cereb) run_cereb_module="false" ;;
   # several options that set a variable
   --cereb_segfile) cereb_segfile="$1" ; shift ;;
   --cereb_statsfile) cereb_statsfile="$1" ; shift ;;
 
   # hypothal module options
   #=============================================================
-  --no_hypothal) run_hypvinn_module="0" ;;
+  --no_hypothal) run_hypvinn_module="false" ;;
   # several options that set a variable
   --hypo_segfile) hypo_segfile="$1" ; shift ;;
   --hypo_statsfile) hypo_statsfile="$1" ; shift ;;
@@ -511,10 +511,10 @@ case $key in
   ##############################################################
   # surf-pipeline options
   ##############################################################
-  --seg_only) run_surf_pipeline="0" ;;
+  --seg_only) run_surf_pipeline="false" ;;
   # several flag options that are *just* passed through to recon-surf.sh
   --fstess|--fsqsphere|--fsaparc|--no_surfreg|--ignore_fs_version) surf_flags+=("$key") ;;
-  --parallel) legacy_parallel_hemi=1 ;;
+  --parallel) legacy_parallel_hemi="true" ;;
   --no_fs_t1) surf_flags+=("--no_fs_T1") ;;
 
   # temporary segstats development flag
@@ -523,8 +523,14 @@ case $key in
   ##############################################################
   # longitudinal options
   ##############################################################
-  --base) base=1 ; run_cereb_module="0" ; run_hypvinn_module="0" ; surf_flags=("${surf_flags[@]}" "--base") ;;
-  --long) long=1 ; baseid="$1" ; surf_flags=("${surf_flags[@]}" "--long" "$1") ; shift ;;
+  --base)
+    base="true"
+    run_cc_module="false"
+    run_cereb_module="false"
+    run_hypvinn_module="false"
+    surf_flags=("${surf_flags[@]}" "--base")
+    ;;
+  --long) long="true" ; baseid="$1" ; surf_flags=("${surf_flags[@]}" "--long" "$1") ; shift ;;
   # unknown option ;  if not empty arguments, error & exit
   *) if [[ "$key" != "" ]] ; then echo "ERROR: Flag '$key' unrecognized." ; exit 1 ; fi ;;
 esac
@@ -551,8 +557,8 @@ fi
 
 if [[ -n "$version_and_quit" ]]
 then
-  # if version_and_quit is 1, it should only print the version number+git branch
-  if [[ "$version_and_quit" != "1" ]]
+  # if version_and_quit is true, it should only print the version number and version info
+  if [[ "$version_and_quit" != "true" ]]
   then
     version_cache_args=("${version_cache_args[@]}" --sections "$version_and_quit")
   fi
@@ -574,7 +580,7 @@ tmpLF=$(mktemp)
 
 # CHECKS
 
-if [[ "$legacy_parallel_hemi" == 1 ]]
+if [[ "$legacy_parallel_hemi" == "true" ]]
 then
   {
     echo "WARNING: The --parallel flag is obsolete and will be removed in FastSurfer 3."
@@ -601,7 +607,7 @@ then
   exit 1
 fi
 
-if [[ "${#warn_seg_only[@]}" -gt 0 ]] && [[ "$run_surf_pipeline" == "1" ]]
+if [[ "${#warn_seg_only[@]}" -gt 0 ]] && [[ "$run_surf_pipeline" == "true" ]]
 then
   {
     echo "WARNING: Specifying '${warn_seg_only[*]}' only affects the segmentation "
@@ -632,7 +638,7 @@ if [[ -z "$exec_time_log" ]] ; then exec_time_log="$subject_dir/${FASTSURFER_EXE
 if [[ -z "$seg_log" ]] ; then seg_log="$subject_dir/scripts/deep-seg.log" ; fi
 if [[ -z "$build_log" ]] ; then build_log="$subject_dir/scripts/build.log" ; fi
 # T2 image is only used in segmentation pipeline (but registration is done even if hypvinn is off)
-if [[ -n "$t2" ]] && [[ "$run_seg_pipeline" == 1 ]]
+if [[ -n "$t2" ]] && [[ "$run_seg_pipeline" == "true" ]]
 then
   if [[ ! -f "$t2" ]] ; then echo "ERROR: T2 file $t2 does not exist!" ; exit 1 ; fi
   copy_name_T2="$subject_dir/mri/orig/T2.001.mgz"
@@ -689,7 +695,7 @@ then
 fi
 
 # Check if running on an existing subject directory
-if [[ "$run_surf_pipeline" == 1 ]]
+if [[ "$run_surf_pipeline" == "true" ]]
 then
   if [[ -f "$SUBJECTS_DIR/$subject/mri/wm.mgz" ]] || [[ -f "$SUBJECTS_DIR/$subject/mri/aparc.DKTatlas+aseg.orig.mgz" ]]
   then
@@ -702,7 +708,7 @@ then
       exit 1
     fi
   fi
-  if [[ "$run_asegdkt_module" == "0" ]] || [[ "$run_seg_pipeline" == "0" ]]
+  if [[ "$run_asegdkt_module" == "false" ]] || [[ "$run_seg_pipeline" == "false" ]]
   then
     if [[ ! -f "$asegdkt_segfile" ]]
     then
@@ -725,7 +731,8 @@ then
   fi
 fi
 
-if [[ "$run_seg_pipeline" == "1" ]] && { [[ "$run_asegdkt_module" == "0" ]] && [[ "$run_cereb_module" == "1" ]]; }
+if [[ "$run_seg_pipeline" == "true" ]] && \
+   { [[ "$run_asegdkt_module" == "false" ]] && [[ "$run_cereb_module" == "true" ]]; }
 then
   if [[ ! -f "$asegdkt_segfile" ]]
   then
@@ -737,7 +744,8 @@ then
   fi
 fi
 
-if [[ "$run_seg_pipeline" == "1" ]] && { [[ "$run_asegdkt_module" == "0" ]] && [[ "$run_cc_module" == "1" ]]; }
+if [[ "$run_seg_pipeline" == "true" ]] && \
+   { [[ "$run_asegdkt_module" == "false" ]] && [[ "$run_cc_module" == "true" ]]; }
 then
   if [[ ! -f "$asegdkt_segfile" ]]
   then
@@ -751,7 +759,8 @@ fi
 
 maybe_xvfb=()
 # check if we are running on a headless system (CC QC needs a (virtual) display that support OpenGL)
-if [[ "$run_seg_pipeline" == "1" ]] && [[ "$run_cc_module" == "1" ]] && [[ "${cc_flags[*]}" =~ --thickness_image ]]
+if [[ "$run_seg_pipeline" == "true" ]] && [[ "$run_cc_module" == "true" ]] && \
+   [[ "${cc_flags[*]}" =~ --thickness_image ]]
 then
   # if we have xvfb-run, we can use it to provide a virtual display
   if [[ -n "$(which xvfb-run)" ]] ; then maybe_xvfb=("xvfb-run" "-a") ; fi
@@ -759,7 +768,8 @@ then
   # try loading opengl, if this is successful we are fine
   py_opengltest="import sys ; import glfw ; import whippersnappy.core ; sys.exit(1-glfw.init())"
   opengl_error_message="$("${maybe_xvfb[@]}" $python -c "$py_opengltest" 2>&1 > /dev/null)"
-  if [[ "$?" != "0" ]]
+  exit_code="$?"
+  if [[ "$exit_code" != "0" ]]
   then
     # if we cannot import OpenGL or whippersnappy, its an environment installation issue
     if [[ "$opengl_error_message" =~ "ModuleNotFoundError" ]] || [[ "$opengl_error_message" =~ "ImportError" ]]
@@ -776,14 +786,14 @@ then
   fi
 fi
 
-if [[ "$run_surf_pipeline" == "1" ]] && [[ "$native_image" != "false" ]]
+if [[ "$run_surf_pipeline" == "true" ]] && [[ "$native_image" != "false" ]]
 then
   echo "ERROR: The surface pipeline is not compatible with the options --native_image or "
   echo "  --keepgeom."
   exit 1
 fi
 
-if [[ "$run_surf_pipeline" == "0" ]] && [[ "$run_seg_pipeline" == "0" ]]
+if [[ "$run_surf_pipeline" == "false" ]] && [[ "$run_seg_pipeline" == "false" ]]
 then
   echo "ERROR: You specified both --surf_only and --seg_only. Therefore neither part of the pipeline will be run."
   echo "  To run the whole FastSurfer pipeline, omit both flags."
@@ -791,9 +801,9 @@ then
 fi
 
 what_needs_license=""
-if [[ "$run_surf_pipeline" == 1 ]] ; then what_needs_license+=" and the surface pipeline" ; fi
-if [[ "$run_seg_pipeline" == 1 ]] ; then
-  if [[ "$run_biasfield" == 1 ]] && [[ "$run_talairach_registration" == "true" ]] ; then
+if [[ "$run_surf_pipeline" == "true" ]] ; then what_needs_license+=" and the surface pipeline" ; fi
+if [[ "$run_seg_pipeline" == "true" ]] ; then
+  if [[ "$run_biasfield" == "true" ]] && [[ "$run_talairach_registration" == "true" ]] ; then
     what_needs_license+=" and the talairach-registration in the segmentation pipeline"
   fi
   if [[ -n "$t2" ]] && [[ "$hypvinn_regmode" != "none" ]] ; then
@@ -833,14 +843,14 @@ fi
 
 # checks and t1 setup for longitudinal pipeline
 # generally any t1 input per command line is overwritten here
-if [[ "$long" == "1" ]] && [[ "$base" == "1" ]]
+if [[ "$long" == "true" ]] && [[ "$base" == "true" ]]
 then
   echo "ERROR: You specified both --long and --base. You need to setup and then run base template first,"
   echo "  before you can run any longitudinal time points."
   exit 1
 fi
 
-if [[ "$base" == "1" ]]
+if [[ "$base" == "true" ]]
 then
   check_is_template "$sd" "$subject"
   if [[ -n "$t1" ]] && [[ "$t1" != "from-base" ]]; then
@@ -854,7 +864,7 @@ then
   fi
 fi
 
-if [[ "$long" == "1" ]]
+if [[ "$long" == "true" ]]
 then
   check_is_template "$sd" "$baseid"
   if ! grep -Fxq "$subject" "$sd/$baseid/base-tps.fastsurfer" ; then
@@ -869,7 +879,7 @@ then
   t1="$sd/$baseid/long-inputs/$subject/long_conform.nii.gz"
 fi
 
-if [[ "$run_seg_pipeline" == "1" ]] && { [[ -z "$t1" ]] || [[ ! -f "$t1" ]]; }
+if [[ "$run_seg_pipeline" == "true" ]] && { [[ -z "$t1" ]] || [[ ! -f "$t1" ]]; }
 then
   echo "ERROR: T1 image ($t1) could not be found. You must supply an existing T1 input"
   echo "  (full head) via --t1 <absolute path and name> for generating the segmentation."
@@ -913,7 +923,7 @@ trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" | tee -
 printf "%s %s\n%s\n" "$THIS_SCRIPT" "${inputargs[*]}" "$(date -R)" >> "$build_log"
 timeout 20 $python "$FASTSURFER_HOME/FastSurferCNN/version.py" --sections all -o "$build_log" "${version_cache_args[@]}" &
 
-if [[ "$run_seg_pipeline" != "1" ]]
+if [[ "$run_seg_pipeline" != "true" ]]
 then
   {
     echo "INFO: Running run_fastsurfer.sh without segmentation pipeline;"
@@ -929,7 +939,7 @@ then
     # filter expected files $LF and scripts/BUILD.log
     IFS=""
     while read -r file ; do
-      if [[ "$sdir/${file:2}" != "$seg_log" ]] && [[ "$file" != "./scripts/BUILD.log" ]] ; then echo "$file" ; fi
+      if [[ "$sd/$subject/${file:2}" != "$seg_log" ]] && [[ "$file" != "./scripts/BUILD.log" ]] ; then echo "$file" ; fi
     done
   }
 
@@ -949,7 +959,7 @@ fi
 
 asegdkt_segfile_manedit=$(add_file_suffix "$asegdkt_segfile" "manedit")
 
-if [[ "$run_seg_pipeline" == "1" ]]
+if [[ "$run_seg_pipeline" == "true" ]]
 then
 
   echo "SEGMENTATION PIPELINE" >> "$exec_time_log"
@@ -958,7 +968,7 @@ then
   # "============= Running FastSurferCNN (Creating Segmentation aparc.DKTatlas.aseg.mgz) ==============="
   # use FastSurferCNN to create cortical parcellation + anatomical segmentation into 95 classes.
 
-  if [[ "$run_asegdkt_module" == "1" ]]
+  if [[ "$run_asegdkt_module" == "true" ]]
   then
     echo "MODULE: FastSurferVINN aseg+DKT segmentation" >> "$exec_time_log"
     cmd=($python "$fastsurfercnndir/run_prediction.py" --t1 "$t1" --sid "$subject" --asegdkt_segfile "$asegdkt_segfile"
@@ -1009,7 +1019,7 @@ then
     fi
   fi
 
-  if [[ "$run_biasfield" == "1" ]]
+  if [[ "$run_biasfield" == "true" ]]
   then
     echo "MODULE: Biasfield correction" >> "$exec_time_log"
     {
@@ -1031,8 +1041,8 @@ then
     then
       cmd=("$reconsurfdir/talairach-reg.sh" "$seg_log"
            --dir "$subject_dir/mri" --conformed_name "$conformed_name" --norm_name "$norm_name")
-      if [[ "$long" == "1" ]] ; then cmd+=(--long "$basedir") ; fi
-      if [[ "$edits" == "1" ]] ; then cmd+=(--edits) ; fi
+      if [[ "$long" == "true" ]] ; then cmd+=(--long "$basedir") ; fi
+      if [[ "$edits" == "true" ]] ; then cmd+=(--edits) ; fi
       if [[ "$atlas3T" == "true" ]] ; then cmd+=(--3T) ; fi
       {
         echo "INFO: Running talairach registration..."
@@ -1100,7 +1110,7 @@ then
         exit 1
       fi
     fi
-  fi  # [[ "$run_biasfield" == "1" ]]
+  fi  # [[ "$run_biasfield" == "true" ]]
 
   if [[ -n "$t2" ]]
   then
@@ -1122,7 +1132,7 @@ then
       exit $exit_code  # this will only terminate the subshell
     } | tee -a "$seg_log"
     if [[ "${PIPESTATUS[0]}" != 0 ]] ; then echo "ERROR: Robust scaling of T2 failed!" | tee -a "$seg_log" ; exit 1 ; fi
-    if [[ "$run_biasfield" == "1" ]]
+    if [[ "$run_biasfield" == "true" ]]
     then
       # ... we have a t2 image, bias field-correct it (save robustly scaled uchar)
       cmd=($python "${reconsurfdir}/N4_bias_correct.py" "--in" "$copy_name_T2" --out "$norm_name_t2"
@@ -1152,7 +1162,7 @@ then
     fi
   fi
 
-  if [[ "$run_cc_module" == "1" ]]
+  if [[ "$run_cc_module" == "true" ]]
   then
     # ============================= CC SEGMENTATION ============================================
 
@@ -1172,7 +1182,7 @@ then
       echo_quoted "${cmd[@]}"
       "${wrap[@]}" "${cmd[@]}"
       if [[ "${PIPESTATUS[0]}" != 0 ]] ; then echo "ERROR: FastSurferCC corpus callosum analysis failed!" ; exit 1 ; fi
-      if [[ "$edits" == 1 ]] && [[ -f "$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
+      if [[ "$edits" == "true" ]] && [[ -f "$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
 
       # add CC into aparc.DKTatlas+aseg.deep.mgz and aseg.auto.mgz as mri_cc did before.
       cmd=($python "$CorpusCallosumDir/paint_cc_into_pred.py" -in_cc "$callosum_seg" -in_pred "$asegdkt_segfile"
@@ -1181,7 +1191,7 @@ then
       "${wrap[@]}" "${cmd[@]}"
       if [[ "${PIPESTATUS[0]}" != 0 ]] ; then echo "ERROR: asegdkt cc inpainting failed!" ; exit 1 ; fi
 
-      if [[ "$run_biasfield" == 1 ]]
+      if [[ "$run_biasfield" == "true" ]]
       then
         cmd=($python "${fastsurfercnndir}/segstats.py" --segfile "$asegdkt_withcc_segfile" --normfile "$norm_name"
              --lut "$fastsurfercnndir/config/FreeSurferColorLUT.txt" --sd "${sd}" --sid "${subject}"
@@ -1214,10 +1224,10 @@ then
         fi
       fi
     } 2>&1 | tee -a "$seg_log"
-    code="${PIPESTATUS[0]}"
-    if [[ "$code" != 0 ]]; then exit 1; fi # forward subshell exit to main script
+    exit_code="${PIPESTATUS[0]}"
+    if [[ "$exit_code" != 0 ]]; then exit 1; fi # forward subshell exit to main script
 
-    if [[ "$run_biasfield" == 1 ]]
+    if [[ "$run_biasfield" == "true" ]]
     then
       {
         cmd=($python "${fastsurfercnndir}/segstats.py" --segfile "$aseg_auto_segfile" --normfile "$norm_name"
@@ -1237,10 +1247,10 @@ then
     fi
   fi
 
-  if [[ "$run_cereb_module" == "1" ]]
+  if [[ "$run_cereb_module" == "true" ]]
   then
     echo "MODULE: CerebNet cerebellum segmentation" >> "$exec_time_log"
-    if [[ "$run_biasfield" == "1" ]]
+    if [[ "$run_biasfield" == "true" ]]
     then
       cereb_flags+=(--norm_name "$norm_name" --cereb_statsfile "$cereb_statsfile")
     else
@@ -1265,14 +1275,14 @@ then
     fi
   fi
 
-  if [[ "$run_hypvinn_module" == "1" ]]
+  if [[ "$run_hypvinn_module" == "true" ]]
   then
     echo "MODULE: HypVINN hypothalamus segmentation" >> "$exec_time_log"
     # currently, the order of the T2 preprocessing only is registration to T1w
     cmd=($python "$hypvinndir/run_prediction.py" --sd "${sd}" --sid "${subject}" --reg_mode "$hypvinn_regmode"
          "${hypvinn_flags[@]}" --threads "$threads_seg" --async_io --batch_size "$batch_size" --seg_log "$seg_log"
          --device "$device" --viewagg_device "$viewagg" --t1)
-    if [[ "$run_biasfield" == "1" ]]
+    if [[ "$run_biasfield" == "true" ]]
     then
       cmd+=("$norm_name")
       if [[ -n "$t2" ]] ; then cmd+=(--t2 "$norm_name_t2") ; fi
@@ -1303,7 +1313,7 @@ else # not running segmentation pipeline
   if [[ -e "$asegdkt_segfile_manedit" ]] ; then asegdkt_segfile="$asegdkt_segfile_manedit" ; fi
 fi
 
-if [[ "$run_surf_pipeline" == "1" ]]
+if [[ "$run_surf_pipeline" == "true" ]]
 then
 
   echo "SURFACE RECONSTRUCTION PIPELINE" >> "$exec_time_log"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -81,8 +81,8 @@ allow_root=()
 version_and_quit=""
 warn_seg_only=()
 warn_base=()
-base=0                # flag for longitudinal template (base) run
-long=0                # flag for longitudinal time point run
+base="false"          # flag for longitudinal template (base) run
+long="false"          # flag for longitudinal time point run
 baseid=""             # baseid for logitudinal time point run
 
 function usage()
@@ -1263,7 +1263,7 @@ then
     cmd=($python "$cerebnetdir/run_prediction.py" --t1 "$t1" --asegdkt_segfile "$asegdkt_segfile" --seg_log "$seg_log"
          --conformed_name "$conformed_name" --cereb_segfile "$cereb_segfile" --async_io --batch_size "$batch_size"
          --viewagg_device "$viewagg" --device "$device" --threads "$threads_seg" "${cereb_flags[@]}")
-    # specify the subject dir $sd, if asegdkt_segfile explicitly starts with it
+    # specify the subject dir $sd, if cereb_segfile explicitly starts with it
     if [[ "$sd" == "${cereb_segfile:0:${#sd}}" ]] ; then cmd=("${cmd[@]}" --sd "$sd"); fi
     if [[ "$native_image" != "false" ]] ; then cmd+=(--orientation native --image_size fov --vox_size none) ; fi
     echo_quoted "${cmd[@]}" | tee -a "$seg_log"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -525,7 +525,8 @@ case $key in
   ##############################################################
   --base)
     base="true"
-    run_cc_module="false"
+    # for now, keep the cc running in base, as it is very fast and should not have side effects
+    # run_cc_module="false"
     run_cereb_module="false"
     run_hypvinn_module="false"
     surf_flags=("${surf_flags[@]}" "--base")

--- a/stools.sh
+++ b/stools.sh
@@ -124,24 +124,16 @@ function check_cases_in_out_dir ()
   #param1 out_dir
   #param2 cases
   #param3 optional: true/false jobarray defined (default: false)
-  if [[ "$#" -gt 2 ]] && [[ "$3" == "true" ]]
-  then
-    jobarray_defined="true"
-  else
-    jobarray_defined="false"
-  fi
+  if [[ "$#" -gt 2 ]] && [[ "$3" == "true" ]] ; then jobarray_defined="true" ; else jobarray_defined="false" ; fi
   case_already_exists=""
   for subject in $2
   do
     subject_id=$(echo "$subject" | cut -d= -f1)
-    if [[ -e "$1/$subject_id" ]]
-    then
-      case_already_exists="$case_already_exists, $subject_id"
-    fi
+    if [[ -e "$1/$subject_id" ]] ; then case_already_exists="$case_already_exists, $subject_id" ; fi
   done
   if [[ "$case_already_exists" != "" ]]
   then
-    echo "Some cases already exist in $1 (${case_already_exists:2})"
+    echo "WARNING: Some cases already exist in $1 (${case_already_exists:2})"
     if [[ "$jobarray_defined" == "true" ]]
     then
       echo "This list does not filter for the --slurm_jobarray argument!"
@@ -157,7 +149,7 @@ function check_seg_surf_only ()
   #param1 seg_only
   #param2 surf_only
   if [[ "$1" == "true" ]] && [[ "$2" == "true" ]]; then
-    echo "Selecting both --seg_only and --surf_only is invalid!"
+    echo "ERROR: Selecting both --seg_only and --surf_only is invalid!"
     exit 1
   fi
 }
@@ -165,7 +157,7 @@ function check_subject_images ()
 {
   #param1 data dir
   #param2 cases
-  if [[ "$#" -lt 2 ]]; then >&2 echo "check_subject_images is missing parameters!"; exit 1; fi
+  if [[ "$#" -lt 2 ]]; then >&2 echo "ERROR: check_subject_images is missing parameters!"; exit 1; fi
   missing_subject_ids=""
   missing_subject_imgs=""
   symlink_subject_imgs=""


### PR DESCRIPTION
This PR fixes a bug in run_fastsurfer where the 0/1 boolean convention was mixed with the "true"/"false" convention.

For clarity, 0/1 is usually deprecated over the more clear "true"/"false" because the exit codes/return codes have an inverted meaning to the usual usage of 0/1, i.e. in exit codes 0 is true, but in the checks 0 is false.

This PR consistently changes the usage of 0/1 to "true"/"false" strings across the main bash scripts.

The run_fastsurfer.sh, brun_fastsurfer.sh and recon-surf.sh scripts inconsistently used 0/1 and "false"/"true" to indicate boolean values. This even caused a bug, where edits was initialized to "true"/"false", but checked against 0/1 for the talairach registration.

This commit also improves the inline comments/documentation of brun_fastsurfer's (complex) process_by_token function.

This issue was reported in #778.