### PR TITLE
Fix bug in spherically project wrapper

### DIFF
--- a/FastSurferCNN/utils/run_tools.py
+++ b/FastSurferCNN/utils/run_tools.py
@@ -64,6 +64,35 @@ class MessageBuffer:
     def err_str(self, encoding="utf-8"):
         return self.err.decode(encoding=encoding)
 
+    def forward_output(
+        self,
+        file: io.TextIOBase | None = None,
+        encoding: str | None = None,
+        out_prefix: str = "",
+        err_prefix: str = "!",
+    ):
+        """
+        Forward the content of this MessageBuffer to a file or stream.
+
+        Parameters
+        ----------
+        file : IO.TextIO, optional
+            The file or stream to which the output should be forwarded (defaults to stdout).
+        encoding : str, optional
+            Charset to encode.
+        out_prefix : str, default=""
+            String to prefix lines from the stdout output.
+        err_prefix : str, default="!"
+            String to prefix lines from the stderr output.
+        """
+        if file is None:
+            from sys import stdout
+            file = stdout
+        for line in self.out_str(encoding=encoding).splitlines():
+            print(f"{out_prefix}{line}", file=file)
+        for line in self.err_str(encoding=encoding).splitlines():
+            print(f"{err_prefix}{line}", file=file)
+
 
 class Popen(subprocess.Popen):
     """
@@ -71,9 +100,9 @@ class Popen(subprocess.Popen):
     """
     _starttime: datetime | None = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, args, /, **kwargs):
         self._starttime = datetime.now()
