### PR TITLE
add stages to long_fastsurfer.sh

### DIFF
--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -317,7 +317,23 @@ function check_stage_dependencies() {
 # Warning if run as root user
 check_allow_root "${brun_flags[@]}" # --allow_root must be passed to brun
 
-# Check if prepare stage will run - only then we need t1s and tpids
+# Validate required inputs based on which stages will run
+if [ -z "$tid" ]
+ then
+  echo "ERROR: Must supply person-specific template name via --tid <template id>!"
+  exit 1
+fi
+
+# tpids required for prepare, long_seg, and long_surf stages
+if should_run_stage "prepare" || should_run_stage "long_seg" || should_run_stage "long_surf"; then
+  if [ "${#tpids[@]}" -lt 1 ]
+   then
+    echo "ERROR: Must supply time point IDs via --tpids <timepoint id 1> [<timepoint id 2> ...]!"
+    exit 1
+  fi
+fi
+
+# t1s only required for prepare stage
 if should_run_stage "prepare"; then
   if [ "${#t1s[@]}" -lt 1 ]
    then
@@ -325,33 +341,12 @@ if should_run_stage "prepare"; then
     exit 1
   fi
 
-  if [ "${#tpids[@]}" -lt 1 ]
-   then
-    echo "ERROR: Must supply time points ids via --tpids <timepoint id 1> [<timepoint id 2> ...] when running 'prepare' stage!"
-    exit 1
-  fi
-
-  # check that t1s list is same length as tpids
+  # For prepare stage, t1s and tpids must have same length
   if [ "${#tpids[@]}" -ne "${#t1s[@]}" ]
    then
     echo "ERROR: Length of tpids must equal t1s!"
     exit 1
   fi
-else
-  # For other stages, we still need tpids but not necessarily t1s
-  if should_run_stage "long_seg" || should_run_stage "long_surf"; then
-    if [ "${#tpids[@]}" -lt 1 ]
-     then
-      echo "ERROR: Must supply time points ids via --tpids <timepoint id 1> [<timepoint id 2> ...] when running 'long_seg' or 'long_surf' stages!"
-      exit 1
-    fi
-  fi
-fi
-
-if [ -z "$tid" ]
- then
-  echo "ERROR: Must supply person-specific template name via --tid <template id>!"
-  exit 1
 fi
 
 # check that SUBJECTS_DIR exists

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -59,6 +59,10 @@ LF=""
 brun_flags=()
 python="python3 -s" # avoid user-directory package inclusion
 
+# Stage control
+run_stages=("prepare" "template_seg" "template_surf" "long_seg" "long_surf")
+valid_stages=("prepare" "template_seg" "template_surf" "long_seg" "long_surf" "all")
+
 
 function usage()
 {
@@ -84,6 +88,19 @@ FLAGS:
                               Default: "$python"
                               (-s: do no search for packages in home directory)
   -h --help                 Print Help
+
+Stage control:
+  --stage <stage>           Run specific stage(s). Can be specified multiple times.
+                              Valid stages: prepare, template_seg, template_surf,
+                                            long_seg, long_surf, all
+                              Default: all (runs full pipeline)
+
+                            Stage dependencies:
+                              - prepare: none (requires --t1s and --tpids)
+                              - template_seg: prepare
+                              - template_surf: prepare, template_seg
+                              - long_seg: prepare
+                              - long_surf: prepare, template_seg, template_surf, long_seg
 
 Parallelization options:
   All of the following options will activate parallel processing of the template and the longitudinal time-point images
@@ -151,6 +168,21 @@ shift # past argument
 case $key in
   --tid) tid="$1" ; shift ;;
   --log) LF="$1" ; shift ;;
