### PR TITLE
Remove corpus callosum processing from surface pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Modules (all run by default):
    - outputs a hypothalamic subsegmentation including 3rd ventricle, c. mammilare, fornix and optic tracts.
    - a T1w image is highly recommended ([notes on input images](#requirements-to-input-images)), supports high-res (up to 0.7mm, but experimental beyond that).
    - allows the additional passing of a T2w image with `--t2 <path>`, which will be registered to the T1w image (see `--reg_mode` option).
-   - calculates volume statistics corrected for partial volume effects based on the T1w image (skipped if `--no_bias_field` is passed).
+   - calculates volume statistics corrected for partial volume effects based on the T1w image (skipped if `--no_biasfield` is passed).
 
 ### Surface reconstruction
 - approximately 60-90 minutes, `--surf_only` runs only [the surface part](recon_surf/README.md).
 - supports high-resolution images (up to 0.7mm, experimental beyond that).
 - requires a FreeSurfer license file as it uses some FreeSurfer binaries internally.
+- requires outputs of the `asegdkt` and the `cc` modules as a prerequisite (can be included in the same run).
 
 <!-- start of image requirements -->
 ### Requirements to input images

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -161,17 +161,21 @@ case $key in
   --tid) tid="$1" ; shift ;;
   --tpids) while [[ $# -gt 0 ]] && [[ $1 != -* ]] ; do tpids+=("$1") ; shift ; done ;;
   --t1s) while [[ $# -gt 0 ]] && [[ $1 != -* ]] ; do t1s+=("$1") ; shift ; done ;;
-  --sd) sd="$1" ; export SUBJECTS_DIR="$1" ; shift  ;;
+  --sd) export SUBJECTS_DIR="$1" ; shift  ;;
   # these flags are passed through to run_prediction.py
   --vox_size|--device|--viewagg_device|--conform_to_1mm_threshold) run_pred_flags+=("$key" "$1") ; shift ;;
   --threads|--threads_seg) run_pred_flags+=("--threads" "$1") ; shift ;;
   --batch) run_pred_flags+=("--batch_size" "$1") ; shift ;;
   # these known arguments get ignored
   --aseg_name|--conformed_name|--asegdkt_segfile|--brainmask_name|--seg_log|--qc_log|--parallel|--threads_surf) shift ;;
-  --no_cereb|--no_hypothal|--no_biasfield|--3t) shift ;;
-  --async_io) ;;
+  --norm_name|--reg_mode|--cereb_segfile) shift ;;
+  # no additional argument
+  --no_cc|--no_cereb|--no_hypothal|--no_biasfield|--3t|--edits|--async_io|--tal_reg|--allow_root|--qc_snap) ;;
   --fs_license) export FS_LICENSE="$1" ; shift ;;
-  --remove_suffix) echo "ERROR: The --remove_suffix option is not supported by long_prepare_template.sh" ; exit 1 ;;
+  --remove_suffix|--keepgeom|--native_image|--t2)
+    echo "ERROR: The $key option is not supported by long_prepare_template.sh"
+    exit 1
+    ;;
   -h|--help) usage ; exit ;;
   --py) python="$1" ; shift ;;
   *)    # unknown options also get ignored, but also print warnings

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -338,6 +338,18 @@ then
   exit 1
 fi
 
+# Check if the required aseg_auto file from the segmentation pipeline exists, which includes the corpus callosum
+# segmentation and is needed for the surface pipeline.
+aseg_auto="aseg.auto.mgz"
+if [[ ! -e "$SUBJECTS_DIR/$subject/mri/$aseg_auto" ]]
+then
+  echo "ERROR: The surface pipeline requires that the aseg segmentation including the corpus callosum is performed as"
+  echo "  a prerequisite. The corpus callosum segmentation and the transfer of the corpus callosum into the aseg"
+  echo "  is performed in FastSurfer's segmentation pipeline. However, \$SUBJECTS_DIR/\$SID/mri/$aseg_auto"
+  echo "  is missing. Please re-run FastSurfer's segmentation pipeline without the --no_asegdkt and --no_cc options."
+  exit 1
+fi
+
 # Check if running on an existing subject directory
 if [[ -f "$SUBJECTS_DIR/$subject/mri/wm.mgz" ]] || [[ -f "$SUBJECTS_DIR/$subject/mri/aparc.DKTatlas+aseg.orig.mgz" ]]
 then
