### PR TITLE
Add missing '[@]' to function `RunBatchJobs`

### DIFF
--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -161,7 +161,7 @@ function RunBatchJobs()
 
   # wait till all processes have finished
   local unsuccessful=()
-  for i in $(seq "${#PIDS}")
+  for i in $(seq "${#PIDS[@]}")
   do
     echo "Waiting for PID ${PIDS[i-1]} of (${PIDS[*]}) to complete..."
     wait "${PIDS[i-1]}"


### PR DESCRIPTION
This PR fixes a typo made in #777 that meant large number PIDS caused errors in processing.

Fix missing '[@]' in function `RunBatchJobs` in `recon_surf/functions.sh`.