+  --stage)
+    # Clear default if first --stage flag
+    if [[ ${#run_stages[@]} -eq 5 ]]; then run_stages=(); fi
+    stage=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+    if [[ ! " ${valid_stages[*]} " =~ " ${stage} " ]]; then
+      echo "ERROR: Invalid stage '$1'. Valid stages: ${valid_stages[*]}"
+      exit 1
+    fi
+    if [[ "$stage" == "all" ]]; then
+      run_stages=("prepare" "template_seg" "template_surf" "long_seg" "long_surf")
+    else
+      run_stages+=("$stage")
+    fi
+    shift
+    ;;
   --tpids)
     while [[ $# -gt 0 ]] && [[ $1 != -* ]] 
     do
@@ -194,31 +226,98 @@ done
 
 source "${reconsurfdir}/functions.sh"
 
+# Function to check if a stage should run
+function should_run_stage() {
+  local stage=$1
+  for s in "${run_stages[@]}"; do
+    if [[ "$s" == "$stage" ]]; then return 0; fi
+  done
+  return 1
+}
+
+# Function to validate stage dependencies
+function check_stage_dependencies() {
+  for stage in "${run_stages[@]}"; do
+    case $stage in
+      template_seg|template_surf|long_seg|long_surf)
+        if [[ ! -d "$sd/$tid" ]] || [[ ! -f "$sd/$tid/mri/orig.mgz" ]]; then
+          echo "ERROR: Stage '$stage' requires 'prepare' to have been run first."
+          echo "  Template directory $sd/$tid or $sd/$tid/mri/orig.mgz not found."
+          exit 1
+        fi
+        ;;
+    esac
+
+    case $stage in
+      template_surf)
+        if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
+          echo "ERROR: Stage 'template_surf' requires 'template_seg' to have been run first."
+          exit 1
+        fi
+        ;;
+      long_surf)
+        if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
+          echo "ERROR: Stage 'long_surf' requires 'template_seg' to have been run first."
+          exit 1
+        fi
+        if [[ ! -f "$sd/$tid/surf/lh.white" ]]; then
+          echo "ERROR: Stage 'long_surf' requires 'template_surf' to have been run first."
+          exit 1
+        fi
+        # Check that ALL time points have completed long_seg
+        missing_long_seg=()
+        for tpid in "${tpids[@]}"; do
+          if [[ ! -f "$sd/$tpid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
+            missing_long_seg+=("$tpid")
+          fi
+        done
+        if [[ ${#missing_long_seg[@]} -gt 0 ]]; then
+          echo "ERROR: Stage 'long_surf' requires 'long_seg' to have been run first for ALL time points."
+          echo "  Missing segmentation for: ${missing_long_seg[*]}"
+          exit 1
+        fi
+        ;;
+    esac
+  done
+}
+
 # Warning if run as root user
 check_allow_root "${brun_flags[@]}" # --allow_root must be passed to brun
 
-if [ "${#t1s[@]}" -lt 1 ]
- then
-  echo "ERROR: Must supply T1 inputs (full head) via --t1s <t1w file 1> [<t1w file 2> ...]!"
-  exit 1
-fi
+# Check if prepare stage will run - only then we need t1s and tpids
+if should_run_stage "prepare"; then
+  if [ "${#t1s[@]}" -lt 1 ]
+   then
+    echo "ERROR: Must supply T1 inputs (full head) via --t1s <t1w file 1> [<t1w file 2> ...] when running 'prepare' stage!"
+    exit 1
+  fi
 
-if [ "${#tpids[@]}" -lt 1 ]
- then
-  echo "ERROR: Must supply time points ids via --tpids <timepoint id 1> [<timepoint id 2> ...]!"
-  exit 1
+  if [ "${#tpids[@]}" -lt 1 ]
+   then
+    echo "ERROR: Must supply time points ids via --tpids <timepoint id 1> [<timepoint id 2> ...] when running 'prepare' stage!"
+    exit 1
+  fi
+
+  # check that t1s list is same length as tpids
+  if [ "${#tpids[@]}" -ne "${#t1s[@]}" ]
+   then
+    echo "ERROR: Length of tpids must equal t1s!"
+    exit 1
+  fi
+else
+  # For other stages, we still need tpids but not necessarily t1s
+  if should_run_stage "long_seg" || should_run_stage "long_surf"; then
+    if [ "${#tpids[@]}" -lt 1 ]
+     then
+      echo "ERROR: Must supply time points ids via --tpids <timepoint id 1> [<timepoint id 2> ...] when running 'long_seg' or 'long_surf' stages!"
+      exit 1
+    fi
+  fi
 fi
 
 if [ -z "$tid" ]
  then
   echo "ERROR: Must supply person-specific template name via --tid <template id>!"
-  exit 1
-fi
-
-# check that t1s list is same length as tpids
-if [ "${#tpids[@]}" -ne "${#t1s[@]}" ]
- then
-  echo "ERROR: Length of tpids must equal t1s!"
   exit 1
 fi
 
@@ -241,132 +340,158 @@ function log () { echo "$1" | tee -a "$LF" ; }
 ## make sure +eo are unset
 set +eo > /dev/null
 
+# Validate stage dependencies
+check_stage_dependencies
+
 log "Logging outputs of $THIS_SCRIPT to $LF"
 log "======================================="
 
 ################################### Prepare Person-Template ##################################
 
-log "Person-Template Setup $tid"
-cmda=("$reconsurfdir/long_prepare_template.sh"
-     --tid "$tid" --t1s "${t1s[@]}" --tpids "${tpids[@]}"
-     --py "$python"
-     "${POSITIONAL_FASTSURFER[@]}")
-# run_it will exit the bash script if the command fails (with exit code 1)
-run_it "$LF" "${cmda[@]}"
+if should_run_stage "prepare"; then
+  log "Person-Template Setup $tid"
+  cmda=("$reconsurfdir/long_prepare_template.sh"
+       --tid "$tid" --t1s "${t1s[@]}" --tpids "${tpids[@]}"
+       --py "$python"
+       "${POSITIONAL_FASTSURFER[@]}")
+  # run_it will exit the bash script if the command fails (with exit code 1)
+  run_it "$LF" "${cmda[@]}"
+fi
 
 ################################### Run Person-Template Seg ##################################
 
-log "Person-Template Segmentation $tid"
-cmda=("$FASTSURFER_HOME/run_fastsurfer.sh"
-        --sid "$tid" --sd "$sd" --base
-        --seg_only --py "$python"
-        "${POSITIONAL_FASTSURFER[@]}")
-# run_it will exit the bash script if the command fails (with exit code 1)
-run_it "$LF" "${cmda[@]}"
+if should_run_stage "template_seg"; then
+  log "Person-Template Segmentation $tid"
+  cmda=("$FASTSURFER_HOME/run_fastsurfer.sh"
+          --sid "$tid" --sd "$sd" --base
+          --seg_only --py "$python"
+          "${POSITIONAL_FASTSURFER[@]}")
+  # run_it will exit the bash script if the command fails (with exit code 1)
+  run_it "$LF" "${cmda[@]}"
+fi
 
 ################################### Run Person-Template Surf #################################
 
-log "Person-Template Surface Reconstruction $tid"
-cmda=("$FASTSURFER_HOME/run_fastsurfer.sh"
-        --sid "$tid" --sd "$sd"
-        --surf_only --base --py "$python"
-        "${POSITIONAL_FASTSURFER[@]}")
-if [[ "$parallel" == "1" ]] ; then
-  base_surf_cmdf="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf"
-  base_surf_cmdf_log="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf.log"
-  {
-    echo "Log file of person-template surface pipeline"
-    date
-  } > "$base_surf_cmdf_log"
-  echo "#/bin/bash" > "$base_surf_cmdf"
-  run_it_cmdf "$LF" "$base_surf_cmdf" "${cmda[@]}"
-  log "Starting person-template surface reconstruction, logs temporarily diverted to $base_surf_cmdf_log..."
-  log "Output from this process will be delayed to when it has finished."
-  log "======================================="
-  bash "$base_surf_cmdf" >> "$base_surf_cmdf_log" 2>&1 &
-  base_surf_pid=$!
-  # shellcheck disable=SC2064
-  trap "if [[ -n \"\$(ps --no-headers $base_surf_pid)\" ]] ; then kill $base_surf_pid ; fi" EXIT
-else
-  run_it "$LF" "${cmda[@]}"
+if should_run_stage "template_surf"; then
+  log "Person-Template Surface Reconstruction $tid"
+  cmda=("$FASTSURFER_HOME/run_fastsurfer.sh"
+          --sid "$tid" --sd "$sd"
+          --surf_only --base --py "$python"
+          "${POSITIONAL_FASTSURFER[@]}")
+  if [[ "$parallel" == "1" ]] ; then
+    base_surf_cmdf="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf"
+    base_surf_cmdf_log="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf.log"
+    {
+      echo "Log file of person-template surface pipeline"
+      date
+    } > "$base_surf_cmdf_log"
+    echo "#/bin/bash" > "$base_surf_cmdf"
+    run_it_cmdf "$LF" "$base_surf_cmdf" "${cmda[@]}"
+    log "Starting person-template surface reconstruction, logs temporarily diverted to $base_surf_cmdf_log..."
+    log "Output from this process will be delayed to when it has finished."
+    log "======================================="
+    bash "$base_surf_cmdf" >> "$base_surf_cmdf_log" 2>&1 &
+    base_surf_pid=$!
+    # shellcheck disable=SC2064
+    trap "if [[ -n \"\$(ps --no-headers $base_surf_pid)\" ]] ; then kill $base_surf_pid ; fi" EXIT
+  else
+    run_it "$LF" "${cmda[@]}"
+  fi
 fi
 
 ################################### Run Long Seg ##################################
 
-# skip this for now as brun does not even have the --long flag yet
-time_points=()
-for ((i=0;i<${#tpids[@]};++i)); do
-  time_points+=("${tpids[$i]}=from-base")
-done
-cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --seg_only --long "$tid"
-      "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
+# Prepare time_points array for long_seg and long_surf stages
+if should_run_stage "long_seg" || should_run_stage "long_surf"; then
+  time_points=()
+  for ((i=0;i<${#tpids[@]};++i)); do
+    time_points+=("${tpids[$i]}=from-base")
+  done
+fi
 
-if [[ "$parallel" == "1" ]] ; then
-  long_seg_cmdf="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf"
-  long_seg_cmdf_log="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf.log"
-  {
-    echo "Log file of longitudinal segmentation pipeline"
-    date
-  } > "$long_seg_cmdf_log"
-  echo "#/bin/bash" > "$long_seg_cmdf"
-  run_it_cmdf "$LF" "$long_seg_cmdf" "${cmda[@]}"
-  log "Starting longitudinal segmentations, logs temporarily diverted to $long_seg_cmdf_log..."
-  log "Output from this process will be delayed to when it has finished."
-  log "======================================="
-  # at the end of the job below, the gpu can be released (for tight management of resources, run
-  # Surfaces in different jobs. Alternative, add a command to "$long_seg_cmdf" that releases the gpu or
-  # triggers the next "subject"
-  #TQDM_DISABLE=1
-  bash "$long_seg_cmdf" >> "$long_seg_cmdf_log" 2>&1 &
-  long_seg_pid=$!
-  # shellcheck disable=SC2064
-  trap "if [[ -n \"\$(ps --no-headers $long_seg_pid)\" ]] ; then kill $long_seg_pid ; fi" EXIT
-else
-  run_it "$LF" "${cmda[@]}"
+if should_run_stage "long_seg"; then
+  cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --seg_only --long "$tid"
+        "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
+
+  if [[ "$parallel" == "1" ]] ; then
+    long_seg_cmdf="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf"
+    long_seg_cmdf_log="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf.log"
+    {
+      echo "Log file of longitudinal segmentation pipeline"
+      date
+    } > "$long_seg_cmdf_log"
+    echo "#/bin/bash" > "$long_seg_cmdf"
+    run_it_cmdf "$LF" "$long_seg_cmdf" "${cmda[@]}"
+    log "Starting longitudinal segmentations, logs temporarily diverted to $long_seg_cmdf_log..."
+    log "Output from this process will be delayed to when it has finished."
+    log "======================================="
+    # at the end of the job below, the gpu can be released (for tight management of resources, run
+    # Surfaces in different jobs. Alternative, add a command to "$long_seg_cmdf" that releases the gpu or
+    # triggers the next "subject"
+    #TQDM_DISABLE=1
+    bash "$long_seg_cmdf" >> "$long_seg_cmdf_log" 2>&1 &
+    long_seg_pid=$!
+    # shellcheck disable=SC2064
+    trap "if [[ -n \"\$(ps --no-headers $long_seg_pid)\" ]] ; then kill $long_seg_pid ; fi" EXIT
+  else
+    run_it "$LF" "${cmda[@]}"
+  fi
 fi
 
 ################################### Run Long Surf #################################
 
-cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --surf_only --long "$tid"
-      "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
-if [[ "$parallel" == "1" ]] ; then
-  # Append the template surface and longitudinal segmentation logs, exit if either failed
-  what_failed=()
-  log "======================================="
-  log "Waiting for person-template surface reconstruction and longitudinal segmentations to finish... (this may take 30+ minutes)"
-  wait "$base_surf_pid"
-  success1=$?
-  log "done."
-  log "Person-Template Surface pipeline Log:"
-  log "======================================="
-  tee -a "$LF" < "$base_surf_cmdf_log"
-  if [ "$success1" -ne 0 ] ; then
-    log "Person-Template Surface pipeline terminated with error: $success1"
-    what_failed+=("Person-Template Surface Pipeline")
-  else
-    log "Person-Template Surface pipeline finished successfully!"
-    rm "$base_surf_cmdf_log" # the content of this file is transferred to LF
+if should_run_stage "long_surf"; then
+  cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --surf_only --long "$tid"
+        "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
+  if [[ "$parallel" == "1" ]] ; then
+    # Append the template surface and longitudinal segmentation logs, exit if either failed
+    what_failed=()
+    log "======================================="
+
+    # Wait for base_surf if it was started
+    if [[ -n "${base_surf_pid:-}" ]]; then
+      log "Waiting for person-template surface reconstruction to finish... (this may take 30+ minutes)"
+      wait "$base_surf_pid"
+      success1=$?
+      log "done."
+      log "Person-Template Surface pipeline Log:"
+      log "======================================="
+      tee -a "$LF" < "$base_surf_cmdf_log"
+      if [ "$success1" -ne 0 ] ; then
+        log "Person-Template Surface pipeline terminated with error: $success1"
+        what_failed+=("Person-Template Surface Pipeline")
+      else
+        log "Person-Template Surface pipeline finished successfully!"
+        rm "$base_surf_cmdf_log" # the content of this file is transferred to LF
+      fi
+      log "======================================="
+    fi
+
+    # Wait for long_seg if it was started
+    if [[ -n "${long_seg_pid:-}" ]]; then
+      log "Waiting for longitudinal segmentations to finish..."
+      wait "$long_seg_pid"
+      success2=$?
+      log "Longitudinal Segmentation pipeline Log:"
+      log "======================================="
+      tee -a "$LF" < "$long_seg_cmdf_log"
+      if [ "$success2" -ne 0 ] ; then
+        log "Longitudinal Segmentation pipeline terminated with error: $success2"
+        what_failed+=("Longitudinal Segmentation Pipeline")
+      else
+        log "Longitudinal Segmentation pipeline finished successfully!"
+        rm "$long_seg_cmdf_log" # the content of this file is transferred to LF
+      fi
+      log "======================================="
+    fi
+
+    if [[ ${#what_failed[@]} -gt 0 ]] ; then
+      log "Terminating because ${what_failed[*]} failed!"
+      exit 1
+    fi
   fi
-  log "======================================="
-  wait "$long_seg_pid"
-  success2=$?
-  log "Longitudinal Segmentation pipeline Log:"
-  log "======================================="
-  tee -a "$LF" < "$long_seg_cmdf_log"
-  if [ "$success2" -ne 0 ] ; then
-    log "Longitudinal Segmentation pipeline terminated with error: $success2"
-    what_failed+=("Longitudinal Segmentation Pipeline")
-  else
-    log "Longitudinal Segmentation pipeline finished successfully!"
-    rm "$long_seg_cmdf_log" # the content of this file is transferred to LF
-  fi
-  log "======================================="
-  if [[ "$success1" -ne 0 ]] || [[ "$success2" -ne 0 ]] ; then
-    log "Terminating because ${what_failed[*]} failed!"
-    exit 1
-  fi
+  run_it "$LF" "${cmda[@]}"
 fi
-run_it "$LF" "${cmda[@]}"
 
 log "======================================="
 log "Full longitudinal processing for $tid finished!"

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -419,7 +419,8 @@ if should_run_stage "template_surf"; then
           --sid "$tid" --sd "$sd"
           --surf_only --base --py "$python"
           "${POSITIONAL_FASTSURFER[@]}")
-  if [[ "$parallel" == "1" ]] ; then
+  # Only background template_surf when long_surf will also run (so it can wait for completion)
+  if [[ "$parallel" == "1" ]] && should_run_stage "long_surf"; then
     base_surf_cmdf="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf"
     base_surf_cmdf_log="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf.log"
     {
@@ -454,7 +455,8 @@ if should_run_stage "long_seg"; then
   cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --seg_only --long "$tid"
         "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
 
-  if [[ "$parallel" == "1" ]] ; then
+  # Only background long_seg when long_surf will also run (so it can wait for completion)
+  if [[ "$parallel" == "1" ]] && should_run_stage "long_surf"; then
     long_seg_cmdf="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf"
     long_seg_cmdf_log="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf.log"
     {

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -475,9 +475,6 @@ if should_run_stage "long_seg"; then
     log "Starting longitudinal segmentations, logs temporarily diverted to $long_seg_cmdf_log..."
     log "Output from this process will be delayed to when it has finished."
     log "======================================="
-    # at the end of the job below, the gpu can be released (for tight management of resources, run
-    # Surfaces in different jobs. Alternative, add a command to "$long_seg_cmdf" that releases the gpu or
-    # triggers the next "subject"
     #TQDM_DISABLE=1
     bash "$long_seg_cmdf" >> "$long_seg_cmdf_log" 2>&1 &
     long_seg_pid=$!

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -246,42 +246,34 @@ function should_run_stage() {
 function check_stage_dependencies() {
   # Check 'prepare' stage outputs once if any dependent stage needs it and prepare won't run
   if ! should_run_stage "prepare"; then
-    for stage in "${run_stages[@]}"; do
-      case $stage in
-        template_seg|template_surf|long_seg|long_surf)
-          # Basic checks: template directory and files from 'prepare'
-          if [[ ! -d "$sd/$tid" ]] || [[ ! -f "$sd/$tid/mri/orig.mgz" ]]; then
-            echo "ERROR: Stage '$stage' requires 'prepare' to have been run first."
-            echo "  Template directory $sd/$tid or $sd/$tid/mri/orig.mgz not found."
-            exit 1
-          fi
-          # Additional check: template must be fully prepared for --base/--long runs
-          if [[ ! -f "$sd/$tid/base-tps.fastsurfer" ]]; then
-            echo "ERROR: Stage '$stage' requires 'prepare' to have been fully completed."
-            echo "  Template indicator file $sd/$tid/base-tps.fastsurfer not found."
-            exit 1
-          fi
-          # Long stages additionally require long-inputs for all time points
-          if [[ "$stage" == "long_seg" || "$stage" == "long_surf" ]]; then
-            missing_long_inputs=()
-            for tpid in "${tpids[@]}"; do
-              if [[ ! -f "$sd/$tid/long-inputs/$tpid/long_conform.nii.gz" ]]; then
-                missing_long_inputs+=("$tpid")
-              fi
-            done
-            if [[ ${#missing_long_inputs[@]} -gt 0 ]]; then
-              echo "ERROR: Stage '$stage' requires 'prepare' long-inputs for ALL time points."
-              echo "  Missing long-inputs for: ${missing_long_inputs[*]}"
-              exit 1
-            fi
-          fi
-          # Only check once, then break
-          break
-          ;;
-      esac
-    done
+    # Basic checks: template directory and files from 'prepare'
+    if [[ ! -d "$sd/$tid" ]] || [[ ! -f "$sd/$tid/mri/orig.mgz" ]]; then
+      echo "ERROR: Stages require 'prepare' to have been run first."
+      echo "  Template directory $sd/$tid or $sd/$tid/mri/orig.mgz not found."
+      exit 1
+    fi
+    # Additional check: template must be fully prepared for --base/--long runs
+    if [[ ! -f "$sd/$tid/base-tps.fastsurfer" ]]; then
+      echo "ERROR: Stages require 'prepare' to have been fully completed."
+      echo "  Template indicator file $sd/$tid/base-tps.fastsurfer not found."
+      exit 1
+    fi
+    # Long stages additionally require long-inputs for all time points
+    if should_run_stage "long_seg" || should_run_stage "long_surf"; then
+      missing_long_inputs=()
+      for tpid in "${tpids[@]}"; do
+        if [[ ! -f "$sd/$tid/long-inputs/$tpid/long_conform.nii.gz" ]]; then
+          missing_long_inputs+=("$tpid")
+        fi
+      done
+      if [[ ${#missing_long_inputs[@]} -gt 0 ]]; then
+        echo "ERROR: Long stages require 'prepare' long-inputs for ALL time points."
+        echo "  Missing long-inputs for: ${missing_long_inputs[*]}"
+        exit 1
+      fi
+    fi
   fi
-
+  # Here template_seg and long_seg are fine to run
   # Check other stage dependencies
   for stage in "${run_stages[@]}"; do
     case $stage in
@@ -295,13 +287,6 @@ function check_stage_dependencies() {
         fi
         ;;
       long_surf)
-        # Only check for 'template_seg' outputs if 'template_seg' is NOT going to run
-        if ! should_run_stage "template_seg"; then
-          if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
-            echo "ERROR: Stage 'long_surf' requires 'template_seg' to have been run first."
-            exit 1
-          fi
-        fi
         # Only check for 'template_surf' outputs if 'template_surf' is NOT going to run
         if ! should_run_stage "template_surf"; then
           if [[ ! -f "$sd/$tid/surf/lh.white" ]]; then

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -237,65 +237,85 @@ function should_run_stage() {
 
 # Function to validate stage dependencies
 function check_stage_dependencies() {
+  # Check 'prepare' stage outputs once if any dependent stage needs it and prepare won't run
+  if ! should_run_stage "prepare"; then
+    for stage in "${run_stages[@]}"; do
+      case $stage in
+        template_seg|template_surf|long_seg|long_surf)
+          # Basic checks: template directory and files from 'prepare'
+          if [[ ! -d "$sd/$tid" ]] || [[ ! -f "$sd/$tid/mri/orig.mgz" ]]; then
+            echo "ERROR: Stage '$stage' requires 'prepare' to have been run first."
+            echo "  Template directory $sd/$tid or $sd/$tid/mri/orig.mgz not found."
+            exit 1
+          fi
+          # Additional check: template must be fully prepared for --base/--long runs
+          if [[ ! -f "$sd/$tid/base-tps.fastsurfer" ]]; then
+            echo "ERROR: Stage '$stage' requires 'prepare' to have been fully completed."
+            echo "  Template indicator file $sd/$tid/base-tps.fastsurfer not found."
+            exit 1
+          fi
+          # Long stages additionally require long-inputs for all time points
+          if [[ "$stage" == "long_seg" || "$stage" == "long_surf" ]]; then
+            missing_long_inputs=()
+            for tpid in "${tpids[@]}"; do
+              if [[ ! -f "$sd/long-inputs/$tpid/long_conform.nii.gz" ]]; then
+                missing_long_inputs+=("$tpid")
+              fi
+            done
+            if [[ ${#missing_long_inputs[@]} -gt 0 ]]; then
+              echo "ERROR: Stage '$stage' requires 'prepare' long-inputs for ALL time points."
+              echo "  Missing long-inputs for: ${missing_long_inputs[*]}"
+              exit 1
+            fi
+          fi
+          # Only check once, then break
+          break
+          ;;
+      esac
+    done
+  fi
+
+  # Check other stage dependencies
   for stage in "${run_stages[@]}"; do
     case $stage in
-      template_seg|template_surf|long_seg|long_surf)
-        # Basic check: template directory and orig.mgz from 'prepare'
-        if [[ ! -d "$sd/$tid" ]] || [[ ! -f "$sd/$tid/mri/orig.mgz" ]]; then
-          echo "ERROR: Stage '$stage' requires 'prepare' to have been run first."
-          echo "  Template directory $sd/$tid or $sd/$tid/mri/orig.mgz not found."
-          exit 1
-        fi
-        # Additional check: template must be fully prepared for --base/--long runs
-        if [[ ! -f "$sd/$tid/base-tps.fastsurfer" ]]; then
-          echo "ERROR: Stage '$stage' requires 'prepare' to have been fully completed."
-          echo "  Template indicator file $sd/$tid/base-tps.fastsurfer not found."
-          exit 1
-        fi
-        # Long stages additionally require long-inputs for all time points
-        if [[ "$stage" == "long_seg" || "$stage" == "long_surf" ]]; then
-          missing_long_inputs=()
-          for tpid in "${tpids[@]}"; do
-            if [[ ! -f "$sd/long-inputs/$tpid/long_conform.nii.gz" ]]; then
-              missing_long_inputs+=("$tpid")
-            fi
-          done
-          if [[ ${#missing_long_inputs[@]} -gt 0 ]]; then
-            echo "ERROR: Stage '$stage' requires 'prepare' long-inputs for ALL time points."
-            echo "  Missing long-inputs for: ${missing_long_inputs[*]}"
+      template_surf)
+        # Only check for 'template_seg' outputs if 'template_seg' is NOT going to run
+        if ! should_run_stage "template_seg"; then
+          if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
+            echo "ERROR: Stage 'template_surf' requires 'template_seg' to have been run first."
             exit 1
           fi
         fi
         ;;
-    esac
-
-    case $stage in
-      template_surf)
-        if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
-          echo "ERROR: Stage 'template_surf' requires 'template_seg' to have been run first."
-          exit 1
-        fi
-        ;;
       long_surf)
-        if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
-          echo "ERROR: Stage 'long_surf' requires 'template_seg' to have been run first."
-          exit 1
-        fi
-        if [[ ! -f "$sd/$tid/surf/lh.white" ]]; then
-          echo "ERROR: Stage 'long_surf' requires 'template_surf' to have been run first."
-          exit 1
-        fi
-        # Check that ALL time points have completed long_seg
-        missing_long_seg=()
-        for tpid in "${tpids[@]}"; do
-          if [[ ! -f "$sd/$tpid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
-            missing_long_seg+=("$tpid")
+        # Only check for 'template_seg' outputs if 'template_seg' is NOT going to run
+        if ! should_run_stage "template_seg"; then
+          if [[ ! -f "$sd/$tid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
+            echo "ERROR: Stage 'long_surf' requires 'template_seg' to have been run first."
+            exit 1
           fi
-        done
-        if [[ ${#missing_long_seg[@]} -gt 0 ]]; then
-          echo "ERROR: Stage 'long_surf' requires 'long_seg' to have been run first for ALL time points."
-          echo "  Missing segmentation for: ${missing_long_seg[*]}"
-          exit 1
+        fi
+        # Only check for 'template_surf' outputs if 'template_surf' is NOT going to run
+        if ! should_run_stage "template_surf"; then
+          if [[ ! -f "$sd/$tid/surf/lh.white" ]]; then
+            echo "ERROR: Stage 'long_surf' requires 'template_surf' to have been run first."
+            exit 1
+          fi
+        fi
+        # Only check for 'long_seg' outputs if 'long_seg' is NOT going to run
+        if ! should_run_stage "long_seg"; then
+          # Check that ALL time points have completed long_seg
+          missing_long_seg=()
+          for tpid in "${tpids[@]}"; do
+            if [[ ! -f "$sd/$tpid/mri/aparc.DKTatlas+aseg.deep.mgz" ]]; then
+              missing_long_seg+=("$tpid")
+            fi
+          done
+          if [[ ${#missing_long_seg[@]} -gt 0 ]]; then
+            echo "ERROR: Stage 'long_surf' requires 'long_seg' to have been run first for ALL time points."
+            echo "  Missing segmentation for: ${missing_long_seg[*]}"
+            exit 1
+          fi
         fi
         ;;
     esac

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -54,7 +54,7 @@ tid=""
 sd="$SUBJECTS_DIR"
 tpids=()
 t1s=()
-parallel=0
+parallel="false"
 LF=""
 brun_flags=()
 python="python3 -s" # avoid user-directory package inclusion
@@ -62,6 +62,7 @@ python="python3 -s" # avoid user-directory package inclusion
 # Stage control
 run_stages=("prepare" "template_seg" "template_surf" "long_seg" "long_surf")
 valid_stages=("prepare" "template_seg" "template_surf" "long_seg" "long_surf" "all")
+stage_specified="false"  # Track if user has specified any --stage flags
 
 
 function usage()
@@ -169,16 +170,22 @@ case $key in
   --tid) tid="$1" ; shift ;;
   --log) LF="$1" ; shift ;;
   --stage)
-    # Clear default if first --stage flag
-    if [[ ${#run_stages[@]} -eq 5 ]]; then run_stages=(); fi
     stage=$(echo "$1" | tr '[:upper:]' '[:lower:]')
     if [[ ! " ${valid_stages[*]} " =~ " ${stage} " ]]; then
       echo "ERROR: Invalid stage '$1'. Valid stages: ${valid_stages[*]}"
       exit 1
     fi
+
+    # Handle 'all' as a reset - clear any previous stages and set all stages
     if [[ "$stage" == "all" ]]; then
       run_stages=("prepare" "template_seg" "template_surf" "long_seg" "long_surf")
+      stage_specified="true"
     else
+      # Clear default stages only on first --stage flag (when stage_specified is "false")
+      if [[ "$stage_specified" == "false" ]]; then
+        run_stages=()
+        stage_specified="true"
+      fi
       run_stages+=("$stage")
     fi
     shift
@@ -198,7 +205,7 @@ case $key in
     done
     ;;
   --sd) sd="$1" ; export SUBJECTS_DIR="$1" ; shift  ;;
-  --parallel|--parallel_seg|--parallel_surf) parallel=1 ; brun_flags+=("$key" "$1") ; shift ;;
+  --parallel|--parallel_seg|--parallel_surf) parallel="true" ; brun_flags+=("$key" "$1") ; shift ;;
   --py) python="$1" ; shift ;;
   -h|--help) usage ; exit ;;
   --remove_suffix) echo "ERROR: The --remove_suffix option is not supported by long_prepare_template.sh" ; exit 1 ;;
@@ -420,7 +427,7 @@ if should_run_stage "template_surf"; then
           --surf_only --base --py "$python"
           "${POSITIONAL_FASTSURFER[@]}")
   # Only background template_surf when long_surf will also run (so it can wait for completion)
-  if [[ "$parallel" == "1" ]] && should_run_stage "long_surf"; then
+  if [[ "$parallel" == "true" ]] && should_run_stage "long_surf"; then
     base_surf_cmdf="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf"
     base_surf_cmdf_log="$SUBJECTS_DIR/$tid/scripts/base_surf.cmdf.log"
     {
@@ -456,7 +463,7 @@ if should_run_stage "long_seg"; then
         "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
 
   # Only background long_seg when long_surf will also run (so it can wait for completion)
-  if [[ "$parallel" == "1" ]] && should_run_stage "long_surf"; then
+  if [[ "$parallel" == "true" ]] && should_run_stage "long_surf"; then
     long_seg_cmdf="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf"
     long_seg_cmdf_log="$SUBJECTS_DIR/$tid/scripts/long_seg.cmdf.log"
     {
@@ -486,7 +493,7 @@ fi
 if should_run_stage "long_surf"; then
   cmda=("$FASTSURFER_HOME/brun_fastsurfer.sh" --subjects "${time_points[@]}" --sd "$sd" --surf_only --long "$tid"
         "${brun_flags[@]}" "${POSITIONAL_FASTSURFER[@]}")
-  if [[ "$parallel" == "1" ]] ; then
+  if [[ "$parallel" == "true" ]] ; then
     # Append the template surface and longitudinal segmentation logs, exit if either failed
     what_failed=()
     log "======================================="

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -240,10 +240,31 @@ function check_stage_dependencies() {
   for stage in "${run_stages[@]}"; do
     case $stage in
       template_seg|template_surf|long_seg|long_surf)
+        # Basic check: template directory and orig.mgz from 'prepare'
         if [[ ! -d "$sd/$tid" ]] || [[ ! -f "$sd/$tid/mri/orig.mgz" ]]; then
           echo "ERROR: Stage '$stage' requires 'prepare' to have been run first."
           echo "  Template directory $sd/$tid or $sd/$tid/mri/orig.mgz not found."
           exit 1
+        fi
+        # Additional check: template must be fully prepared for --base/--long runs
+        if [[ ! -f "$sd/$tid/base-tps.fastsurfer" ]]; then
+          echo "ERROR: Stage '$stage' requires 'prepare' to have been fully completed."
+          echo "  Template indicator file $sd/$tid/base-tps.fastsurfer not found."
+          exit 1
+        fi
+        # Long stages additionally require long-inputs for all time points
+        if [[ "$stage" == "long_seg" || "$stage" == "long_surf" ]]; then
+          missing_long_inputs=()
+          for tpid in "${tpids[@]}"; do
+            if [[ ! -f "$sd/long-inputs/$tpid/long_conform.nii.gz" ]]; then
+              missing_long_inputs+=("$tpid")
+            fi
+          done
+          if [[ ${#missing_long_inputs[@]} -gt 0 ]]; then
+            echo "ERROR: Stage '$stage' requires 'prepare' long-inputs for ALL time points."
+            echo "  Missing long-inputs for: ${missing_long_inputs[*]}"
+            exit 1
+          fi
         fi
         ;;
     esac

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -541,4 +541,5 @@ if should_run_stage "long_surf"; then
 fi
 
 log "======================================="
-log "Full longitudinal processing for $tid finished!"
+if should_run_stage "long_surf"; then what="Full"; else what="Stage(s) ${run_stages[*]}"; fi
+log "$what longitudinal processing for $tid finished!"

--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -265,7 +265,7 @@ function check_stage_dependencies() {
           if [[ "$stage" == "long_seg" || "$stage" == "long_surf" ]]; then
             missing_long_inputs=()
             for tpid in "${tpids[@]}"; do
-              if [[ ! -f "$sd/long-inputs/$tpid/long_conform.nii.gz" ]]; then
+              if [[ ! -f "$sd/$tid/long-inputs/$tpid/long_conform.nii.gz" ]]; then
                 missing_long_inputs+=("$tpid")
               fi
             done


### PR DESCRIPTION
Enhancement requested #780 

## Summary

Adds stage-based execution to `long_fastsurfer.sh`, allowing users to run individual pipeline stages independently for flexible resource allocation across compute nodes with varying GPU/CPU capabilities.

## Changes

- Added `--stage` flag to select which stages to run: `prepare`, `template_seg`, `template_surf`, `long_seg`, `long_surf`, or `all` (default)
- Automatic dependency validation ensures required stages have completed before running dependent stages
- Smart input validation: only requires `--t1s` when running `prepare` stage
- Backward compatible: default behavior unchanged (runs all stages)

## Usage

```bash
# Run full pipeline (default, unchanged)
./long_fastsurfer.sh --tid template01 --t1s tp1.mgz tp2.mgz --tpids tp1 tp2

# Run individual stage
./long_fastsurfer.sh --tid template01 --tpids tp1 tp2 --stage template_seg

# Run multiple stages
./long_fastsurfer.sh --tid template01 --tpids tp1 tp2 --stage template_surf --stage long_surf
```

## Benefits

- **Resource optimization**: Send GPU stages to GPU nodes, CPU stages to CPU nodes
- **Restart capability**: Re-run individual stages without reprocessing completed ones
- **Better cluster scheduling**: Split heavy jobs into smaller, faster-to-schedule jobs