-        super().__init__(*args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def messages(self, timeout: float) -> Generator[MessageBuffer, None, None]:
         """

--- a/FastSurferCNN/utils/run_tools.py
+++ b/FastSurferCNN/utils/run_tools.py
@@ -284,7 +284,7 @@ class Popen(subprocess.Popen):
 
 
 class PyPopen(Popen):
-    def __init__(self, args: Sequence[str], *_args, **kwargs):
+    def __init__(self, args: Sequence[str], /, **kwargs):
         """
         Create a python process with same flags, and additional args.
 
@@ -292,7 +292,7 @@ class PyPopen(Popen):
         ----------
         args : Sequence[str]
             Arguments to python process.
-        additional arguments as in subprocess.Popen
+        additional keyword arguments as in subprocess.Popen
 
         See Also
         --------
@@ -318,5 +318,5 @@ class PyPopen(Popen):
         flags = "".join(k for k, v in all_flags.items() if getattr(sys.flags, v) == 1)
         flags = [] if len(flags) == 0 else ["-" + flags]
         super().__init__(
-            [sys.executable] + flags + list(args), *_args, **kwargs
+            [sys.executable] + flags + list(args), **kwargs
         )

--- a/FastSurferCNN/utils/run_tools.py
+++ b/FastSurferCNN/utils/run_tools.py
@@ -67,7 +67,7 @@ class MessageBuffer:
     def forward_output(
         self,
         file: io.TextIOBase | None = None,
-        encoding: str | None = None,
+        encoding: str = "utf-8",
         out_prefix: str = "",
         err_prefix: str = "!",
     ):
@@ -78,7 +78,7 @@ class MessageBuffer:
         ----------
         file : IO.TextIO, optional
             The file or stream to which the output should be forwarded (defaults to stdout).
-        encoding : str, optional
+        encoding : str, default="utf-8"
             Charset to encode.
         out_prefix : str, default=""
             String to prefix lines from the stdout output.
@@ -245,7 +245,7 @@ class Popen(subprocess.Popen):
     def forward_output(
         self,
         file: io.TextIOBase | None = None,
-        encoding: str | None = None,
+        encoding: str = "utf-8",
         timeout: float | None = None,
         out_prefix: str = "",
         err_prefix: str = "!",
@@ -257,7 +257,7 @@ class Popen(subprocess.Popen):
         ----------
         file : IO.TextIO, optional
             The file or stream to which the output should be forwarded.
-        encoding : str, optional
+        encoding : str, default="utf-8"
             Charset to encode.
         timeout : float, optional
             Interval to let the child process, before returning to the parent (this) process.

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -775,7 +775,7 @@ for hemi in lh rh ; do
       RunIt "$cmd" "$LF" "$CMDF"
     else
       # instead of mris_sphere, directly project to sphere with spectral approach equivalent to -qsphere (23sec)
-      cmda=("${binpath}spherically_project_wrapper.py" --hemi "$hemi" --sdir "$SUBJECTS_DIR" --subject "$subject")
+      cmda=("${binpath}spherically_project_wrapper.py" --hemi "$hemi" --sd "$SUBJECTS_DIR" --subject "$subject")
       run_it_cmdf "$LF" "$CMDF" $python "${cmda[@]}" --threads "$threads_hemi"
     fi
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -775,7 +775,7 @@ for hemi in lh rh ; do
       RunIt "$cmd" "$LF" "$CMDF"
     else
       # instead of mris_sphere, directly project to sphere with spectral approach equivalent to -qsphere (23sec)
-      cmda=("${binpath}spherically_project_wrapper.py" --hemi "$hemi" --sdir "$sdir" --subject "$subject")
+      cmda=("${binpath}spherically_project_wrapper.py" --hemi "$hemi" --sdir "$SUBJECTS_DIR" --subject "$subject")
       run_it_cmdf "$LF" "$CMDF" $python "${cmda[@]}" --threads "$threads_hemi"
     fi
 

--- a/recon_surf/spherically_project_wrapper.py
+++ b/recon_surf/spherically_project_wrapper.py
@@ -27,13 +27,20 @@ def setup_options():
     options : argparse.Namespace
         Namespace object holding options.
     """
+    from os import environ
     # Validation settings
     parser = argparse.ArgumentParser(description="Wrapper for spherical projection")
 
-    parser.add_argument("--hemi", type=str, help="Hemisphere to analyze.")
-    parser.add_argument("--sd", type=Path, help="Subjects directory, $SUBJECT_DIR.")
-    parser.add_argument("--subject", type=str, help="Name (ID) of subject.")
-    parser.add_argument("--threads", type=int, help="Number of threads to use.")
+    parser.add_argument("--hemi", choices=("lh", "rh"), help="Hemisphere to analyze.", required=True)
+    parser.add_argument(
+        "--sd",
+        type=Path,
+        help="Subjects directory $SUBJECTS_DIR.",
+        default=Path(environ.get("SUBJECTS_DIR", Path.cwd())),
+        required="SUBJECTS_DIR" not in environ,
+    )
+    parser.add_argument("--subject", type=str, help="Name (ID) of subject.", required=True)
+    parser.add_argument("--threads", type=int, help="Number of threads to use.", default=1)
 
     args = parser.parse_args()
     return args

--- a/recon_surf/spherically_project_wrapper.py
+++ b/recon_surf/spherically_project_wrapper.py
@@ -31,7 +31,7 @@ def setup_options():
     parser = argparse.ArgumentParser(description="Wrapper for spherical projection")
 
     parser.add_argument("--hemi", type=str, help="Hemisphere to analyze.")
-    parser.add_argument("--sdir", type=Path, help="Surface directory of subject.")
+    parser.add_argument("--sd", type=Path, help="Subjects directory, $SUBJECT_DIR.")
     parser.add_argument("--subject", type=str, help="Name (ID) of subject.")
     parser.add_argument("--threads", type=int, help="Number of threads to use.")
 
@@ -56,8 +56,8 @@ if __name__ == "__main__":
 
         from recon_surf.spherically_project import spherically_project_surface
 
-        source_surface = opts.sdir / f"{opts.hemi}.smoothwm.nofix"
-        projected_surface = opts.sdir / f"{opts.hemi}.qsphere.nofix"
+        source_surface = opts.sd / opts.subject / "surf" / f"{opts.hemi}.smoothwm.nofix"
+        projected_surface = opts.sd / opts.subject / "surf" / f"{opts.hemi}.qsphere.nofix"
         print(f"Reading in surface: {source_surface} ...")
 
         # make sure the process has a username, so nibabel does not crash in write_geometry
@@ -88,6 +88,6 @@ if __name__ == "__main__":
             fallback += ("-threads", str(opts.threads), "-itkthreads", str(opts.threads))
 
         print(f"spherical_project.py failed.\nRunning fallback command: {' '.join(fallback)}")
-        process = Popen(fallback, env=dict(environ, SUBJECTS_DIR=str(opts.sdir)))
+        process = Popen(fallback, env=dict(environ, SUBJECTS_DIR=str(opts.sd)))
         done = process.forward_output(encoding="utf-8", timeout=None)
         sys.exit(done.retcode)


### PR DESCRIPTION
This PR fixes two bugs in the use of spherically_project_wrapper.py. Both of them only appear if the baseline python implementation fails.

1. the call to `spherically_project_wrapper.py` uses a `--sd` argument, but the value was previously passed as empty (the used variable did not exist).
2. There was a missing function in `MessageBuffer`: `forward_output`, which forwards stdout and stderr content through the wrapper to the python stdout. This function missing raised an error.

Additionally, the PR fixes a near-irrelevant signature-inconsistency between the `run_tools` extension of `Popen.__init__` and the underlying `subprocess.Popen.__init__`, where `subprocess.Popen` only accepts one positional parameter, but `run_tools.Popen` accepted multiple ... only to then pass that to `subprocess.Popen`, where it would be invalid.

Todo:
- ~~test in bigger dataset to cover both spherically project implementations~~