### PR TITLE
Update pre-commit script and GitHub workflows to use uv

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -2,6 +2,8 @@
 # selected branch and crates a docker image in an artifact (fastsurfer-<github-sha>-docker)
 # The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
 
+# This action requires an existing uv installation!
+
 name: 'Build a FastSurfer docker image'
 author: 'David Kuegler'
 description: 'Build a FastSurfer image'
@@ -53,8 +55,8 @@ runs:
           v="$(bash $bashopts "$FASTSURFER_HOME/run_fastsurfer.sh" --version --py python)"
           image_name="fastsurfer:cpu-${v/+/_}"
         fi
-        if [[ -z "$(which python)" ]] ; then echo "ERROR: Cannot find python!" ; fi
-        cmd=(python "$FASTSURFER_HOME/tools/Docker/build.py" --device cpu --tag "$image_name" --target "${{ inputs.target }}")
+        if [[ -z "$(uv run python -c 'import sys; print(sys.executable)' 2>/dev/null)" ]] ; then echo "ERROR: Cannot find python!" ; fi
+        cmd=(uv run python "$FASTSURFER_HOME/tools/Docker/build.py" --device cpu --tag "$image_name" --target "${{ inputs.target }}")
         if [[ "${{ inputs.freesurfer-build-image }}" != "rebuild" ]] ; then 
           cmd+=(--freesurfer_build_image "${{ inputs.freesurfer-build-image }}")
         fi

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -33,19 +33,10 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v5
+    - name: Setup uv and Python 3.10
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: '3.10'
-        architecture: 'x64'
-        cache: 'pip' # caching pip dependencies
-    - name: Install dependencies
-      shell: bash
-      run: |
-        echo "::group::Create python environment"
-        python -m pip install --progress-bar off --upgrade pip setuptools wheel
-        python -m pip install --progress-bar off .[quicktest]
-        echo "::endgroup::"
     - name: Download and unpack reference data
       shell: bash
       env:
@@ -78,7 +69,7 @@ runs:
         then 
           flags+=(-vv --log_cli_level=DEBUG)
         fi
-        python -m pytest "${flags[@]}" test/quicktest
+        uv run --extra quicktest python -m pytest "${flags[@]}" test/quicktest
         echo "::endgroup::"
     - name: Upload the the JUnit XML file as an artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/QUICKTEST.md
+++ b/.github/workflows/QUICKTEST.md
@@ -14,7 +14,7 @@ This job checks out the repository using the `actions/checkout@v2` action.
 ### Prepare Job
 This job sets up the necessary environments for the workflow. It depends on the successful completion of the `checkout` job. The environments set up in this job include:
 
-- Python 3.10, using the `actions/setup-python@v3` action.
+- Python 3.10, using the `astral-sh/setup-uv@v5` action.
 - Go, using the `actions/setup-go@v5` action with version `1.13.1`.
 - Singularity, using the `eWaterCycle/setup-singularity@v7` action with version `3.8.3`.
 

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -15,25 +15,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Python 3.10
-        uses: actions/setup-python@v5
+        with:
+          path: 'src'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.10'
-          architecture: 'x64'
-          cache: 'pip' # caching pip dependencies
-      - name: Install dependencies
-        run: |
-          python -m pip install --progress-bar off --upgrade pip setuptools wheel
-          python -m pip install --progress-bar off .[style]
       - name: Run Ruff
-        run: ruff check .
+        run: uv run --project src --extra style ruff check src
       - name: Run codespell
         uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
           check_hidden: true
-          skip: './build,./doc/images,./Tutorial,./.git,./.mypy_cache,./.pytest_cache'
-          ignore_words_file: ./.codespellignore
+          skip: 'src/build,src/doc/images,src/Tutorial,src/.git,src/.mypy_cache,src/.pytest_cache,src/.venv'
+          ignore_words_file: src/.codespellignore
+          path: 'src'
 #      - name: Run pydocstyle
 #        run: pydocstyle .
 #      - name: Run bibclean

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up python environment
-        uses: actions/setup-python@v6
+        id: setup-uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.10'
       - name: install dependencies
         run: |
-          python -m pip install py2app tomli
+          uv venv .venv
+          uv pip install py2app tomli
           
           # update system to the newest version, not pin pointing package version on purpose
           brew update  

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,22 +22,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: src
-      - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.12'
-          architecture: 'x64'
-          cache: 'pip' # caching pip dependencies
-      - name: Install package
-        run: |
-          python -m pip install --progress-bar off --upgrade pip setuptools wheel
-          python -m pip install --progress-bar off src/.[doc]
       - name: Build doc
         env:
           PYTHONPATH: ${{ env.PYTHONPATH != '' && format( '{1}:src', env.PYTHONPATH ) || 'src' }}
           TZ: UTC
         run: |
-          sphinx-build -WT --keep-going -j auto src/doc doc-build
+          uv run --project src --extra doc sphinx-build -WT --keep-going -j auto src/doc doc-build
       - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -139,14 +139,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.parse.outputs.DOCKER_IMAGE }}
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+      - name: Setup uv and Python 3.11
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.11'
           # python 3.11 is needed to read pyproject.toml (tomllib)
-          architecture: 'x64'
-          # no cache is needed, no installations and no cache is faster
-          # cache: 'pip' # caching pip dependencies
       - name: Get the FreeSurfer version
         # we want to build the docker image, get what we want to do for freesurfer (read fslink from install_pruned.sh,
         if: steps.parse.outputs.CONTINUE == 'true' && (steps.parse.outputs.DOCKER_IMAGE == 'build-cached' || startsWith(steps.parse.outputs.DOCKER_IMAGE, 'pr/'))
@@ -155,7 +152,7 @@ jobs:
         run: |
           # get the FreeSurfer version from pyproject.toml
           {
-            fs_version="$(python ./tools/read_toml.py --file ./pyproject.toml --key tool.freesurfer.version)"
+            fs_version="$(uv run python ./tools/read_toml.py --file ./pyproject.toml --key tool.freesurfer.version)"
             fs_version_short="${fs_version//\./}"
             echo "FS_VERSION=$fs_version"
             echo "FS_VERSION_SHORT=$fs_version_short"

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -59,6 +59,14 @@ else
 	uv run --extra style codespell --check-filenames --check-hidden --context 3 \
 	  --skip "$skip_files" --ignore-words ./.codespellignore
 
+  # if this is a valid git repository and the doc/api/generated or doc-build folder exists, clean them before sphinx-doc
+  if [[ -d ".git" ]] && [[ -n "$(which git)" ]] && git --git-dir=.git branch --show-current 2>/dev/null >/dev/null \
+     && { [[ -d "doc/api/generated" ]] || [[ -d "doc-build" ]]; }
+  then
+    echo "INFO: pre-commit hook: cleaning doc/api/generated and doc-build folder"
+    if [[ -d "doc/api/generated" ]] ; then rm -rf doc/api/generated/* ; fi
+    if [[ -d "doc-build" ]] ; then rm -rf doc/api/generated/* doc-build/* ; fi
+  fi
 	echo "INFO: pre-commit hook: Build sphinx-doc"
 	uv run --extra doc sphinx-build -j auto -WT --keep-going doc ./doc-build
 fi


### PR DESCRIPTION
This pull request updates the CI/CD workflows and supporting scripts to consistently use the `uv` Python package manager and the `astral-sh/setup-uv` GitHub Action for Python environment management, replacing previous usage of `pip` and `actions/setup-python`. Additionally, the pre-commit hook now cleans documentation build folders before running Sphinx, preventing stale files from affecting documentation builds. (`tools/git-hooks/pre-commit`)