@@ -615,55 +627,6 @@ else
   popd > /dev/null || (echo "Could not popd" ; exit 1 )
 fi
 
-
-# ============================= CC SEGMENTATION ============================================
-
-# here, we are only generating the "necessary" files for the pipeline to recon-surf pipeline to
-# complete, people should use the seg pipeline to get extended results.
-callosum_seg="callosum_seg_aseg_space.mgz"
-callosum_seg_manedit="$(add_file_suffix "$callosum_seg" "manedit")"
-aseg_auto="aseg.auto.mgz"
-CorpusCallosumDir="$FASTSURFER_HOME/CorpusCallosum"
-updated_cc_seg="false"
-if [[ ! -e "$mdir/$aseg_auto" ]] || [[ ! -e "$mdir/$callosum_seg" ]] || [[ "$edits" == "true" ]]
-then
-  {
-    echo " "
-    echo "============ Creating and adding CC Segmentation ============"
-    echo " "
-  } | tee -a "$LF"
-fi
-# here, in edits mode we also check, if the corpus callosum should be updated based on an updated aseg.nocc
-if [[ ! -e "$mdir/$callosum_seg" ]] || \
-  { [[ "$edits" == "true" ]] && [[ "$(date -r "$mdir/$aseg_nocc" "+%s")" -gt "$(date -r "$mdir/$callosum_seg" "+%s")" ]] ; }
-then
-  {
-    echo "Segmenting the corpus callosum, so mri/$aseg_nocc exists. If you are interested in detailed"
-    echo "  and extended analysis and statistics of the Corpus Callosum, use the corpus callosum pipeline"
-    echo "  of the segmentation pipeline (in run_fastsurfer.sh, i.e. run without --no_cc)."
-  }
-  updated_cc_seg="true"
-  # create aseg.auto including corpus callosum segmentation and 46 sec, requires norm.mgz
-  # Note: if original input segmentation already contains CC, this will exit with ERROR
-  # in the future maybe check and skip this step (and next)
-  cmda=($python "$CorpusCallosumDir/fastsurfer_cc.py" --sd "$SUBJECTS_DIR" --sid "$subject"
-        "--aseg_name" "$mdir/$aseg_nocc" "--segmentation_in_orig" "$mdir/$callosum_seg"
-        --threads "$threads"
-        # qc_snapshots are only defined by the seg_only pipeline
-        # limit the processing things to do here
-        --slice_selection "middle" --cc_measures "none" --cc_mid_measures "none" --surf "none"
-        --thickness_overlay "none")
-  run_it "$LF" "${cmda[@]}"
-fi
-# do not move below statement up, fastsurfer_cc.py uses the $callosum_seg variable
-if [[ "$edits" == "true" ]] && [[ -e "$mdir/$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
-cmd_paint_cc_into_pred=($python "$CorpusCallosumDir/paint_cc_into_pred.py" -in_cc "$mdir/$callosum_seg" -in_pred)
-if [[ ! -e "$mdir/$aseg_auto" ]] || [[ "$updated_cc_seg" == "true" ]]
-then
-  # add CC into aseg.auto.mgz as mri_cc did before. Not sure where this is used.
-  cmda=("${cmd_paint_cc_into_pred[@]}" "$mdir/$aseg_nocc" "-out" "$mdir/$aseg_auto")
-  run_it "$LF" "${cmda[@]}"
-fi
 # ============================= FILLED =====================================================
 
 {

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -170,7 +170,7 @@ SEGMENTATION PIPELINE:
                             \$SUBJECTS_DIR/\$sid/mri/orig.mgz.
   --no_biasfield          Create a bias field corrected image and enable the
                             calculation of partial volume-corrected stats-files.
-  --norm_name             Name of the biasfield corrected image
+  --norm_name <nu.mgz>    Name of the biasfield corrected image
                             Default location:
                             \$SUBJECTS_DIR/\$sid/mri/orig_nu.mgz
   --tal_reg               Perform the talairach registration for eTIV estimates
@@ -324,6 +324,12 @@ Faber J*, Kuegler D*, Bahrami E*, et al. (*co-first). CerebNet: A fast and
  reliable deep-learning pipeline for detailed cerebellum sub-segmentation.
  NeuroImage 264 (2022), 119703.
  https://doi.org/10.1016/j.neuroimage.2022.119703
+
+For corpus callosum segmentation and analysis:
+Pollak C, Diers K, Estrada S, Kuegler D, Reuter M, FastSurfer-CC: A robust,
+ accurate, and comprehensive framework for corpus callosum morphometry,
+ pre-print on arXiv:
+ https://doi.org/10.48550/arXiv.2511.16471
 
 For hypothalamus sub-segemntation:
 Estrada S, Kuegler D, Bahrami E, Xu P, Mousa D, Breteler MMB, Aziz NA, Reuter M.
@@ -1179,12 +1185,15 @@ then
          "--threads" "$threads_seg" "--conformed_name" "$conformed_name" "--aseg_name" "$asegdkt_segfile"
          "--segmentation_in_orig" "$callosum_seg" "${cc_flags[@]}")
     # if we are trying to create the thickness image in a headless setting, wrap call in xvfb-run
+    echo_quoted "${cmd[@]}" | tee -a "$seg_log"
+    "${wrap[@]}" "${cmd[@]}" 2>&1 | tee -a "$seg_log"
+    exit_code=${PIPESTATUS[0]}
+    if [[ "$exit_code" != 0 ]] ; then
+      echo "ERROR: FastSurferCC corpus callosum analysis failed!" | tee -a "$seg_log"
+      exit "$exit_code"
+    fi
+    if [[ "$edits" == "true" ]] && [[ -f "$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
     {
-      echo_quoted "${cmd[@]}"
-      "${wrap[@]}" "${cmd[@]}"
-      if [[ "${PIPESTATUS[0]}" != 0 ]] ; then echo "ERROR: FastSurferCC corpus callosum analysis failed!" ; exit 1 ; fi
-      if [[ "$edits" == "true" ]] && [[ -f "$callosum_seg_manedit" ]] ; then callosum_seg="$callosum_seg_manedit" ; fi
-
       # add CC into aparc.DKTatlas+aseg.deep.mgz and aseg.auto.mgz as mri_cc did before.
       cmd=($python "$CorpusCallosumDir/paint_cc_into_pred.py" -in_cc "$callosum_seg" -in_pred "$asegdkt_segfile"
            "-out" "$asegdkt_withcc_segfile" "-aseg" "$aseg_auto_segfile")
@@ -1219,14 +1228,15 @@ then
         )
         echo_quoted "${cmd[@]}"
         "${wrap[@]}" "${cmd[@]}"
-        if [[ "${PIPESTATUS[0]}" != 0 ]] ; then
-          echo "ERROR: asegdkt statsfile ($asegdkt_withcc_segfile) generation failed!" ; exit 1
+        exit_code=${PIPESTATUS[0]}
+        if [[ "$exit_code" != 0 ]] ; then
+          echo "ERROR: asegdkt statsfile ($asegdkt_withcc_segfile) generation failed!"
+          exit "$exit_code"
           # this will only terminate the subshell
         fi
       fi
     } 2>&1 | tee -a "$seg_log"
-    exit_code="${PIPESTATUS[0]}"
-    if [[ "$exit_code" != 0 ]]; then exit 1; fi # forward subshell exit to main script
+    if [[ "${PIPESTATUS[0]}" != 0 ]]; then exit "${PIPESTATUS[0]}"; fi # forward subshell exit to main script
 
     if [[ "$run_biasfield" == "true" ]]
     then


### PR DESCRIPTION
This PR changes where the corpus callosum is run. It is no longer run in the surface pipeline, but now only checked. The surface pipeline terminates with error if `mri/aseg.auto.mgz`, the aseg with CC inpainted, is missing.
The PR also includes some flag filtering and cleanup and minor documentation fixes.

Remove corpus callosum processing from recon-surf.sh
Make sure the corpus callosum_seg variable gets set in the main process not just the subshell.
Add Corpus Callosum Paper Reference to run_fastsurfer.sh help text.
Fix --norm_name help text in run_fastsurfer.sh
Add asegdkt and corpus callosum dependency of surface pipeline in README.md
Filter corpus callosum and other "unused" flags for long_prepare_template.sh