### PR TITLE
CC midplane refinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /tools/Docker/custom-ssl.crt
 /.idea/**
 /rough_work/**
+/scripts/**
 /doc-build/**
 
 # Byte-compiled / optimized / DLL files

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -110,7 +110,7 @@ class ArgumentDefaultsHelpFormatter(HelpFormatter):
         """
         help = action.help
         if help is None:
-            help = ''
+            help = ""
 
         if "%(default)" not in help and not getattr(action, "required", False):
             if action.default is not argparse.SUPPRESS and not getattr(action.default, "DO_NOT_PRINT_DEFAULT", False):
@@ -154,33 +154,31 @@ def make_parser() -> argparse.ArgumentParser:
 
     def _set_help_sid(action):
         action.help = "The subject id to use."
+
     modify_argument(parser, "--sid", _set_help_sid)
 
     parser.add_argument(
-        "--num_thickness_points",
-        type=int,
-        default=100,
-        help="Number of points for thickness estimation."
+        "--num_thickness_points", type=int, default=100, help="Number of points for thickness estimation."
     )
     parser.add_argument(
         "--subdivisions",
         type=float,
-        nargs='*',
+        nargs="*",
         metavar="FRAC",
         default=_FixFloatFormattingList([1 / 6, 1 / 2, 2 / 3, 3 / 4], ".3f"),
         help="List of subdivision fractions for the corpus callosum subsegmentation."
-          "The method allows for an arbitrary number of fractions."
-          "By default it uses following Hofer-Frahms convention."
+        "The method allows for an arbitrary number of fractions."
+        "By default it uses following Hofer-Frahms convention.",
     )
     parser.add_argument(
         "--subdivision_method",
         default=_do_not_print("shape"),
         help="Method for contour subdivision. Options: <br>"
-             "- shape (default): Intercallosal subdivision perpendicular to intercallosal line, <br>"
-             "- vertical: orthogonal to the most anterior and posterior points in the AC/PC standardized CC contour, "
-             "<br>"
-             "- angular: subdivision based on equally spaced angles, as proposed by Hampel and colleagues, <br>"
-             "- eigenvector: primary direction, same as FreeSurfers mri_cc.",
+        "- shape (default): Intercallosal subdivision perpendicular to intercallosal line, <br>"
+        "- vertical: orthogonal to the most anterior and posterior points in the AC/PC standardized CC contour, "
+        "<br>"
+        "- angular: subdivision based on equally spaced angles, as proposed by Hampel and colleagues, <br>"
+        "- eigenvector: primary direction, same as FreeSurfers mri_cc.",
         choices=["shape", "vertical", "angular", "eigenvector"],
     )
     parser.add_argument(
@@ -188,12 +186,14 @@ def make_parser() -> argparse.ArgumentParser:
         type=int,
         default=5,
         help="Gaussian sigma for smoothing during contour detection. Higher values mean a smoother CC outline, at the "
-             "cost of precision.",
+        "cost of precision.",
     )
+
     def _slice_selection(a: str) -> SliceSelection:
         if (b := a.lower()) in ("middle", "all"):
             return b
         return int(a)
+
     parser.add_argument(
         "--slice_selection",
         type=_slice_selection,
@@ -206,11 +206,12 @@ def make_parser() -> argparse.ArgumentParser:
     advanced = parser.add_argument_group(
         title="Advanced options",
         description="Custom output paths, useful if no standard case directory is used. Relative paths are always "
-                    "relative to the subject_dir defined via --sd and --sid!",
+        "relative to the subject_dir defined via --sd and --sid!",
     )
     add_arguments(advanced, ["threads"])
     advanced.add_argument(
-        "--segmentation", "--seg",
+        "--segmentation",
+        "--seg",
         type=path_or_none,
         help="Output path for corpus callosum and fornix segmentation output.",
         default=Path(DEFAULT_OUTPUT_PATHS["segmentation"]),
@@ -237,7 +238,7 @@ def make_parser() -> argparse.ArgumentParser:
         "--upright_lta",
         type=path_or_none,
         help="Output path for upright LTA transform. This makes sure the midplane is at 128 in LR direction, "
-             "but no nodding correction is applied.",
+        "but no nodding correction is applied.",
         default=DEFAULT_OUTPUT_PATHS["upright_lta"],
     )
     advanced.add_argument(
@@ -250,8 +251,8 @@ def make_parser() -> argparse.ArgumentParser:
         "--orient_volume_lta",
         type=path_or_none,
         help="Output path for orientation volume LTA transform. This makes sure the midplane is the volume center, "
-             "the anterior and posterior commisures are on the coordinate line, and the posterior commissure is "
-             "at the origin - standardizing the head position.",
+        "the anterior and posterior commisures are on the coordinate line, and the posterior commissure is "
+        "at the origin - standardizing the head position.",
         default=DEFAULT_OUTPUT_PATHS["orient_volume_lta"],
     )
     advanced.add_argument(
@@ -287,10 +288,10 @@ def make_parser() -> argparse.ArgumentParser:
     advanced.add_argument(
         "--midplane_method",
         choices=["none", "lr_shift", "distance_map"],
-        default="distance_map",
+        default="lr_shift",
         help="Midsagittal plane refinement method. 'none': no refinement (baseline); "
-             "'lr_shift': 1D integer-voxel shift by scoring left-right label-pair mirroring; "
-             "'distance_map': 3D plane fit from hemisphere distance transforms (default).",
+        "'lr_shift': 1D integer-voxel shift by scoring left-right label-pair mirroring (default); "
+        "'distance_map': 3D plane fit from hemisphere distance transforms.",
     )
     advanced.add_argument(
         "--qc_image",
@@ -302,7 +303,7 @@ def make_parser() -> argparse.ArgumentParser:
         "--save_template_dir",
         type=path_or_none,
         help="Directory path where to save contours.txt and thickness_values.txt files. These files can be used to "
-             "visualize the CC shape and volume with the cc_visualization.py script.",
+        "visualize the CC shape and volume with the cc_visualization.py script.",
         default=None,
     )
     advanced.add_argument(
@@ -316,18 +317,19 @@ def make_parser() -> argparse.ArgumentParser:
         dest="cc_surf",
         type=path_or_none,
         help="Output path for surf file for visualization in freeview, use --save_template_dir and contours.txt to "
-             "obtain source CC contours.",
+        "obtain source CC contours.",
         default=DEFAULT_OUTPUT_PATHS["cc_surf"],
     )
     advanced.add_argument(
         "--thickness_overlay",
         type=path_or_none,
         help="Output path for corpus callosum thickness overlay file for visualization in freeview, use "
-             "--save_template_dir and thickness_values.txt to obtain source CC thickness values.",
+        "--save_template_dir and thickness_values.txt to obtain source CC thickness values.",
         default=DEFAULT_OUTPUT_PATHS["cc_thickness_overlay"],
     )
     advanced.add_argument(
-        "--cc_interactive_html", "--cc_html",
+        "--cc_interactive_html",
+        "--cc_html",
         dest="cc_html",
         type=path_or_none,
         help="Output path to the corpus callosum interactive 3D visualization HTML file.",
@@ -337,28 +339,28 @@ def make_parser() -> argparse.ArgumentParser:
         "--cc_surf_vtk",
         type=path_or_none,
         help=f"Output path for vtk file, showing the CC 3D mesh for visualization, use --save_template_dir and "
-             f"contours.txt to obtain source CC contours. Example: {DEFAULT_OUTPUT_PATHS['cc_surf_vtk']}.",
+        f"contours.txt to obtain source CC contours. Example: {DEFAULT_OUTPUT_PATHS['cc_surf_vtk']}.",
         default=None,
     )
     advanced.add_argument(
         "--softlabels_cc",
         type=path_or_none,
         help=f"Output path for corpus callosum softlabels, which contains the soft labels of each voxel. "
-             f"Example: {DEFAULT_OUTPUT_PATHS['softlabels_cc']}.",
+        f"Example: {DEFAULT_OUTPUT_PATHS['softlabels_cc']}.",
         default=None,
     )
     advanced.add_argument(
         "--softlabels_fn",
         type=path_or_none,
         help=f"Output path for fornix softlabels, which contains the soft labels of each voxel. "
-             f"Example: {DEFAULT_OUTPUT_PATHS['softlabels_fn']}.",
+        f"Example: {DEFAULT_OUTPUT_PATHS['softlabels_fn']}.",
         default=None,
     )
     advanced.add_argument(
         "--softlabels_background",
         type=path_or_none,
         help=f"Output path for background softlabels, which contains the probability of each voxel. "
-             f"Example: {DEFAULT_OUTPUT_PATHS['softlabels_background']}.",
+        f"Example: {DEFAULT_OUTPUT_PATHS['softlabels_background']}.",
         default=None,
     )
     ############ END OF OUTPUT PATHS ############
@@ -371,8 +373,8 @@ def options_parse() -> argparse.Namespace:
     args = parser.parse_args()
 
     # Reconstruct subject_dir from sd and sid (but sd might be stored as out_dir by parser_defaults)
-    sd_value = getattr(args, 'out_dir', None)
-    if sd_value and hasattr(args, 'sid') and args.sid:
+    sd_value = getattr(args, "out_dir", None)
+    if sd_value and hasattr(args, "sid") and args.sid:
         args.subject_dir = Path(sd_value) / args.sid
     else:
         args.subject_dir = None
@@ -380,19 +382,19 @@ def options_parse() -> argparse.Namespace:
     # Validation logic: must use either directory approach (--sd + --sid) OR file approach (--conf_name + --aseg_name)
     if sd_value:
         # Using directory approach - make sure sid was also provided
-        if not (hasattr(args, 'sid') and args.sid):
+        if not (hasattr(args, "sid") and args.sid):
             parser.error("When using --sd, you must also provide --sid.")
-    elif hasattr(args, 'sid') and args.sid:
+    elif hasattr(args, "sid") and args.sid:
         # If sid is provided without sd, that's an error
         if not sd_value:
             parser.error("When using --sid, you must also provide --sd.")
-    elif hasattr(args, 'conf_name') and args.conf_name:
+    elif hasattr(args, "conf_name") and args.conf_name:
         # Using file approach - make sure aseg_name was also provided
-        if not (hasattr(args, 'aseg_name') and args.aseg_name):
+        if not (hasattr(args, "aseg_name") and args.aseg_name):
             parser.error("When using --conf_name, you must also provide --aseg_name.")
-    elif hasattr(args, 'aseg_name') and args.aseg_name:
+    elif hasattr(args, "aseg_name") and args.aseg_name:
         # If aseg_name is provided without conf_name, that's an error
-        if not (hasattr(args, 'conf_name') and args.conf_name):
+        if not (hasattr(args, "conf_name") and args.conf_name):
             parser.error("When using --aseg_name, you must also provide --conf_name.")
     else:
         parser.error("You must specify either --sd and --sid OR both --conf_name and --aseg_name.")
@@ -415,9 +417,22 @@ def options_parse() -> argparse.Namespace:
                     f"absolute! But the argument passed to {arg} was {path}, i.e. not absolute."
                 )
 
-        all_paths = ("segmentation", "segmentation_in_orig", "cc_measures", "upright_lta", "orient_volume_lta",
-                     "cc_surf", "softlabels_cc", "softlabels_fn", "softlabels_background", "cc_mid_measures",
-                     "thickness_overlay", "qc_image", "thickness_image", "cc_html")
+        all_paths = (
+            "segmentation",
+            "segmentation_in_orig",
+            "cc_measures",
+            "upright_lta",
+            "orient_volume_lta",
+            "cc_surf",
+            "softlabels_cc",
+            "softlabels_fn",
+            "softlabels_background",
+            "cc_mid_measures",
+            "thickness_overlay",
+            "qc_image",
+            "thickness_image",
+            "cc_html",
+        )
 
         warnings_paths = []
         # Create parent directories for all output paths
@@ -429,28 +444,39 @@ def options_parse() -> argparse.Namespace:
                 setattr(args, path_name, None)
         if warnings_paths:
             _warnings_paths = "' '".join(warnings_paths)
-            print(f"WARNING: Not writing '{_warnings_paths}', because --sd and --sid are not specified and "
-                  f"its paths are relative.")
+            print(
+                f"WARNING: Not writing '{_warnings_paths}', because --sd and --sid are not specified and "
+                f"its paths are relative."
+            )
     return args
+
+
+# Standard FreeSurfer aseg left/right label pairs.
+_ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
+    (2, 41),  # Cerebral-White-Matter
+    (3, 42),  # Cerebral-Cortex
+    (4, 43),  # Lateral-Ventricle
+    (5, 44),  # Inf-Lat-Vent
+    (7, 46),  # Cerebellum-White-Matter
+    (8, 47),  # Cerebellum-Cortex
+    (10, 49),  # Thalamus
+    (11, 50),  # Caudate
+    (12, 51),  # Putamen
+    (13, 52),  # Pallidum
+    (17, 53),  # Hippocampus
+    (18, 54),  # Amygdala
+    (26, 58),  # Accumbens-area
+    (28, 60),  # VentralDC
+)
 
 
 def _prepare_lr_pair_labels(seg_data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Create matched left/right label-id arrays from a FreeSurfer-style segmentation."""
-    labels = np.unique(seg_data.astype(np.int32))
-    labels = labels[labels > 0]
-    label_set = set(labels.tolist())
+    label_set = set(np.unique(seg_data.astype(np.int32)).tolist())
+    label_set.discard(0)
 
-    left_ids = []
-    right_ids = []
-    for left_label in labels:
-        right_label = left_label + 1000
-        if right_label in label_set:
-            left_ids.append(int(left_label))
-            right_ids.append(int(right_label))
-
-    if not left_ids and 2 in label_set and 41 in label_set:
-        left_ids.append(2)
-        right_ids.append(41)
+    left_ids = [lbl for lbl, r in _ASEG_LR_PAIRS if lbl in label_set and r in label_set]
+    right_ids = [r for lbl, r in _ASEG_LR_PAIRS if lbl in label_set and r in label_set]
 
     return np.asarray(left_ids, dtype=np.int32), np.asarray(right_ids, dtype=np.int32)
 
@@ -513,7 +539,7 @@ def _score_midline_shift(
 
 def refine_midline_lr_shift(
     orig2fsavg_vox2vox: AffineMatrix4x4,
-    aseg_nib: nibabelImage,
+    aseg_data: np.ndarray,
     fsavg_shape: Shape3d,
     base_middle_vox: float,
     max_shift_vox: int = 6,
@@ -523,21 +549,13 @@ def refine_midline_lr_shift(
     if max_shift_vox < 0 or step_vox <= 0:
         return orig2fsavg_vox2vox, 0, float("inf"), {}
 
-    seg_data = np.asarray(aseg_nib.dataobj).astype(np.int32)
+    seg_data = aseg_data.astype(np.int32)
     left_ids, right_ids = _prepare_lr_pair_labels(seg_data)
     if left_ids.size == 0:
         logger.warning("Midline refinement skipped: no left/right label pairs found.")
         return orig2fsavg_vox2vox, 0, float("inf"), {}
 
-    seg_fsavg = affine_transform(
-        seg_data,
-        np.linalg.inv(orig2fsavg_vox2vox),
-        output_shape=fsavg_shape,
-        order=0,
-        mode="constant",
-        cval=0,
-        prefilter=False,
-    ).astype(np.int32)
+    seg_fsavg = resample_segmentation_to_fsavg(seg_data, orig2fsavg_vox2vox, fsavg_shape)
 
     candidate_scores: list[dict[str, int | float | None]] = []
     zero_shift_score = float("inf")
@@ -559,12 +577,14 @@ def refine_midline_lr_shift(
             shift_vox=-shift,
         )
         adjusted_score = raw_score + shift_penalty * abs(shift)
-        candidate_scores.append({
-            "shift_vox": int(shift),
-            "raw_score": float(raw_score) if np.isfinite(raw_score) else None,
-            "adjusted_score": float(adjusted_score) if np.isfinite(adjusted_score) else None,
-            "support": int(support),
-        })
+        candidate_scores.append(
+            {
+                "shift_vox": int(shift),
+                "raw_score": float(raw_score) if np.isfinite(raw_score) else None,
+                "adjusted_score": float(adjusted_score) if np.isfinite(adjusted_score) else None,
+                "support": int(support),
+            }
+        )
         if shift == 0:
             zero_shift_score = raw_score
             zero_shift_support = support
@@ -602,9 +622,10 @@ def refine_midline_lr_shift(
         or (not no_baseline and small_improvement)
     )
 
+    diagnostics["no_baseline"] = no_baseline
     diagnostics["rejected_boundary_shift"] = at_boundary
     diagnostics["rejected_low_support"] = insufficient_support
-    diagnostics["rejected_small_improvement"] = (not no_baseline and small_improvement)
+    diagnostics["rejected_small_improvement"] = not no_baseline and small_improvement
 
     if reject_shift:
         logger.info(
@@ -628,8 +649,9 @@ def refine_midline_lr_shift(
     return updated_transform, best_shift, best_raw_score, diagnostics
 
 
-def register_centroids_to_fsavg(aseg_nib: nibabelImage) \
-        -> tuple[AffineMatrix4x4, AffineMatrix4x4, AffineMatrix4x4, MGHHeaderDict]:
+def register_centroids_to_fsavg(
+    aseg_nib: nibabelImage,
+) -> tuple[AffineMatrix4x4, AffineMatrix4x4, AffineMatrix4x4, MGHHeaderDict]:
     """Perform centroid-based registration between subject and fsaverage space.
 
     Computes a rigid transformation between the subject's segmentation and fsaverage space
@@ -678,7 +700,7 @@ def register_centroids_to_fsavg(aseg_nib: nibabelImage) \
     resolution_trans: AffineMatrix4x4 = np.diagflat(np.append(aseg_zooms_ras[[0, 2, 1]], [1])).astype(float)
 
     fsaverage_vox2ras, fsavg_header = fsaverage_data_future.result()
-    fsavg_header["delta"] = aseg_zooms_ras[[0, 2, 1]] # vox sizes in lia
+    fsavg_header["delta"] = aseg_zooms_ras[[0, 2, 1]]  # vox sizes in lia
     # fsavg_hires_vox2ras translation should be 128 always (independent of resolution)
     fsavg_hires_vox2ras: AffineMatrix4x4 = np.concatenate(
         [(resolution_trans @ fsaverage_vox2ras)[:, :3], fsaverage_vox2ras[:, 3:4]],
@@ -729,16 +751,16 @@ def localize_ac_pc(
         PC voxel coordinates with shape (2,) containing its [y,x] positions.
     """
     num_slices_to_analyze = resample_shape[0]
-    resample_shape = (num_slices_to_analyze + 2,) + resample_shape[1:] # 2 for context slices
+    resample_shape = (num_slices_to_analyze + 2,) + resample_shape[1:]  # 2 for context slices
     _midslices_fut = thread_executor().submit(
         affine_transform,
         orig_data,
-        np.linalg.inv(orig2midslice_vox2vox), # inverse is required for affine_transform
+        np.linalg.inv(orig2midslice_vox2vox),  # inverse is required for affine_transform
         output_shape=resample_shape,
-        order=2, # unclear, why this is not order=3
+        order=2,  # unclear, why this is not order=3
         mode="constant",
         cval=0,
-        prefilter=True, # unclear, why we are using a smoothing filter here
+        prefilter=True,  # unclear, why we are using a smoothing filter here
     )
 
     # get center of third ventricle from aseg and map to fsaverage space (voxel coordinates)
@@ -748,7 +770,9 @@ def localize_ac_pc(
 
     # get 5 mm of slices with 3 slices per inference (cropping num_slices_to_analyze + 2 slices around the center)
     ac_coords, pc_coords = localization_inference.run_inference_on_slice(
-        model_localization, _midslices_fut.result(), third_ventricle_center_vox[1:],
+        model_localization,
+        _midslices_fut.result(),
+        third_ventricle_center_vox[1:],
     )
 
     return ac_coords, pc_coords
@@ -830,7 +854,7 @@ def main(
     midplane_left_hemi_mask: str | Path | None = None,
     midplane_right_hemi_mask: str | Path | None = None,
     midplane_upright_aseg: str | Path | None = None,
-    midplane_method: str = "distance_map",
+    midplane_method: str = "lr_shift",
     cc_surf: str | Path | None = None,
     cc_thickness_overlay: str | Path | None = None,
     cc_html: str | Path | None = None,
@@ -1027,10 +1051,11 @@ def main(
     _fsavg_shape = tuple(_fsavg_header_dict["dims"])
     _base_middle_vox = float(FSAVERAGE_MIDDLE) / float(vox_size[0])
     dm_result = None
+    _aseg_data = np.asarray(aseg_img.dataobj)
     if midplane_method == "distance_map":
         dm_result = refine_midplane_with_distance_maps(
             orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-            aseg_nib=aseg_img,
+            aseg_data=_aseg_data,
             fsavg_shape=_fsavg_shape,
             base_middle_vox=_base_middle_vox,
         )
@@ -1040,7 +1065,7 @@ def main(
     elif midplane_method == "lr_shift":
         orig2fsavg_vox2vox, _lr_shift, _, midline_shift_diagnostics = refine_midline_lr_shift(
             orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-            aseg_nib=aseg_img,
+            aseg_data=_aseg_data,
             fsavg_shape=_fsavg_shape,
             base_middle_vox=_base_middle_vox,
         )
@@ -1059,44 +1084,53 @@ def main(
     if dm_result is not None and sd.has_attribute("cc_midplane_distance_map"):
         distance_map_path = sd.filename_by_attribute("cc_midplane_distance_map")
         distance_map_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            nib.save,
-            nib.MGHImage(dm_result.debug_volumes.distance_diff.astype(np.float32),
-                         fsavg_vox2ras, orig.header),
-            distance_map_path,
-        ))
+        futures.append(
+            thread_executor().submit(
+                nib.save,
+                nib.MGHImage(dm_result.debug_volumes.distance_diff.astype(np.float32), fsavg_vox2ras, orig.header),
+                distance_map_path,
+            )
+        )
     if dm_result is not None and sd.has_attribute("cc_midplane_fit_mask"):
         fit_mask_path = sd.filename_by_attribute("cc_midplane_fit_mask")
         fit_mask_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            nib.save,
-            nib.MGHImage(dm_result.debug_volumes.candidate_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
-            fit_mask_path,
-        ))
+        futures.append(
+            thread_executor().submit(
+                nib.save,
+                nib.MGHImage(dm_result.debug_volumes.candidate_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+                fit_mask_path,
+            )
+        )
     if dm_result is not None and sd.has_attribute("cc_midplane_left_hemi_mask"):
         left_hemi_mask_path = sd.filename_by_attribute("cc_midplane_left_hemi_mask")
         left_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            nib.save,
-            nib.MGHImage(dm_result.debug_volumes.left_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
-            left_hemi_mask_path,
-        ))
+        futures.append(
+            thread_executor().submit(
+                nib.save,
+                nib.MGHImage(dm_result.debug_volumes.left_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+                left_hemi_mask_path,
+            )
+        )
     if dm_result is not None and sd.has_attribute("cc_midplane_right_hemi_mask"):
         right_hemi_mask_path = sd.filename_by_attribute("cc_midplane_right_hemi_mask")
         right_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            nib.save,
-            nib.MGHImage(dm_result.debug_volumes.right_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
-            right_hemi_mask_path,
-        ))
+        futures.append(
+            thread_executor().submit(
+                nib.save,
+                nib.MGHImage(dm_result.debug_volumes.right_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+                right_hemi_mask_path,
+            )
+        )
     if sd.has_attribute("cc_midplane_upright_aseg"):
         upright_aseg_path = sd.filename_by_attribute("cc_midplane_upright_aseg")
         upright_aseg_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            nib.save,
-            nib.MGHImage(midplane_upright_aseg_data.astype(np.int32), fsavg_vox2ras, orig.header),
-            upright_aseg_path,
-        ))
+        futures.append(
+            thread_executor().submit(
+                nib.save,
+                nib.MGHImage(midplane_upright_aseg_data.astype(np.int32), fsavg_vox2ras, orig.header),
+                upright_aseg_path,
+            )
+        )
 
     # start saving upright volume, this is the image in fsaverage space but not yet oriented via AC-PC
     if sd.has_attribute("upright_volume"):
@@ -1126,7 +1160,6 @@ def main(
     fsavg2midslab_vox2vox = offset_affine([slices_to_analyze // 2, 0, 0]) @ fsavg2midslice_vox2vox
     fsaverage_midslab_vox2ras: AffineMatrix4x4 = fsavg_vox2ras @ np.linalg.inv(fsavg2midslab_vox2vox)
 
-
     #### do localization and segmentation inference
     logger.info("Starting AC/PC localization")
     target_shape: tuple[int, int, int] = (slices_to_analyze, fsavg_header["dims"][1], fsavg_header["dims"][2])
@@ -1143,12 +1176,14 @@ def main(
     target_shape: Shape3d = (slices_to_analyze + num_context, fsavg_header["dims"][1], fsavg_header["dims"][2])
     midslices: Image3d = affine_transform(
         np.asarray(orig.dataobj),
-        np.linalg.inv(_orig2midslab_vox2vox(additional_context=num_context)), # inverse is required for affine_transform
+        np.linalg.inv(
+            _orig2midslab_vox2vox(additional_context=num_context)
+        ),  # inverse is required for affine_transform
         output_shape=target_shape,
-        order=2, # @ClePol unclear, why this is not order=3
+        order=2,  # @ClePol unclear, why this is not order=3
         mode="constant",
         cval=0,
-        prefilter=True, # unclear, why we are using a smoothing filter here
+        prefilter=True,  # unclear, why we are using a smoothing filter here
     )
     cc_fn_seg_labels, cc_fn_softlabels = segment_cc(
         midslices,
@@ -1162,11 +1197,13 @@ def main(
     for i, (attr, name) in enumerate((("background",) * 2, ("cc", "Corpus Callosum"), ("fn", "Fornix"))):
         if sd.has_attribute(f"cc_softlabels_{attr}"):
             logger.info(f"Saving {name} softlabels to {sd.filename_by_attribute(f'cc_softlabels_{attr}')}")
-            futures.append(thread_executor().submit(
-                nib.save,
-                nib.MGHImage(cc_fn_softlabels[..., i], fsaverage_midslab_vox2ras, orig.header),
-                sd.filename_by_attribute(f"cc_softlabels_{attr}"),
-            ))
+            futures.append(
+                thread_executor().submit(
+                    nib.save,
+                    nib.MGHImage(cc_fn_softlabels[..., i], fsaverage_midslab_vox2ras, orig.header),
+                    sd.filename_by_attribute(f"cc_softlabels_{attr}"),
+                )
+            )
 
     # Create a temporary segmentation image with proper affine for enhanced postprocessing
     # Process slices based on selection mode
@@ -1176,11 +1213,13 @@ def main(
         _cc_seg_path = sd.filename_by_attribute("cc_segmentation")
         _cc_seg_path.parent.mkdir(exist_ok=True, parents=True)
         logger.info(f"Saving CC segmentation to {_cc_seg_path}")
-        futures.append(thread_executor().submit(
-            nib.save,
-            nib.MGHImage(cc_fn_seg_labels, fsaverage_midslab_vox2ras, orig.header),
-            _cc_seg_path,
-        ))
+        futures.append(
+            thread_executor().submit(
+                nib.save,
+                nib.MGHImage(cc_fn_seg_labels, fsaverage_midslab_vox2ras, orig.header),
+                _cc_seg_path,
+            )
+        )
 
     logger.info(f"Processing slices with selection mode: {slice_selection}")
     try:
@@ -1208,12 +1247,12 @@ def main(
         slice_results = []
         slice_io_futures = []
         cc_contours = []
-        num_failed_slices = cc_fn_seg_labels.shape[0] if slice_selection  == "all" else 1
+        num_failed_slices = cc_fn_seg_labels.shape[0] if slice_selection == "all" else 1
 
     # Filter out None results for further processing
     valid_slice_results = [r for r in slice_results if r is not None]
     valid_cc_contours = [c for c in cc_contours if c is not None]
-    num_failed_slices +=  len(cc_contours) - len(valid_cc_contours)
+    num_failed_slices += len(cc_contours) - len(valid_cc_contours)
     outer_contours = []
     cc_volume_contour = None
 
@@ -1243,7 +1282,7 @@ def main(
             cc_subseg_midslice = make_subdivision_mask(
                 (cc_fn_seg_labels.shape[1], cc_fn_seg_labels.shape[2]),
                 middle_slice_result["subdivision_lines"],
-                vox2ras=fsavg_vox2ras @ np.linalg.inv(fsavg2midslice_vox2vox)
+                vox2ras=fsavg_vox2ras @ np.linalg.inv(fsavg2midslice_vox2vox),
             )
         else:
             if middle_slice_result is None:
@@ -1253,15 +1292,17 @@ def main(
             cc_subseg_midslice = None
         # if num_threads is not large enough (>1), this might be blocking ; serial_executor runs the function in submit
         executor = thread_executor() if get_num_threads() > 2 else serial_executor()
-        futures.append(executor.submit(
-            map_softlabels_to_orig,
-            cc_fn_softlabels=cc_fn_softlabels,
-            orig=orig,
-            orig_space_segmentation_path=sd.filename_by_attribute("cc_orig_segfile"),
-            orig2slab_vox2vox=_orig2midslab_vox2vox(),
-            cc_subseg_midslice=cc_subseg_midslice,
-            orig2midslice_vox2vox=orig2midslice_vox2vox,
-        ))
+        futures.append(
+            executor.submit(
+                map_softlabels_to_orig,
+                cc_fn_softlabels=cc_fn_softlabels,
+                orig=orig,
+                orig_space_segmentation_path=sd.filename_by_attribute("cc_orig_segfile"),
+                orig2slab_vox2vox=_orig2midslab_vox2vox(),
+                cc_subseg_midslice=cc_subseg_midslice,
+                orig2midslice_vox2vox=orig2midslice_vox2vox,
+            )
+        )
 
     metrics: tuple[CCMeasures] = get_args(CCMeasures)
 
@@ -1274,18 +1315,20 @@ def main(
 
     # Create enhanced output dictionary with all slice results
     per_slice_output_dict = {
-        "slices": [convert_numpy_to_json_serializable({metric: result[metric] for metric in metrics})
-                   if result else None for result in slice_results],
+        "slices": [
+            convert_numpy_to_json_serializable({metric: result[metric] for metric in metrics}) if result else None
+            for result in slice_results
+        ],
     }
 
     ########## Save outputs ##########
     additional_metrics = {}
 
     cc_num_voxel = segmentation_postprocessing.get_cc_num_voxel(
-            desired_width_mm=5,
-            cc_mask=np.equal(cc_fn_seg_labels, CC_LABEL),
-            voxel_size=vox_size, # in LIA order
-        )
+        desired_width_mm=5,
+        cc_mask=np.equal(cc_fn_seg_labels, CC_LABEL),
+        voxel_size=vox_size,  # in LIA order
+    )
     additional_metrics["cc_num_voxel"] = cc_num_voxel
     voxel_volume = np.prod(vox_size)
     additional_metrics["voxel_volume"] = voxel_volume
@@ -1328,7 +1371,7 @@ def main(
     additional_metrics["subdivision_ratios"] = subdivisions
     additional_metrics["contour_smoothing"] = contour_smoothing
     additional_metrics["slice_selection"] = slice_selection
-    additional_metrics["midline_refine_shift_vox"] = int(midline_shift_vox)
+    additional_metrics["midline_refine_shift_vox"] = float(midline_shift_vox)
     additional_metrics["midline_refine_diagnostics"] = midline_shift_diagnostics
 
     # QC checks
@@ -1356,51 +1399,60 @@ def main(
         )
 
     if sd.has_attribute("cc_mid_measures") and middle_slice_result is not None:
-        sd.filename_by_attribute('cc_mid_measures').parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            save_cc_measures_json,
-            sd.filename_by_attribute('cc_mid_measures'),
-            output_metrics_middle_slice | additional_metrics,
-        ))
+        sd.filename_by_attribute("cc_mid_measures").parent.mkdir(exist_ok=True, parents=True)
+        futures.append(
+            thread_executor().submit(
+                save_cc_measures_json,
+                sd.filename_by_attribute("cc_mid_measures"),
+                output_metrics_middle_slice | additional_metrics,
+            )
+        )
 
     if sd.has_attribute("cc_measures"):
         sd.filename_by_attribute("cc_measures").parent.mkdir(exist_ok=True, parents=True)
-        futures.append(thread_executor().submit(
-            save_cc_measures_json,
-            sd.filename_by_attribute("cc_measures"),
-            per_slice_output_dict | additional_metrics,
-        ))
+        futures.append(
+            thread_executor().submit(
+                save_cc_measures_json,
+                sd.filename_by_attribute("cc_measures"),
+                per_slice_output_dict | additional_metrics,
+            )
+        )
 
     # save lta to fsaverage space
 
     if sd.has_attribute("upright_lta"):
         sd.filename_by_attribute("upright_lta").parent.mkdir(exist_ok=True, parents=True)
         logger.info(f"Saving LTA to fsaverage space: {sd.filename_by_attribute('upright_lta')}")
-        futures.append(thread_executor().submit(
-            write_lta,
-            sd.filename_by_attribute("upright_lta"),
-            orig2fsavg_ras2ras,
-            sd.filename_by_attribute("aseg_name"),
-            aseg_img.header,
-            "fsaverage",
-            fsavg_header,
-        ))
+        futures.append(
+            thread_executor().submit(
+                write_lta,
+                sd.filename_by_attribute("upright_lta"),
+                orig2fsavg_ras2ras,
+                sd.filename_by_attribute("aseg_name"),
+                aseg_img.header,
+                "fsaverage",
+                fsavg_header,
+            )
+        )
 
     if sd.has_attribute("cc_orient_volume_lta"):
         sd.filename_by_attribute("cc_orient_volume_lta").parent.mkdir(exist_ok=True, parents=True)
         # save lta to standardized space (fsaverage + nodding + ac to center)
-        fsavg2standardized_ras2ras = fsavg_vox2ras @ \
-            np.linalg.inv(standardized2orig_vox2vox) @ np.linalg.inv(orig.affine)
+        fsavg2standardized_ras2ras = (
+            fsavg_vox2ras @ np.linalg.inv(standardized2orig_vox2vox) @ np.linalg.inv(orig.affine)
+        )
         logger.info(f"Saving LTA to standardized space: {sd.filename_by_attribute('cc_orient_volume_lta')}")
-        futures.append(thread_executor().submit(
-            write_lta,
-            sd.filename_by_attribute("cc_orient_volume_lta"),
-            fsavg2standardized_ras2ras,
-            sd.conf_name,
-            orig.header,
-            "standardized",
-            fsavg_header,
-        ))
+        futures.append(
+            thread_executor().submit(
+                write_lta,
+                sd.filename_by_attribute("cc_orient_volume_lta"),
+                fsavg2standardized_ras2ras,
+                sd.conf_name,
+                orig.header,
+                "standardized",
+                fsavg_header,
+            )
+        )
 
     # this waits for all io to finish
     return_value: Literal[0] | str = 0
@@ -1461,37 +1513,39 @@ if __name__ == "__main__":
     # Set up logging if verbose mode is enabled
     logging.setup_logging(None, options.verbose)  # Log to stdout only
 
-    sys.exit(main(
-        conf_name=options.conf_name,
-        aseg_name=options.aseg_name,
-        subject_dir=options.subject_dir,
-        slice_selection=options.slice_selection,
-        num_thickness_points=options.num_thickness_points,
-        subdivisions=list(options.subdivisions),
-        subdivision_method=str(options.subdivision_method),
-        contour_smoothing=options.contour_smoothing,
-        save_template_dir=options.save_template_dir,
-        device=options.device,
-        upright_volume=options.upright_volume,
-        segmentation=options.segmentation,
-        cc_measures=options.cc_measures,
-        cc_mid_measures=options.cc_mid_measures,
-        upright_lta=options.upright_lta,
-        orient_volume_lta=options.orient_volume_lta,
-        midplane_distance_map=options.midplane_distance_map,
-        midplane_fit_mask=options.midplane_fit_mask,
-        midplane_left_hemi_mask=options.midplane_left_hemi_mask,
-        midplane_right_hemi_mask=options.midplane_right_hemi_mask,
-        midplane_upright_aseg=options.midplane_upright_aseg,
-        midplane_method=options.midplane_method,
-        cc_surf=options.cc_surf,
-        cc_thickness_overlay=options.thickness_overlay,
-        cc_html=options.cc_html,
-        cc_surf_vtk=options.cc_surf_vtk,
-        segmentation_in_orig=options.segmentation_in_orig,
-        qc_image=options.qc_image,
-        thickness_image=options.thickness_image,
-        softlabels_cc=options.softlabels_cc,
-        softlabels_fn=options.softlabels_fn,
-        softlabels_background=options.softlabels_background,
-    ))
+    sys.exit(
+        main(
+            conf_name=options.conf_name,
+            aseg_name=options.aseg_name,
+            subject_dir=options.subject_dir,
+            slice_selection=options.slice_selection,
+            num_thickness_points=options.num_thickness_points,
+            subdivisions=list(options.subdivisions),
+            subdivision_method=str(options.subdivision_method),
+            contour_smoothing=options.contour_smoothing,
+            save_template_dir=options.save_template_dir,
+            device=options.device,
+            upright_volume=options.upright_volume,
+            segmentation=options.segmentation,
+            cc_measures=options.cc_measures,
+            cc_mid_measures=options.cc_mid_measures,
+            upright_lta=options.upright_lta,
+            orient_volume_lta=options.orient_volume_lta,
+            midplane_distance_map=options.midplane_distance_map,
+            midplane_fit_mask=options.midplane_fit_mask,
+            midplane_left_hemi_mask=options.midplane_left_hemi_mask,
+            midplane_right_hemi_mask=options.midplane_right_hemi_mask,
+            midplane_upright_aseg=options.midplane_upright_aseg,
+            midplane_method=options.midplane_method,
+            cc_surf=options.cc_surf,
+            cc_thickness_overlay=options.thickness_overlay,
+            cc_html=options.cc_html,
+            cc_surf_vtk=options.cc_surf_vtk,
+            segmentation_in_orig=options.segmentation_in_orig,
+            qc_image=options.qc_image,
+            thickness_image=options.thickness_image,
+            softlabels_cc=options.softlabels_cc,
+            softlabels_fn=options.softlabels_fn,
+            softlabels_background=options.softlabels_background,
+        )
+    )

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -35,7 +35,7 @@ from CorpusCallosum.data.constants import (
 )
 from CorpusCallosum.data.read_write import MGHHeaderDict, convert_numpy_to_json_serializable
 from CorpusCallosum.localization import inference as localization_inference
-from CorpusCallosum.midplane_refinement import find_midplane_transform
+from CorpusCallosum.registration.midsagittal_plane_alignment import find_midplane_transform
 from CorpusCallosum.segmentation import inference as segmentation_inference
 from CorpusCallosum.segmentation import segmentation_postprocessing
 from CorpusCallosum.shape.contour import calculate_volume as calculate_cc_volume_contour

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -285,6 +285,14 @@ def make_parser() -> argparse.ArgumentParser:
         default=None,
     )
     advanced.add_argument(
+        "--midplane_method",
+        choices=["none", "lr_shift", "distance_map"],
+        default="distance_map",
+        help="Midsagittal plane refinement method. 'none': no refinement (baseline); "
+             "'lr_shift': 1D integer-voxel shift by scoring left-right label-pair mirroring; "
+             "'distance_map': 3D plane fit from hemisphere distance transforms (default).",
+    )
+    advanced.add_argument(
         "--qc_image",
         type=path_or_none,
         help="Output path for QC visualization image.",
@@ -822,6 +830,7 @@ def main(
     midplane_left_hemi_mask: str | Path | None = None,
     midplane_right_hemi_mask: str | Path | None = None,
     midplane_upright_aseg: str | Path | None = None,
+    midplane_method: str = "distance_map",
     cc_surf: str | Path | None = None,
     cc_thickness_overlay: str | Path | None = None,
     cc_html: str | Path | None = None,
@@ -1015,54 +1024,69 @@ def main(
 
     logger.info("Performing centroid registration to fsaverage space")
     orig2fsavg_vox2vox, orig2fsavg_ras2ras, fsavg_vox2ras, _fsavg_header_dict = register_centroids_to_fsavg(aseg_img)
-    midplane_refinement = refine_midplane_with_distance_maps(
-        orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-        aseg_nib=aseg_img,
-        fsavg_shape=tuple(_fsavg_header_dict["dims"]),
-        base_middle_vox=float(FSAVERAGE_MIDDLE) / float(vox_size[0]),
-    )
-    orig2fsavg_vox2vox = midplane_refinement.updated_vox2vox
-    midline_shift_vox = midplane_refinement.center_shift_vox
-    midline_shift_diagnostics = midplane_refinement.diagnostics
+    _fsavg_shape = tuple(_fsavg_header_dict["dims"])
+    _base_middle_vox = float(FSAVERAGE_MIDDLE) / float(vox_size[0])
+    dm_result = None
+    if midplane_method == "distance_map":
+        dm_result = refine_midplane_with_distance_maps(
+            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+            aseg_nib=aseg_img,
+            fsavg_shape=_fsavg_shape,
+            base_middle_vox=_base_middle_vox,
+        )
+        orig2fsavg_vox2vox = dm_result.updated_vox2vox
+        midline_shift_vox = dm_result.center_shift_vox
+        midline_shift_diagnostics = dm_result.diagnostics
+    elif midplane_method == "lr_shift":
+        orig2fsavg_vox2vox, _lr_shift, _, midline_shift_diagnostics = refine_midline_lr_shift(
+            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+            aseg_nib=aseg_img,
+            fsavg_shape=_fsavg_shape,
+            base_middle_vox=_base_middle_vox,
+        )
+        midline_shift_vox = float(_lr_shift)
+    else:  # "none"
+        midline_shift_vox = 0.0
+        midline_shift_diagnostics = {}
     orig2fsavg_ras2ras = fsavg_vox2ras @ orig2fsavg_vox2vox @ np.linalg.inv(orig.affine)
     fsavg_header = init_mgh_header(orig.header, _fsavg_header_dict)
     midplane_upright_aseg_data = resample_segmentation_to_fsavg(
         np.asarray(aseg_img.dataobj),
         orig2fsavg_vox2vox,
-        tuple(_fsavg_header_dict["dims"]),
+        _fsavg_shape,
     )
 
-    if sd.has_attribute("cc_midplane_distance_map"):
+    if dm_result is not None and sd.has_attribute("cc_midplane_distance_map"):
         distance_map_path = sd.filename_by_attribute("cc_midplane_distance_map")
         distance_map_path.parent.mkdir(exist_ok=True, parents=True)
         futures.append(thread_executor().submit(
             nib.save,
-            nib.MGHImage(midplane_refinement.debug_volumes.distance_diff.astype(np.float32),
+            nib.MGHImage(dm_result.debug_volumes.distance_diff.astype(np.float32),
                          fsavg_vox2ras, orig.header),
             distance_map_path,
         ))
-    if sd.has_attribute("cc_midplane_fit_mask"):
+    if dm_result is not None and sd.has_attribute("cc_midplane_fit_mask"):
         fit_mask_path = sd.filename_by_attribute("cc_midplane_fit_mask")
         fit_mask_path.parent.mkdir(exist_ok=True, parents=True)
         futures.append(thread_executor().submit(
             nib.save,
-            nib.MGHImage(midplane_refinement.debug_volumes.candidate_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+            nib.MGHImage(dm_result.debug_volumes.candidate_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
             fit_mask_path,
         ))
-    if sd.has_attribute("cc_midplane_left_hemi_mask"):
+    if dm_result is not None and sd.has_attribute("cc_midplane_left_hemi_mask"):
         left_hemi_mask_path = sd.filename_by_attribute("cc_midplane_left_hemi_mask")
         left_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
         futures.append(thread_executor().submit(
             nib.save,
-            nib.MGHImage(midplane_refinement.debug_volumes.left_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+            nib.MGHImage(dm_result.debug_volumes.left_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
             left_hemi_mask_path,
         ))
-    if sd.has_attribute("cc_midplane_right_hemi_mask"):
+    if dm_result is not None and sd.has_attribute("cc_midplane_right_hemi_mask"):
         right_hemi_mask_path = sd.filename_by_attribute("cc_midplane_right_hemi_mask")
         right_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
         futures.append(thread_executor().submit(
             nib.save,
-            nib.MGHImage(midplane_refinement.debug_volumes.right_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+            nib.MGHImage(dm_result.debug_volumes.right_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
             right_hemi_mask_path,
         ))
     if sd.has_attribute("cc_midplane_upright_aseg"):
@@ -1459,6 +1483,7 @@ if __name__ == "__main__":
         midplane_left_hemi_mask=options.midplane_left_hemi_mask,
         midplane_right_hemi_mask=options.midplane_right_hemi_mask,
         midplane_upright_aseg=options.midplane_upright_aseg,
+        midplane_method=options.midplane_method,
         cc_surf=options.cc_surf,
         cc_thickness_overlay=options.thickness_overlay,
         cc_html=options.cc_html,

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -453,14 +453,16 @@ def options_parse() -> argparse.Namespace:
     return args
 
 
-# Standard FreeSurfer aseg left/right label pairs.
+# Standard FreeSurfer aseg left/right label pairs used for LR symmetry scoring.
+# Restricted to subcortical structures that are clearly unilateral (present on one side
+# only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded
+# because they wrap both hemispheres throughout the y-z extent, driving all symmetry
+# scores to zero and making the shift selector uninformative.
 _ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
     (2, 41),  # Cerebral-White-Matter
-    (3, 42),  # Cerebral-Cortex
     (4, 43),  # Lateral-Ventricle
     (5, 44),  # Inf-Lat-Vent
     (7, 46),  # Cerebellum-White-Matter
-    (8, 47),  # Cerebellum-Cortex
     (10, 49),  # Thalamus
     (11, 50),  # Caudate
     (12, 51),  # Putamen

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -410,11 +410,7 @@ def options_parse() -> argparse.Namespace:
     return args
 
 
-# Standard FreeSurfer aseg left/right label pairs used for LR symmetry scoring.
-# Restricted to subcortical structures that are clearly unilateral (present on one side
-# only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded
-# because they wrap both hemispheres throughout the y-z extent, driving all symmetry
-# scores to zero and making the shift selector uninformative.
+
 def localize_ac_pc(
     orig_data: Image3d,
     aseg_nib: nibabelImage,
@@ -448,7 +444,7 @@ def localize_ac_pc(
         PC voxel coordinates with shape (2,) containing its [y,x] positions.
     """
     num_slices_to_analyze = resample_shape[0]
-    resample_shape = (num_slices_to_analyze + 2,) + resample_shape[1:]  # 2 for context slices
+    resample_shape = (num_slices_to_analyze + 2,) + resample_shape[1:] # 2 for context slices
     _midslices_fut = thread_executor().submit(
         affine_transform,
         orig_data,

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -287,11 +287,13 @@ def make_parser() -> argparse.ArgumentParser:
     )
     advanced.add_argument(
         "--midplane_method",
-        choices=["none", "lr_shift", "distance_map"],
-        default="lr_shift",
-        help="Midsagittal plane refinement method. 'none': no refinement (baseline); "
-        "'lr_shift': 1D integer-voxel shift by scoring left-right label-pair mirroring (default); "
-        "'distance_map': 3D plane fit from hemisphere distance transforms.",
+        choices=["center", "fsaverage", "fsaverage_symmetry", "fsaverage_distance_map"],
+        default="fsaverage_symmetry",
+        help="Midsagittal plane finding method. "
+        "'center': center slice of the input volume, no alignment; "
+        "'fsaverage': centroid-based alignment to fsaverage template; "
+        "'fsaverage_symmetry': fsaverage alignment + LR label-symmetry shift refinement (default); "
+        "'fsaverage_distance_map': fsaverage alignment + distance-map plane-fitting refinement.",
     )
     advanced.add_argument(
         "--qc_image",
@@ -854,7 +856,7 @@ def main(
     midplane_left_hemi_mask: str | Path | None = None,
     midplane_right_hemi_mask: str | Path | None = None,
     midplane_upright_aseg: str | Path | None = None,
-    midplane_method: str = "lr_shift",
+    midplane_method: str = "fsaverage_symmetry",
     cc_surf: str | Path | None = None,
     cc_thickness_overlay: str | Path | None = None,
     cc_html: str | Path | None = None,
@@ -1046,33 +1048,43 @@ def main(
         logger.error(error_message)
         return error_message
 
-    logger.info("Performing centroid registration to fsaverage space")
-    orig2fsavg_vox2vox, orig2fsavg_ras2ras, fsavg_vox2ras, _fsavg_header_dict = register_centroids_to_fsavg(aseg_img)
-    _fsavg_shape = tuple(_fsavg_header_dict["dims"])
-    _base_middle_vox = float(FSAVERAGE_MIDDLE) / float(vox_size[0])
     dm_result = None
     _aseg_data = np.asarray(aseg_img.dataobj)
-    if midplane_method == "distance_map":
-        dm_result = refine_midplane_with_distance_maps(
-            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-            aseg_data=_aseg_data,
-            fsavg_shape=_fsavg_shape,
-            base_middle_vox=_base_middle_vox,
-        )
-        orig2fsavg_vox2vox = dm_result.updated_vox2vox
-        midline_shift_vox = dm_result.center_shift_vox
-        midline_shift_diagnostics = dm_result.diagnostics
-    elif midplane_method == "lr_shift":
-        orig2fsavg_vox2vox, _lr_shift, _, midline_shift_diagnostics = refine_midline_lr_shift(
-            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-            aseg_data=_aseg_data,
-            fsavg_shape=_fsavg_shape,
-            base_middle_vox=_base_middle_vox,
-        )
-        midline_shift_vox = float(_lr_shift)
-    else:  # "none"
+    if midplane_method == "center":
+        # No registration: use the original image space with the center x-slice as midplane.
+        orig2fsavg_vox2vox = np.eye(4)
+        fsavg_vox2ras = orig.affine
+        _fsavg_header_dict: MGHHeaderDict = {"dims": list(orig.shape[:3])}
+        _fsavg_shape = orig.shape[:3]
+        _base_middle_vox = orig.shape[0] / 2.0
         midline_shift_vox = 0.0
         midline_shift_diagnostics = {}
+    else:
+        logger.info("Performing centroid registration to fsaverage space")
+        orig2fsavg_vox2vox, _, fsavg_vox2ras, _fsavg_header_dict = register_centroids_to_fsavg(aseg_img)
+        _fsavg_shape = tuple(_fsavg_header_dict["dims"])
+        _base_middle_vox = float(FSAVERAGE_MIDDLE) / float(vox_size[0])
+        if midplane_method == "fsaverage_distance_map":
+            dm_result = refine_midplane_with_distance_maps(
+                orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+                aseg_data=_aseg_data,
+                fsavg_shape=_fsavg_shape,
+                base_middle_vox=_base_middle_vox,
+            )
+            orig2fsavg_vox2vox = dm_result.updated_vox2vox
+            midline_shift_vox = dm_result.center_shift_vox
+            midline_shift_diagnostics = dm_result.diagnostics
+        elif midplane_method == "fsaverage_symmetry":
+            orig2fsavg_vox2vox, _lr_shift, _, midline_shift_diagnostics = refine_midline_lr_shift(
+                orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+                aseg_data=_aseg_data,
+                fsavg_shape=_fsavg_shape,
+                base_middle_vox=_base_middle_vox,
+            )
+            midline_shift_vox = float(_lr_shift)
+        else:  # "fsaverage"
+            midline_shift_vox = 0.0
+            midline_shift_diagnostics = {}
     orig2fsavg_ras2ras = fsavg_vox2ras @ orig2fsavg_vox2vox @ np.linalg.inv(orig.affine)
     fsavg_header = init_mgh_header(orig.header, _fsavg_header_dict)
     midplane_upright_aseg_data = resample_segmentation_to_fsavg(
@@ -1147,7 +1159,7 @@ def main(
         )
 
     # calculate affine for segmentation volume
-    fsavg2midslice_vox2vox: AffineMatrix4x4 = offset_affine([-FSAVERAGE_MIDDLE / vox_size[0], 0, 0])
+    fsavg2midslice_vox2vox: AffineMatrix4x4 = offset_affine([-_base_middle_vox, 0, 0])
     orig2midslice_vox2vox = fsavg2midslice_vox2vox @ orig2fsavg_vox2vox
 
     # calculate vox2vox for input resampling volumes

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -44,6 +44,10 @@ from CorpusCallosum.data.read_write import (
     load_fsaverage_data,
 )
 from CorpusCallosum.localization import inference as localization_inference
+from CorpusCallosum.midplane_refinement import (
+    refine_midplane_with_distance_maps,
+    resample_segmentation_to_fsavg,
+)
 from CorpusCallosum.segmentation import inference as segmentation_inference
 from CorpusCallosum.segmentation import segmentation_postprocessing
 from CorpusCallosum.shape.contour import calculate_volume as calculate_cc_volume_contour
@@ -251,6 +255,36 @@ def make_parser() -> argparse.ArgumentParser:
         default=DEFAULT_OUTPUT_PATHS["orient_volume_lta"],
     )
     advanced.add_argument(
+        "--midplane_distance_map",
+        type=path_or_none,
+        help="Output path for the fsaverage-space left-right distance-difference volume used for midplane fitting.",
+        default=None,
+    )
+    advanced.add_argument(
+        "--midplane_fit_mask",
+        type=path_or_none,
+        help="Output path for the fsaverage-space candidate mask used for midplane fitting.",
+        default=None,
+    )
+    advanced.add_argument(
+        "--midplane_left_hemi_mask",
+        type=path_or_none,
+        help="Output path for the cleaned left-hemisphere mask used for the distance map.",
+        default=None,
+    )
+    advanced.add_argument(
+        "--midplane_right_hemi_mask",
+        type=path_or_none,
+        help="Output path for the cleaned right-hemisphere mask used for the distance map.",
+        default=None,
+    )
+    advanced.add_argument(
+        "--midplane_upright_aseg",
+        type=path_or_none,
+        help="Output path for the fsaverage-space transformed segmentation used to derive the midplane masks.",
+        default=None,
+    )
+    advanced.add_argument(
         "--qc_image",
         type=path_or_none,
         help="Output path for QC visualization image.",
@@ -390,6 +424,200 @@ def options_parse() -> argparse.Namespace:
             print(f"WARNING: Not writing '{_warnings_paths}', because --sd and --sid are not specified and "
                   f"its paths are relative.")
     return args
+
+
+def _prepare_lr_pair_labels(seg_data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Create matched left/right label-id arrays from a FreeSurfer-style segmentation."""
+    labels = np.unique(seg_data.astype(np.int32))
+    labels = labels[labels > 0]
+    label_set = set(labels.tolist())
+
+    left_ids = []
+    right_ids = []
+    for left_label in labels:
+        right_label = left_label + 1000
+        if right_label in label_set:
+            left_ids.append(int(left_label))
+            right_ids.append(int(right_label))
+
+    if not left_ids and 2 in label_set and 41 in label_set:
+        left_ids.append(2)
+        right_ids.append(41)
+
+    return np.asarray(left_ids, dtype=np.int32), np.asarray(right_ids, dtype=np.int32)
+
+
+def _score_midline_shift(
+    seg_in_fsavg: np.ndarray,
+    left_ids: np.ndarray,
+    right_ids: np.ndarray,
+    base_middle_vox: float,
+    shift_vox: int,
+    max_pairs_per_slice: int = 64,
+) -> tuple[float, int]:
+    """Score a left-right shift candidate using mirrored anatomy close to the midline."""
+    if left_ids.size == 0 or right_ids.size == 0:
+        return float("inf"), 0
+
+    x_mid = int(np.round(base_middle_vox + shift_vox))
+    if x_mid <= 1 or x_mid >= seg_in_fsavg.shape[0] - 2:
+        return float("inf"), 0
+
+    slab_half = 12
+    x0 = max(0, x_mid - slab_half)
+    x1 = min(seg_in_fsavg.shape[0], x_mid + slab_half + 1)
+    slab = seg_in_fsavg[x0:x1]
+
+    left_mask = np.isin(slab, left_ids)
+    right_mask = np.isin(slab, right_ids)
+    if not left_mask.any() or not right_mask.any():
+        return float("inf"), 0
+
+    distances: list[float] = []
+    for z_idx in range(slab.shape[2]):
+        left_slice = left_mask[:, :, z_idx]
+        right_slice = right_mask[:, :, z_idx]
+        if not left_slice.any() or not right_slice.any():
+            continue
+
+        right_x, right_y = np.where(right_slice)
+        if right_x.size == 0:
+            continue
+
+        if right_x.size > max_pairs_per_slice:
+            sample_idx = np.linspace(0, right_x.size - 1, max_pairs_per_slice).astype(int)
+            right_x = right_x[sample_idx]
+            right_y = right_y[sample_idx]
+
+        for rx, ry in zip(right_x, right_y, strict=False):
+            mirror_x = int(np.clip(2 * (x_mid - x0) - rx, 0, slab.shape[0] - 1))
+            left_row = left_slice[mirror_x]
+            if not left_row.any():
+                continue
+            left_y = np.where(left_row)[0]
+            distances.append(float(np.min(np.abs(left_y - ry))))
+
+    if not distances:
+        return float("inf"), 0
+
+    return float(np.median(distances)), len(distances)
+
+
+def refine_midline_lr_shift(
+    orig2fsavg_vox2vox: AffineMatrix4x4,
+    aseg_nib: nibabelImage,
+    fsavg_shape: Shape3d,
+    base_middle_vox: float,
+    max_shift_vox: int = 6,
+    step_vox: int = 1,
+) -> tuple[AffineMatrix4x4, int, float, dict[str, object]]:
+    """Refine the fsaverage alignment by a small left-right shift around the midsagittal plane."""
+    if max_shift_vox < 0 or step_vox <= 0:
+        return orig2fsavg_vox2vox, 0, float("inf"), {}
+
+    seg_data = np.asarray(aseg_nib.dataobj).astype(np.int32)
+    left_ids, right_ids = _prepare_lr_pair_labels(seg_data)
+    if left_ids.size == 0:
+        logger.warning("Midline refinement skipped: no left/right label pairs found.")
+        return orig2fsavg_vox2vox, 0, float("inf"), {}
+
+    seg_fsavg = affine_transform(
+        seg_data,
+        np.linalg.inv(orig2fsavg_vox2vox),
+        output_shape=fsavg_shape,
+        order=0,
+        mode="constant",
+        cval=0,
+        prefilter=False,
+    ).astype(np.int32)
+
+    candidate_scores: list[dict[str, int | float | None]] = []
+    zero_shift_score = float("inf")
+    zero_shift_support = 0
+    best_shift = 0
+    best_adjusted_score = float("inf")
+    best_raw_score = float("inf")
+    best_support = 0
+    shift_penalty = 0.25
+    min_improvement = 0.5
+    min_support = 32
+
+    for shift in range(-max_shift_vox, max_shift_vox + 1, step_vox):
+        raw_score, support = _score_midline_shift(
+            seg_fsavg,
+            left_ids,
+            right_ids,
+            base_middle_vox=base_middle_vox,
+            shift_vox=-shift,
+        )
+        adjusted_score = raw_score + shift_penalty * abs(shift)
+        candidate_scores.append({
+            "shift_vox": int(shift),
+            "raw_score": float(raw_score) if np.isfinite(raw_score) else None,
+            "adjusted_score": float(adjusted_score) if np.isfinite(adjusted_score) else None,
+            "support": int(support),
+        })
+        if shift == 0:
+            zero_shift_score = raw_score
+            zero_shift_support = support
+        if adjusted_score < best_adjusted_score:
+            best_adjusted_score = adjusted_score
+            best_raw_score = raw_score
+            best_shift = shift
+            best_support = support
+
+    diagnostics: dict[str, object] = {
+        "candidate_scores": candidate_scores,
+        "zero_shift_score": float(zero_shift_score) if np.isfinite(zero_shift_score) else None,
+        "zero_shift_support": int(zero_shift_support),
+        "selected_shift_raw_score": float(best_raw_score) if np.isfinite(best_raw_score) else None,
+        "selected_shift_adjusted_score": float(best_adjusted_score) if np.isfinite(best_adjusted_score) else None,
+        "selected_shift_support": int(best_support),
+        "shift_penalty": shift_penalty,
+        "min_improvement": min_improvement,
+        "min_support": min_support,
+    }
+
+    at_boundary = abs(best_shift) == max_shift_vox
+    insufficient_support = best_support < min_support
+    no_baseline = not np.isfinite(zero_shift_score)
+    small_improvement = (
+        np.isfinite(best_raw_score)
+        and np.isfinite(zero_shift_score)
+        and (zero_shift_score - best_raw_score) < min_improvement
+    )
+    reject_shift = (
+        best_shift == 0
+        or not np.isfinite(best_raw_score)
+        or at_boundary
+        or insufficient_support
+        or (not no_baseline and small_improvement)
+    )
+
+    diagnostics["rejected_boundary_shift"] = at_boundary
+    diagnostics["rejected_low_support"] = insufficient_support
+    diagnostics["rejected_small_improvement"] = (not no_baseline and small_improvement)
+
+    if reject_shift:
+        logger.info(
+            "Midline refinement applied no LR correction (best_shift=%d, raw_score=%s, zero_score=%s, support=%d).",
+            best_shift,
+            f"{best_raw_score:.3f}" if np.isfinite(best_raw_score) else "inf",
+            f"{zero_shift_score:.3f}" if np.isfinite(zero_shift_score) else "inf",
+            best_support,
+        )
+        return orig2fsavg_vox2vox, 0, zero_shift_score, diagnostics
+
+    updated_transform = offset_affine([best_shift, 0, 0]) @ orig2fsavg_vox2vox
+    logger.info(
+        "Midline refinement applied %+d vox LR correction in fsaverage space "
+        "(raw_score=%.3f, zero_score=%.3f, support=%d).",
+        best_shift,
+        best_raw_score,
+        zero_shift_score,
+        best_support,
+    )
+    return updated_transform, best_shift, best_raw_score, diagnostics
 
 
 def register_centroids_to_fsavg(aseg_nib: nibabelImage) \
@@ -589,6 +817,11 @@ def main(
     cc_mid_measures: str | Path | None = None,
     upright_lta: str | Path | None = None,
     orient_volume_lta: str | Path | None = None,
+    midplane_distance_map: str | Path | None = None,
+    midplane_fit_mask: str | Path | None = None,
+    midplane_left_hemi_mask: str | Path | None = None,
+    midplane_right_hemi_mask: str | Path | None = None,
+    midplane_upright_aseg: str | Path | None = None,
     cc_surf: str | Path | None = None,
     cc_thickness_overlay: str | Path | None = None,
     cc_html: str | Path | None = None,
@@ -713,6 +946,11 @@ def main(
         cc_mid_measures=cc_mid_measures,
         upright_lta=upright_lta,
         cc_orient_volume_lta=orient_volume_lta,
+        cc_midplane_distance_map=midplane_distance_map,
+        cc_midplane_fit_mask=midplane_fit_mask,
+        cc_midplane_left_hemi_mask=midplane_left_hemi_mask,
+        cc_midplane_right_hemi_mask=midplane_right_hemi_mask,
+        cc_midplane_upright_aseg=midplane_upright_aseg,
         cc_surf=cc_surf,
         cc_thickness_overlay=cc_thickness_overlay,
         cc_html=cc_html,
@@ -777,7 +1015,64 @@ def main(
 
     logger.info("Performing centroid registration to fsaverage space")
     orig2fsavg_vox2vox, orig2fsavg_ras2ras, fsavg_vox2ras, _fsavg_header_dict = register_centroids_to_fsavg(aseg_img)
+    midplane_refinement = refine_midplane_with_distance_maps(
+        orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+        aseg_nib=aseg_img,
+        fsavg_shape=tuple(_fsavg_header_dict["dims"]),
+        base_middle_vox=float(FSAVERAGE_MIDDLE) / float(vox_size[0]),
+    )
+    orig2fsavg_vox2vox = midplane_refinement.updated_vox2vox
+    midline_shift_vox = midplane_refinement.center_shift_vox
+    midline_shift_diagnostics = midplane_refinement.diagnostics
+    orig2fsavg_ras2ras = fsavg_vox2ras @ orig2fsavg_vox2vox @ np.linalg.inv(orig.affine)
     fsavg_header = init_mgh_header(orig.header, _fsavg_header_dict)
+    midplane_upright_aseg_data = resample_segmentation_to_fsavg(
+        np.asarray(aseg_img.dataobj),
+        orig2fsavg_vox2vox,
+        tuple(_fsavg_header_dict["dims"]),
+    )
+
+    if sd.has_attribute("cc_midplane_distance_map"):
+        distance_map_path = sd.filename_by_attribute("cc_midplane_distance_map")
+        distance_map_path.parent.mkdir(exist_ok=True, parents=True)
+        futures.append(thread_executor().submit(
+            nib.save,
+            nib.MGHImage(midplane_refinement.debug_volumes.distance_diff.astype(np.float32),
+                         fsavg_vox2ras, orig.header),
+            distance_map_path,
+        ))
+    if sd.has_attribute("cc_midplane_fit_mask"):
+        fit_mask_path = sd.filename_by_attribute("cc_midplane_fit_mask")
+        fit_mask_path.parent.mkdir(exist_ok=True, parents=True)
+        futures.append(thread_executor().submit(
+            nib.save,
+            nib.MGHImage(midplane_refinement.debug_volumes.candidate_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+            fit_mask_path,
+        ))
+    if sd.has_attribute("cc_midplane_left_hemi_mask"):
+        left_hemi_mask_path = sd.filename_by_attribute("cc_midplane_left_hemi_mask")
+        left_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
+        futures.append(thread_executor().submit(
+            nib.save,
+            nib.MGHImage(midplane_refinement.debug_volumes.left_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+            left_hemi_mask_path,
+        ))
+    if sd.has_attribute("cc_midplane_right_hemi_mask"):
+        right_hemi_mask_path = sd.filename_by_attribute("cc_midplane_right_hemi_mask")
+        right_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
+        futures.append(thread_executor().submit(
+            nib.save,
+            nib.MGHImage(midplane_refinement.debug_volumes.right_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
+            right_hemi_mask_path,
+        ))
+    if sd.has_attribute("cc_midplane_upright_aseg"):
+        upright_aseg_path = sd.filename_by_attribute("cc_midplane_upright_aseg")
+        upright_aseg_path.parent.mkdir(exist_ok=True, parents=True)
+        futures.append(thread_executor().submit(
+            nib.save,
+            nib.MGHImage(midplane_upright_aseg_data.astype(np.int32), fsavg_vox2ras, orig.header),
+            upright_aseg_path,
+        ))
 
     # start saving upright volume, this is the image in fsaverage space but not yet oriented via AC-PC
     if sd.has_attribute("upright_volume"):
@@ -1009,6 +1304,8 @@ def main(
     additional_metrics["subdivision_ratios"] = subdivisions
     additional_metrics["contour_smoothing"] = contour_smoothing
     additional_metrics["slice_selection"] = slice_selection
+    additional_metrics["midline_refine_shift_vox"] = int(midline_shift_vox)
+    additional_metrics["midline_refine_diagnostics"] = midline_shift_diagnostics
 
     # QC checks
     if len(outer_contours) > 1 and cc_volume_contour is not None:
@@ -1157,6 +1454,11 @@ if __name__ == "__main__":
         cc_mid_measures=options.cc_mid_measures,
         upright_lta=options.upright_lta,
         orient_volume_lta=options.orient_volume_lta,
+        midplane_distance_map=options.midplane_distance_map,
+        midplane_fit_mask=options.midplane_fit_mask,
+        midplane_left_hemi_mask=options.midplane_left_hemi_mask,
+        midplane_right_hemi_mask=options.midplane_right_hemi_mask,
+        midplane_upright_aseg=options.midplane_upright_aseg,
         cc_surf=options.cc_surf,
         cc_thickness_overlay=options.thickness_overlay,
         cc_html=options.cc_html,

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -238,7 +238,7 @@ def make_parser() -> argparse.ArgumentParser:
         "--orient_volume_lta",
         type=path_or_none,
         help="Output path for orientation volume LTA transform. This makes sure the midplane is the volume center, "
-        "the anterior and posterior commisures are on the coordinate line, and the posterior commissure is "
+        "the anterior and posterior commissures are on the coordinate line, and the posterior commissure is "
         "at the origin - standardizing the head position.",
         default=DEFAULT_OUTPUT_PATHS["orient_volume_lta"],
     )

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -31,23 +31,11 @@ from CorpusCallosum.data.constants import (
     CC_LABEL,
     DEFAULT_INPUT_PATHS,
     DEFAULT_OUTPUT_PATHS,
-    FSAVERAGE_CENTROIDS_PATH,
-    FSAVERAGE_DATA_PATH,
-    FSAVERAGE_MIDDLE,
     THIRD_VENTRICLE_LABEL,
 )
-from CorpusCallosum.data.read_write import (
-    MGHHeaderDict,
-    calc_ras_centroids_from_seg,
-    convert_numpy_to_json_serializable,
-    load_fsaverage_centroids,
-    load_fsaverage_data,
-)
+from CorpusCallosum.data.read_write import MGHHeaderDict, convert_numpy_to_json_serializable
 from CorpusCallosum.localization import inference as localization_inference
-from CorpusCallosum.midplane_refinement import (
-    refine_midplane_with_distance_maps,
-    resample_segmentation_to_fsavg,
-)
+from CorpusCallosum.midplane_refinement import find_midplane_transform
 from CorpusCallosum.segmentation import inference as segmentation_inference
 from CorpusCallosum.segmentation import segmentation_postprocessing
 from CorpusCallosum.shape.contour import calculate_volume as calculate_cc_volume_contour
@@ -82,7 +70,6 @@ from FastSurferCNN.utils.common import SubjectDirectory, find_device
 from FastSurferCNN.utils.lta import write_lta
 from FastSurferCNN.utils.parallel import get_num_threads, serial_executor, shutdown_executors, thread_executor
 from FastSurferCNN.utils.parser_defaults import modify_argument
-from recon_surf.align_points import find_rigid
 
 logger = logging.get_logger(__name__)
 
@@ -254,36 +241,6 @@ def make_parser() -> argparse.ArgumentParser:
         "the anterior and posterior commisures are on the coordinate line, and the posterior commissure is "
         "at the origin - standardizing the head position.",
         default=DEFAULT_OUTPUT_PATHS["orient_volume_lta"],
-    )
-    advanced.add_argument(
-        "--midplane_distance_map",
-        type=path_or_none,
-        help="Output path for the fsaverage-space left-right distance-difference volume used for midplane fitting.",
-        default=None,
-    )
-    advanced.add_argument(
-        "--midplane_fit_mask",
-        type=path_or_none,
-        help="Output path for the fsaverage-space candidate mask used for midplane fitting.",
-        default=None,
-    )
-    advanced.add_argument(
-        "--midplane_left_hemi_mask",
-        type=path_or_none,
-        help="Output path for the cleaned left-hemisphere mask used for the distance map.",
-        default=None,
-    )
-    advanced.add_argument(
-        "--midplane_right_hemi_mask",
-        type=path_or_none,
-        help="Output path for the cleaned right-hemisphere mask used for the distance map.",
-        default=None,
-    )
-    advanced.add_argument(
-        "--midplane_upright_aseg",
-        type=path_or_none,
-        help="Output path for the fsaverage-space transformed segmentation used to derive the midplane masks.",
-        default=None,
     )
     advanced.add_argument(
         "--midplane_method",
@@ -458,270 +415,6 @@ def options_parse() -> argparse.Namespace:
 # only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded
 # because they wrap both hemispheres throughout the y-z extent, driving all symmetry
 # scores to zero and making the shift selector uninformative.
-_ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
-    (2, 41),  # Cerebral-White-Matter
-    (4, 43),  # Lateral-Ventricle
-    (5, 44),  # Inf-Lat-Vent
-    (7, 46),  # Cerebellum-White-Matter
-    (10, 49),  # Thalamus
-    (11, 50),  # Caudate
-    (12, 51),  # Putamen
-    (13, 52),  # Pallidum
-    (17, 53),  # Hippocampus
-    (18, 54),  # Amygdala
-    (26, 58),  # Accumbens-area
-    (28, 60),  # VentralDC
-)
-
-
-def _prepare_lr_pair_labels(seg_data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Create matched left/right label-id arrays from a FreeSurfer-style segmentation."""
-    label_set = set(np.unique(seg_data.astype(np.int32)).tolist())
-    label_set.discard(0)
-
-    left_ids = [lbl for lbl, r in _ASEG_LR_PAIRS if lbl in label_set and r in label_set]
-    right_ids = [r for lbl, r in _ASEG_LR_PAIRS if lbl in label_set and r in label_set]
-
-    return np.asarray(left_ids, dtype=np.int32), np.asarray(right_ids, dtype=np.int32)
-
-
-def _score_midline_shift(
-    seg_in_fsavg: np.ndarray,
-    left_ids: np.ndarray,
-    right_ids: np.ndarray,
-    base_middle_vox: float,
-    shift_vox: int,
-    max_pairs_per_slice: int = 64,
-) -> tuple[float, int]:
-    """Score a left-right shift candidate using mirrored anatomy close to the midline."""
-    if left_ids.size == 0 or right_ids.size == 0:
-        return float("inf"), 0
-
-    x_mid = int(np.round(base_middle_vox + shift_vox))
-    if x_mid <= 1 or x_mid >= seg_in_fsavg.shape[0] - 2:
-        return float("inf"), 0
-
-    slab_half = 12
-    x0 = max(0, x_mid - slab_half)
-    x1 = min(seg_in_fsavg.shape[0], x_mid + slab_half + 1)
-    slab = seg_in_fsavg[x0:x1]
-
-    left_mask = np.isin(slab, left_ids)
-    right_mask = np.isin(slab, right_ids)
-    if not left_mask.any() or not right_mask.any():
-        return float("inf"), 0
-
-    distances: list[float] = []
-    for z_idx in range(slab.shape[2]):
-        left_slice = left_mask[:, :, z_idx]
-        right_slice = right_mask[:, :, z_idx]
-        if not left_slice.any() or not right_slice.any():
-            continue
-
-        right_x, right_y = np.where(right_slice)
-        if right_x.size == 0:
-            continue
-
-        if right_x.size > max_pairs_per_slice:
-            sample_idx = np.linspace(0, right_x.size - 1, max_pairs_per_slice).astype(int)
-            right_x = right_x[sample_idx]
-            right_y = right_y[sample_idx]
-
-        for rx, ry in zip(right_x, right_y, strict=False):
-            mirror_x = int(np.clip(2 * (x_mid - x0) - rx, 0, slab.shape[0] - 1))
-            left_row = left_slice[mirror_x]
-            if not left_row.any():
-                continue
-            left_y = np.where(left_row)[0]
-            distances.append(float(np.min(np.abs(left_y - ry))))
-
-    if not distances:
-        return float("inf"), 0
-
-    return float(np.median(distances)), len(distances)
-
-
-def refine_midline_lr_shift(
-    orig2fsavg_vox2vox: AffineMatrix4x4,
-    aseg_data: np.ndarray,
-    fsavg_shape: Shape3d,
-    base_middle_vox: float,
-    max_shift_vox: int = 6,
-    step_vox: int = 1,
-) -> tuple[AffineMatrix4x4, int, float, dict[str, object]]:
-    """Refine the fsaverage alignment by a small left-right shift around the midsagittal plane."""
-    if max_shift_vox < 0 or step_vox <= 0:
-        return orig2fsavg_vox2vox, 0, float("inf"), {}
-
-    seg_data = aseg_data.astype(np.int32)
-    left_ids, right_ids = _prepare_lr_pair_labels(seg_data)
-    if left_ids.size == 0:
-        logger.warning("Midline refinement skipped: no left/right label pairs found.")
-        return orig2fsavg_vox2vox, 0, float("inf"), {}
-
-    seg_fsavg = resample_segmentation_to_fsavg(seg_data, orig2fsavg_vox2vox, fsavg_shape)
-
-    candidate_scores: list[dict[str, int | float | None]] = []
-    zero_shift_score = float("inf")
-    zero_shift_support = 0
-    best_shift = 0
-    best_adjusted_score = float("inf")
-    best_raw_score = float("inf")
-    best_support = 0
-    shift_penalty = 0.25
-    min_improvement = 0.5
-    min_support = 32
-
-    for shift in range(-max_shift_vox, max_shift_vox + 1, step_vox):
-        raw_score, support = _score_midline_shift(
-            seg_fsavg,
-            left_ids,
-            right_ids,
-            base_middle_vox=base_middle_vox,
-            shift_vox=-shift,
-        )
-        adjusted_score = raw_score + shift_penalty * abs(shift)
-        candidate_scores.append(
-            {
-                "shift_vox": int(shift),
-                "raw_score": float(raw_score) if np.isfinite(raw_score) else None,
-                "adjusted_score": float(adjusted_score) if np.isfinite(adjusted_score) else None,
-                "support": int(support),
-            }
-        )
-        if shift == 0:
-            zero_shift_score = raw_score
-            zero_shift_support = support
-        if adjusted_score < best_adjusted_score:
-            best_adjusted_score = adjusted_score
-            best_raw_score = raw_score
-            best_shift = shift
-            best_support = support
-
-    diagnostics: dict[str, object] = {
-        "candidate_scores": candidate_scores,
-        "zero_shift_score": float(zero_shift_score) if np.isfinite(zero_shift_score) else None,
-        "zero_shift_support": int(zero_shift_support),
-        "selected_shift_raw_score": float(best_raw_score) if np.isfinite(best_raw_score) else None,
-        "selected_shift_adjusted_score": float(best_adjusted_score) if np.isfinite(best_adjusted_score) else None,
-        "selected_shift_support": int(best_support),
-        "shift_penalty": shift_penalty,
-        "min_improvement": min_improvement,
-        "min_support": min_support,
-    }
-
-    at_boundary = abs(best_shift) == max_shift_vox
-    insufficient_support = best_support < min_support
-    no_baseline = not np.isfinite(zero_shift_score)
-    small_improvement = (
-        np.isfinite(best_raw_score)
-        and np.isfinite(zero_shift_score)
-        and (zero_shift_score - best_raw_score) < min_improvement
-    )
-    reject_shift = (
-        best_shift == 0
-        or not np.isfinite(best_raw_score)
-        or at_boundary
-        or insufficient_support
-        or (not no_baseline and small_improvement)
-    )
-
-    diagnostics["no_baseline"] = no_baseline
-    diagnostics["rejected_boundary_shift"] = at_boundary
-    diagnostics["rejected_low_support"] = insufficient_support
-    diagnostics["rejected_small_improvement"] = not no_baseline and small_improvement
-
-    if reject_shift:
-        logger.info(
-            "Midline refinement applied no LR correction (best_shift=%d, raw_score=%s, zero_score=%s, support=%d).",
-            best_shift,
-            f"{best_raw_score:.3f}" if np.isfinite(best_raw_score) else "inf",
-            f"{zero_shift_score:.3f}" if np.isfinite(zero_shift_score) else "inf",
-            best_support,
-        )
-        return orig2fsavg_vox2vox, 0, zero_shift_score, diagnostics
-
-    updated_transform = offset_affine([best_shift, 0, 0]) @ orig2fsavg_vox2vox
-    logger.info(
-        "Midline refinement applied %+d vox LR correction in fsaverage space "
-        "(raw_score=%.3f, zero_score=%.3f, support=%d).",
-        best_shift,
-        best_raw_score,
-        zero_shift_score,
-        best_support,
-    )
-    return updated_transform, best_shift, best_raw_score, diagnostics
-
-
-def register_centroids_to_fsavg(
-    aseg_nib: nibabelImage,
-) -> tuple[AffineMatrix4x4, AffineMatrix4x4, AffineMatrix4x4, MGHHeaderDict]:
-    """Perform centroid-based registration between subject and fsaverage space.
-
-    Computes a rigid transformation between the subject's segmentation and fsaverage space
-    by aligning centroids of corresponding anatomical structures.
-
-    Parameters
-    ----------
-    aseg_nib : nibabel.analyze.SpatialImage
-        Subject's segmentation image.
-
-    Returns
-    -------
-    aseg2fsaverage_vox2vox : AffineMatrix4x4
-        Transformation matrix from original to fsaverage voxel space.
-    aseg2fsaverage_ras2ras : AffineMatrix4x4
-        Transformation matrix from original to fsaverage RAS space.
-    fsaverage_hires_vox2ras : AffineMatrix4x4
-        High-resolution fsaverage affine matrix.
-    fsaverage_header : MGHHeaderDict
-        FSAverage header fields for LTA writing.
-
-    Notes
-    -----
-    The function uses pre-computed fsaverage centroids and data from static files
-    to perform the registration. It matches corresponding anatomical structures
-    between the subject's segmentation and fsaverage space.
-    """
-    logger.info("Starting centroid registration")
-
-    # Load pre-computed fsaverage centroids and data from static files
-    fsaverage_data_future = thread_executor().submit(load_fsaverage_data, FSAVERAGE_DATA_PATH)
-    ras_centroids_dst = load_fsaverage_centroids(FSAVERAGE_CENTROIDS_PATH)
-
-    ras_centroids_mov = calc_ras_centroids_from_seg(aseg_nib, label_ids=list(ras_centroids_dst.keys()))
-
-    # get the set of joint labels
-    joint_centroid_labels = [lbl for lbl, v in ras_centroids_mov.items() if v is not None]
-
-    ras_centroids_mov = np.array([ras_centroids_mov[lbl] for lbl in joint_centroid_labels]).T
-    ras_centroids_dst = np.array([ras_centroids_dst[lbl] for lbl in joint_centroid_labels]).T
-
-    aseg2fsaverage_ras2ras: AffineMatrix4x4 = find_rigid(p_mov=ras_centroids_mov.T, p_dst=ras_centroids_dst.T)
-
-    # make affine that increases resolution to orig resolution
-    aseg_zooms_ras = np.asarray(nib.as_closest_canonical(aseg_nib).header.get_zooms()[:3])
-    resolution_trans: AffineMatrix4x4 = np.diagflat(np.append(aseg_zooms_ras[[0, 2, 1]], [1])).astype(float)
-
-    fsaverage_vox2ras, fsavg_header = fsaverage_data_future.result()
-    fsavg_header["delta"] = aseg_zooms_ras[[0, 2, 1]]  # vox sizes in lia
-    # fsavg_hires_vox2ras translation should be 128 always (independent of resolution)
-    fsavg_hires_vox2ras: AffineMatrix4x4 = np.concatenate(
-        [(resolution_trans @ fsaverage_vox2ras)[:, :3], fsaverage_vox2ras[:, 3:4]],
-        axis=1,
-    )
-    fsavg_header["dims"] = np.ceil(fsavg_header["dims"] @ np.linalg.inv(resolution_trans[:3, :3])).astype(int).tolist()
-
-    # Correct fsavg_header["Pxyz_c"] by (vox_size - 1) / 2 in all three directions, because Pxyz_c is not actually in
-    # the center of the image, but in the center of the voxel in increasing voxel index direction, i.e. index 128 for a
-    # 256 image (where the center would be at 127.5).
-    fsavg_header["Pxyz_c"] += (aseg_zooms_ras - 1) / 2 @ fsavg_header["Mdc"]
-
-    aseg2fsavg_vox2vox: AffineMatrix4x4 = np.linalg.inv(fsavg_hires_vox2ras) @ aseg2fsaverage_ras2ras @ aseg_nib.affine
-    logger.info("Centroid registration successful!")
-    return aseg2fsavg_vox2vox, aseg2fsaverage_ras2ras, fsavg_hires_vox2ras, fsavg_header
-
-
 def localize_ac_pc(
     orig_data: Image3d,
     aseg_nib: nibabelImage,
@@ -853,11 +546,6 @@ def main(
     cc_mid_measures: str | Path | None = None,
     upright_lta: str | Path | None = None,
     orient_volume_lta: str | Path | None = None,
-    midplane_distance_map: str | Path | None = None,
-    midplane_fit_mask: str | Path | None = None,
-    midplane_left_hemi_mask: str | Path | None = None,
-    midplane_right_hemi_mask: str | Path | None = None,
-    midplane_upright_aseg: str | Path | None = None,
     midplane_method: str = "fsaverage_symmetry",
     cc_surf: str | Path | None = None,
     cc_thickness_overlay: str | Path | None = None,
@@ -983,11 +671,6 @@ def main(
         cc_mid_measures=cc_mid_measures,
         upright_lta=upright_lta,
         cc_orient_volume_lta=orient_volume_lta,
-        cc_midplane_distance_map=midplane_distance_map,
-        cc_midplane_fit_mask=midplane_fit_mask,
-        cc_midplane_left_hemi_mask=midplane_left_hemi_mask,
-        cc_midplane_right_hemi_mask=midplane_right_hemi_mask,
-        cc_midplane_upright_aseg=midplane_upright_aseg,
         cc_surf=cc_surf,
         cc_thickness_overlay=cc_thickness_overlay,
         cc_html=cc_html,
@@ -1050,101 +733,16 @@ def main(
         logger.error(error_message)
         return error_message
 
-    dm_result = None
-    _aseg_data = np.asarray(aseg_img.dataobj)
-    if midplane_method == "center":
-        # No registration: use the original image space with the center x-slice as midplane.
-        orig2fsavg_vox2vox = np.eye(4)
-        fsavg_vox2ras = orig.affine
-        _fsavg_header_dict: MGHHeaderDict = {"dims": list(orig.shape[:3])}
-        _fsavg_shape = orig.shape[:3]
-        _base_middle_vox = orig.shape[0] / 2.0
-        midline_shift_vox = 0.0
-        midline_shift_diagnostics = {}
-    else:
-        logger.info("Performing centroid registration to fsaverage space")
-        orig2fsavg_vox2vox, _, fsavg_vox2ras, _fsavg_header_dict = register_centroids_to_fsavg(aseg_img)
-        _fsavg_shape = tuple(_fsavg_header_dict["dims"])
-        _base_middle_vox = float(FSAVERAGE_MIDDLE) / float(vox_size[0])
-        if midplane_method == "fsaverage_distance_map":
-            dm_result = refine_midplane_with_distance_maps(
-                orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-                aseg_data=_aseg_data,
-                fsavg_shape=_fsavg_shape,
-                base_middle_vox=_base_middle_vox,
-            )
-            orig2fsavg_vox2vox = dm_result.updated_vox2vox
-            midline_shift_vox = dm_result.center_shift_vox
-            midline_shift_diagnostics = dm_result.diagnostics
-        elif midplane_method == "fsaverage_symmetry":
-            orig2fsavg_vox2vox, _lr_shift, _, midline_shift_diagnostics = refine_midline_lr_shift(
-                orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-                aseg_data=_aseg_data,
-                fsavg_shape=_fsavg_shape,
-                base_middle_vox=_base_middle_vox,
-            )
-            midline_shift_vox = float(_lr_shift)
-        else:  # "fsaverage"
-            midline_shift_vox = 0.0
-            midline_shift_diagnostics = {}
+    midplane = find_midplane_transform(orig=orig, aseg_img=aseg_img, midplane_method=midplane_method)
+    orig2fsavg_vox2vox = midplane.orig2fsavg_vox2vox
+    fsavg_vox2ras = midplane.fsavg_vox2ras
+    _fsavg_header_dict = midplane.fsavg_header_dict
+    _fsavg_shape = midplane.fsavg_shape
+    _base_middle_vox = midplane.base_middle_vox
+    midline_shift_vox = midplane.midline_shift_vox
+    midline_shift_diagnostics = midplane.midline_shift_diagnostics
     orig2fsavg_ras2ras = fsavg_vox2ras @ orig2fsavg_vox2vox @ np.linalg.inv(orig.affine)
     fsavg_header = init_mgh_header(orig.header, _fsavg_header_dict)
-    midplane_upright_aseg_data = resample_segmentation_to_fsavg(
-        np.asarray(aseg_img.dataobj),
-        orig2fsavg_vox2vox,
-        _fsavg_shape,
-    )
-
-    if dm_result is not None and sd.has_attribute("cc_midplane_distance_map"):
-        distance_map_path = sd.filename_by_attribute("cc_midplane_distance_map")
-        distance_map_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(
-            thread_executor().submit(
-                nib.save,
-                nib.MGHImage(dm_result.debug_volumes.distance_diff.astype(np.float32), fsavg_vox2ras, orig.header),
-                distance_map_path,
-            )
-        )
-    if dm_result is not None and sd.has_attribute("cc_midplane_fit_mask"):
-        fit_mask_path = sd.filename_by_attribute("cc_midplane_fit_mask")
-        fit_mask_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(
-            thread_executor().submit(
-                nib.save,
-                nib.MGHImage(dm_result.debug_volumes.candidate_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
-                fit_mask_path,
-            )
-        )
-    if dm_result is not None and sd.has_attribute("cc_midplane_left_hemi_mask"):
-        left_hemi_mask_path = sd.filename_by_attribute("cc_midplane_left_hemi_mask")
-        left_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(
-            thread_executor().submit(
-                nib.save,
-                nib.MGHImage(dm_result.debug_volumes.left_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
-                left_hemi_mask_path,
-            )
-        )
-    if dm_result is not None and sd.has_attribute("cc_midplane_right_hemi_mask"):
-        right_hemi_mask_path = sd.filename_by_attribute("cc_midplane_right_hemi_mask")
-        right_hemi_mask_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(
-            thread_executor().submit(
-                nib.save,
-                nib.MGHImage(dm_result.debug_volumes.right_mask.astype(np.uint8), fsavg_vox2ras, orig.header),
-                right_hemi_mask_path,
-            )
-        )
-    if sd.has_attribute("cc_midplane_upright_aseg"):
-        upright_aseg_path = sd.filename_by_attribute("cc_midplane_upright_aseg")
-        upright_aseg_path.parent.mkdir(exist_ok=True, parents=True)
-        futures.append(
-            thread_executor().submit(
-                nib.save,
-                nib.MGHImage(midplane_upright_aseg_data.astype(np.int32), fsavg_vox2ras, orig.header),
-                upright_aseg_path,
-            )
-        )
 
     # start saving upright volume, this is the image in fsaverage space but not yet oriented via AC-PC
     if sd.has_attribute("upright_volume"):
@@ -1545,11 +1143,6 @@ if __name__ == "__main__":
             cc_mid_measures=options.cc_mid_measures,
             upright_lta=options.upright_lta,
             orient_volume_lta=options.orient_volume_lta,
-            midplane_distance_map=options.midplane_distance_map,
-            midplane_fit_mask=options.midplane_fit_mask,
-            midplane_left_hemi_mask=options.midplane_left_hemi_mask,
-            midplane_right_hemi_mask=options.midplane_right_hemi_mask,
-            midplane_upright_aseg=options.midplane_upright_aseg,
             midplane_method=options.midplane_method,
             cc_surf=options.cc_surf,
             cc_thickness_overlay=options.thickness_overlay,

--- a/CorpusCallosum/midplane_refinement.py
+++ b/CorpusCallosum/midplane_refinement.py
@@ -23,6 +23,11 @@ from recon_surf.align_points import find_rigid
 
 logger = logging.get_logger(__name__)
 
+# Standard FreeSurfer aseg left/right label pairs used for LR symmetry scoring.
+# Restricted to subcortical structures that are clearly unilateral (present on one side
+# only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded
+# because they wrap both hemispheres throughout the y-z extent, driving all symmetry
+# scores to zero and making the shift selector uninformative.
 _ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
     (2, 41),
     (3, 42),

--- a/CorpusCallosum/midplane_refinement.py
+++ b/CorpusCallosum/midplane_refinement.py
@@ -2,16 +2,43 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import nibabel as nib
 import numpy as np
 from scipy.ndimage import affine_transform, binary_fill_holes, distance_transform_edt
 from skimage.morphology import convex_hull_image
 
+from CorpusCallosum.data.constants import FSAVERAGE_CENTROIDS_PATH, FSAVERAGE_DATA_PATH, FSAVERAGE_MIDDLE
 from CorpusCallosum.data.read_write import convert_numpy_to_json_serializable
+from CorpusCallosum.data.read_write import (
+    MGHHeaderDict,
+    calc_ras_centroids_from_seg,
+    load_fsaverage_centroids,
+    load_fsaverage_data,
+)
 from CorpusCallosum.shape.postprocessing import offset_affine
-from FastSurferCNN.utils import AffineMatrix4x4, Shape3d, logging
+from FastSurferCNN.utils import AffineMatrix4x4, Shape3d, logging, nibabelImage
 from FastSurferCNN.utils.brainvolstats import hemi_masks_from_aseg
+from FastSurferCNN.utils.parallel import thread_executor
+from recon_surf.align_points import find_rigid
 
 logger = logging.get_logger(__name__)
+
+_ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
+    (2, 41),
+    (3, 42),
+    (4, 43),
+    (5, 44),
+    (7, 46),
+    (8, 47),
+    (10, 49),
+    (11, 50),
+    (12, 51),
+    (13, 52),
+    (17, 53),
+    (18, 54),
+    (26, 58),
+    (28, 60),
+)
 
 
 @dataclass(frozen=True)
@@ -28,6 +55,17 @@ class MidplaneRefinementResult:
     center_shift_vox: float
     diagnostics: dict[str, object]
     debug_volumes: MidplaneDebugVolumes
+
+
+@dataclass(frozen=True)
+class MidplaneTransformResult:
+    orig2fsavg_vox2vox: AffineMatrix4x4
+    fsavg_vox2ras: AffineMatrix4x4
+    fsavg_header_dict: MGHHeaderDict
+    fsavg_shape: Shape3d
+    base_middle_vox: float
+    midline_shift_vox: float
+    midline_shift_diagnostics: dict[str, object]
 
 
 def resample_segmentation_to_fsavg(
@@ -148,6 +186,219 @@ def _affine_from_rotation_and_center(rotation: np.ndarray, center: np.ndarray) -
     affine[:3, :3] = rotation
     affine[:3, 3] = center - rotation @ center
     return affine
+
+
+def _prepare_lr_pair_labels(seg_data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Create matched left/right label-id arrays from a FreeSurfer-style segmentation."""
+    label_set = set(np.unique(seg_data.astype(np.int32)).tolist())
+    label_set.discard(0)
+
+    left_ids = [lbl for lbl, r in _ASEG_LR_PAIRS if lbl in label_set and r in label_set]
+    right_ids = [r for lbl, r in _ASEG_LR_PAIRS if lbl in label_set and r in label_set]
+
+    return np.asarray(left_ids, dtype=np.int32), np.asarray(right_ids, dtype=np.int32)
+
+
+def _score_midline_shift(
+    seg_in_fsavg: np.ndarray,
+    left_ids: np.ndarray,
+    right_ids: np.ndarray,
+    base_middle_vox: float,
+    shift_vox: int,
+    max_pairs_per_slice: int = 64,
+) -> tuple[float, int]:
+    """Score a left-right shift candidate using mirrored anatomy close to the midline."""
+    if left_ids.size == 0 or right_ids.size == 0:
+        return float("inf"), 0
+
+    x_mid = int(np.round(base_middle_vox + shift_vox))
+    if x_mid <= 1 or x_mid >= seg_in_fsavg.shape[0] - 2:
+        return float("inf"), 0
+
+    slab_half = 12
+    x0 = max(0, x_mid - slab_half)
+    x1 = min(seg_in_fsavg.shape[0], x_mid + slab_half + 1)
+    slab = seg_in_fsavg[x0:x1]
+
+    left_mask = np.isin(slab, left_ids)
+    right_mask = np.isin(slab, right_ids)
+    if not left_mask.any() or not right_mask.any():
+        return float("inf"), 0
+
+    distances: list[float] = []
+    for z_idx in range(slab.shape[2]):
+        left_slice = left_mask[:, :, z_idx]
+        right_slice = right_mask[:, :, z_idx]
+        if not left_slice.any() or not right_slice.any():
+            continue
+
+        right_x, right_y = np.where(right_slice)
+        if right_x.size == 0:
+            continue
+
+        if right_x.size > max_pairs_per_slice:
+            sample_idx = np.linspace(0, right_x.size - 1, max_pairs_per_slice).astype(int)
+            right_x = right_x[sample_idx]
+            right_y = right_y[sample_idx]
+
+        for rx, ry in zip(right_x, right_y, strict=False):
+            mirror_x = int(np.clip(2 * (x_mid - x0) - rx, 0, slab.shape[0] - 1))
+            left_row = left_slice[mirror_x]
+            if not left_row.any():
+                continue
+            left_y = np.where(left_row)[0]
+            distances.append(float(np.min(np.abs(left_y - ry))))
+
+    if not distances:
+        return float("inf"), 0
+
+    return float(np.median(distances)), len(distances)
+
+
+def refine_midline_lr_shift(
+    orig2fsavg_vox2vox: AffineMatrix4x4,
+    aseg_data: np.ndarray,
+    fsavg_shape: Shape3d,
+    base_middle_vox: float,
+    max_shift_vox: int = 6,
+    step_vox: int = 1,
+) -> tuple[AffineMatrix4x4, int, float, dict[str, object]]:
+    """Refine the fsaverage alignment by a small left-right shift around the midsagittal plane."""
+    if max_shift_vox < 0 or step_vox <= 0:
+        return orig2fsavg_vox2vox, 0, float("inf"), {}
+
+    seg_data = aseg_data.astype(np.int32)
+    left_ids, right_ids = _prepare_lr_pair_labels(seg_data)
+    if left_ids.size == 0:
+        logger.warning("Midline refinement skipped: no left/right label pairs found.")
+        return orig2fsavg_vox2vox, 0, float("inf"), {}
+
+    seg_fsavg = resample_segmentation_to_fsavg(seg_data, orig2fsavg_vox2vox, fsavg_shape)
+
+    candidate_scores: list[dict[str, int | float | None]] = []
+    zero_shift_score = float("inf")
+    zero_shift_support = 0
+    best_shift = 0
+    best_adjusted_score = float("inf")
+    best_raw_score = float("inf")
+    best_support = 0
+    shift_penalty = 0.25
+    min_improvement = 0.5
+    min_support = 32
+
+    for shift in range(-max_shift_vox, max_shift_vox + 1, step_vox):
+        raw_score, support = _score_midline_shift(
+            seg_fsavg,
+            left_ids,
+            right_ids,
+            base_middle_vox=base_middle_vox,
+            shift_vox=-shift,
+        )
+        adjusted_score = raw_score + shift_penalty * abs(shift)
+        candidate_scores.append(
+            {
+                "shift_vox": int(shift),
+                "raw_score": float(raw_score) if np.isfinite(raw_score) else None,
+                "adjusted_score": float(adjusted_score) if np.isfinite(adjusted_score) else None,
+                "support": int(support),
+            }
+        )
+        if shift == 0:
+            zero_shift_score = raw_score
+            zero_shift_support = support
+        if adjusted_score < best_adjusted_score:
+            best_adjusted_score = adjusted_score
+            best_raw_score = raw_score
+            best_shift = shift
+            best_support = support
+
+    diagnostics: dict[str, object] = {
+        "candidate_scores": candidate_scores,
+        "zero_shift_score": float(zero_shift_score) if np.isfinite(zero_shift_score) else None,
+        "zero_shift_support": int(zero_shift_support),
+        "selected_shift_raw_score": float(best_raw_score) if np.isfinite(best_raw_score) else None,
+        "selected_shift_adjusted_score": float(best_adjusted_score) if np.isfinite(best_adjusted_score) else None,
+        "selected_shift_support": int(best_support),
+        "shift_penalty": shift_penalty,
+        "min_improvement": min_improvement,
+        "min_support": min_support,
+    }
+
+    at_boundary = abs(best_shift) == max_shift_vox
+    insufficient_support = best_support < min_support
+    no_baseline = not np.isfinite(zero_shift_score)
+    small_improvement = (
+        np.isfinite(best_raw_score)
+        and np.isfinite(zero_shift_score)
+        and (zero_shift_score - best_raw_score) < min_improvement
+    )
+    reject_shift = (
+        best_shift == 0
+        or not np.isfinite(best_raw_score)
+        or at_boundary
+        or insufficient_support
+        or (not no_baseline and small_improvement)
+    )
+
+    diagnostics["no_baseline"] = no_baseline
+    diagnostics["rejected_boundary_shift"] = at_boundary
+    diagnostics["rejected_low_support"] = insufficient_support
+    diagnostics["rejected_small_improvement"] = not no_baseline and small_improvement
+
+    if reject_shift:
+        logger.info(
+            "Midline refinement applied no LR correction (best_shift=%d, raw_score=%s, zero_score=%s, support=%d).",
+            best_shift,
+            f"{best_raw_score:.3f}" if np.isfinite(best_raw_score) else "inf",
+            f"{zero_shift_score:.3f}" if np.isfinite(zero_shift_score) else "inf",
+            best_support,
+        )
+        return orig2fsavg_vox2vox, 0, zero_shift_score, diagnostics
+
+    updated_transform = offset_affine([best_shift, 0, 0]) @ orig2fsavg_vox2vox
+    logger.info(
+        "Midline refinement applied %+d vox LR correction in fsaverage space "
+        "(raw_score=%.3f, zero_score=%.3f, support=%d).",
+        best_shift,
+        best_raw_score,
+        zero_shift_score,
+        best_support,
+    )
+    return updated_transform, best_shift, best_raw_score, diagnostics
+
+
+def register_centroids_to_fsavg(
+    aseg_nib: nibabelImage,
+) -> tuple[AffineMatrix4x4, AffineMatrix4x4, AffineMatrix4x4, MGHHeaderDict]:
+    """Perform centroid-based registration between subject and fsaverage space."""
+    logger.info("Starting centroid registration")
+
+    fsaverage_data_future = thread_executor().submit(load_fsaverage_data, FSAVERAGE_DATA_PATH)
+    ras_centroids_dst = load_fsaverage_centroids(FSAVERAGE_CENTROIDS_PATH)
+
+    ras_centroids_mov = calc_ras_centroids_from_seg(aseg_nib, label_ids=list(ras_centroids_dst.keys()))
+    joint_centroid_labels = [lbl for lbl, v in ras_centroids_mov.items() if v is not None]
+
+    ras_centroids_mov = np.array([ras_centroids_mov[lbl] for lbl in joint_centroid_labels]).T
+    ras_centroids_dst = np.array([ras_centroids_dst[lbl] for lbl in joint_centroid_labels]).T
+
+    aseg2fsaverage_ras2ras: AffineMatrix4x4 = find_rigid(p_mov=ras_centroids_mov.T, p_dst=ras_centroids_dst.T)
+
+    aseg_zooms_ras = np.asarray(nib.as_closest_canonical(aseg_nib).header.get_zooms()[:3])
+    resolution_trans: AffineMatrix4x4 = np.diagflat(np.append(aseg_zooms_ras[[0, 2, 1]], [1])).astype(float)
+
+    fsaverage_vox2ras, fsavg_header = fsaverage_data_future.result()
+    fsavg_header["delta"] = aseg_zooms_ras[[0, 2, 1]]
+    fsavg_hires_vox2ras: AffineMatrix4x4 = np.concatenate(
+        [(resolution_trans @ fsaverage_vox2ras)[:, :3], fsaverage_vox2ras[:, 3:4]],
+        axis=1,
+    )
+    fsavg_header["dims"] = np.ceil(fsavg_header["dims"] @ np.linalg.inv(resolution_trans[:3, :3])).astype(int).tolist()
+    fsavg_header["Pxyz_c"] += (aseg_zooms_ras - 1) / 2 @ fsavg_header["Mdc"]
+
+    aseg2fsavg_vox2vox: AffineMatrix4x4 = np.linalg.inv(fsavg_hires_vox2ras) @ aseg2fsaverage_ras2ras @ aseg_nib.affine
+    logger.info("Centroid registration successful!")
+    return aseg2fsavg_vox2vox, aseg2fsaverage_ras2ras, fsavg_hires_vox2ras, fsavg_header
 
 
 def refine_midplane_with_distance_maps(
@@ -304,4 +555,74 @@ def refine_midplane_with_distance_maps(
         center_shift_vox=center_shift_vox,
         diagnostics=diagnostics,
         debug_volumes=debug_volumes,
+    )
+
+
+def find_midplane_transform(
+    orig: nibabelImage,
+    aseg_img: nibabelImage,
+    midplane_method: str,
+) -> MidplaneTransformResult:
+    """Determine the fsaverage-space transform and diagnostics for the requested midplane method."""
+    vox_size_ras: tuple[float, float, float] = nib.as_closest_canonical(orig).header.get_zooms()
+    vox_size = vox_size_ras[0], vox_size_ras[2], vox_size_ras[1]
+    aseg_data = np.asarray(aseg_img.dataobj)
+
+    if midplane_method == "center":
+        return MidplaneTransformResult(
+            orig2fsavg_vox2vox=np.eye(4),
+            fsavg_vox2ras=orig.affine,
+            fsavg_header_dict={"dims": list(orig.shape[:3])},
+            fsavg_shape=orig.shape[:3],
+            base_middle_vox=orig.shape[0] / 2.0,
+            midline_shift_vox=0.0,
+            midline_shift_diagnostics={},
+        )
+
+    orig2fsavg_vox2vox, _, fsavg_vox2ras, fsavg_header_dict = register_centroids_to_fsavg(aseg_img)
+    fsavg_shape = tuple(fsavg_header_dict["dims"])
+    base_middle_vox = float(FSAVERAGE_MIDDLE) / float(vox_size[0])
+
+    if midplane_method == "fsaverage_distance_map":
+        dm_result = refine_midplane_with_distance_maps(
+            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+            aseg_data=aseg_data,
+            fsavg_shape=fsavg_shape,
+            base_middle_vox=base_middle_vox,
+        )
+        return MidplaneTransformResult(
+            orig2fsavg_vox2vox=dm_result.updated_vox2vox,
+            fsavg_vox2ras=fsavg_vox2ras,
+            fsavg_header_dict=fsavg_header_dict,
+            fsavg_shape=fsavg_shape,
+            base_middle_vox=base_middle_vox,
+            midline_shift_vox=dm_result.center_shift_vox,
+            midline_shift_diagnostics=dm_result.diagnostics,
+        )
+
+    if midplane_method == "fsaverage_symmetry":
+        orig2fsavg_vox2vox, lr_shift, _, diagnostics = refine_midline_lr_shift(
+            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+            aseg_data=aseg_data,
+            fsavg_shape=fsavg_shape,
+            base_middle_vox=base_middle_vox,
+        )
+        return MidplaneTransformResult(
+            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+            fsavg_vox2ras=fsavg_vox2ras,
+            fsavg_header_dict=fsavg_header_dict,
+            fsavg_shape=fsavg_shape,
+            base_middle_vox=base_middle_vox,
+            midline_shift_vox=float(lr_shift),
+            midline_shift_diagnostics=diagnostics,
+        )
+
+    return MidplaneTransformResult(
+        orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+        fsavg_vox2ras=fsavg_vox2ras,
+        fsavg_header_dict=fsavg_header_dict,
+        fsavg_shape=fsavg_shape,
+        base_middle_vox=base_middle_vox,
+        midline_shift_vox=0.0,
+        midline_shift_diagnostics={},
     )

--- a/CorpusCallosum/midplane_refinement.py
+++ b/CorpusCallosum/midplane_refinement.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.ndimage import affine_transform, binary_fill_holes, distance_transform_edt
+from skimage.morphology import convex_hull_image
+
+from CorpusCallosum.data.read_write import convert_numpy_to_json_serializable
+from CorpusCallosum.shape.postprocessing import offset_affine
+from FastSurferCNN.utils import AffineMatrix4x4, Shape3d, logging, nibabelImage
+from FastSurferCNN.utils.brainvolstats import hemi_masks_from_aseg
+
+logger = logging.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class MidplaneDebugVolumes:
+    distance_diff: np.ndarray
+    candidate_mask: np.ndarray
+    left_mask: np.ndarray
+    right_mask: np.ndarray
+
+
+@dataclass(frozen=True)
+class MidplaneRefinementResult:
+    updated_vox2vox: AffineMatrix4x4
+    center_shift_vox: float
+    diagnostics: dict[str, object]
+    debug_volumes: MidplaneDebugVolumes
+
+
+def resample_segmentation_to_fsavg(
+    seg_data: np.ndarray,
+    orig2fsavg_vox2vox: AffineMatrix4x4,
+    fsavg_shape: Shape3d,
+) -> np.ndarray:
+    """Resample a segmentation into fsaverage voxel space using nearest-neighbor interpolation."""
+    return affine_transform(
+        seg_data.astype(np.int32),
+        np.linalg.inv(orig2fsavg_vox2vox),
+        output_shape=fsavg_shape,
+        order=0,
+        mode="constant",
+        cval=0,
+        prefilter=False,
+    ).astype(np.int32)
+
+
+def _make_fsavg_convex_hull_mask(brain_mask: np.ndarray) -> np.ndarray:
+    """Approximate the whole-brain convex hull in fsaverage voxel space."""
+    yz_projection = brain_mask.any(axis=0)
+    yz_hull = convex_hull_image(yz_projection)
+
+    x_min = np.full(yz_projection.shape, brain_mask.shape[0], dtype=np.int32)
+    x_max = np.full(yz_projection.shape, -1, dtype=np.int32)
+    x_coords, y_coords, z_coords = np.where(brain_mask)
+    np.minimum.at(x_min, (y_coords, z_coords), x_coords)
+    np.maximum.at(x_max, (y_coords, z_coords), x_coords)
+
+    valid_yz = x_max >= x_min
+    hull_valid = yz_hull & valid_yz
+    if not hull_valid.any():
+        return brain_mask.copy()
+
+    nearest_valid = distance_transform_edt(~valid_yz, return_distances=False, return_indices=True)
+    hull_mask = np.zeros_like(brain_mask, dtype=bool)
+    for y_idx, z_idx in np.argwhere(yz_hull):
+        if valid_yz[y_idx, z_idx]:
+            x0 = int(x_min[y_idx, z_idx])
+            x1 = int(x_max[y_idx, z_idx])
+        else:
+            src_y = int(nearest_valid[0, y_idx, z_idx])
+            src_z = int(nearest_valid[1, y_idx, z_idx])
+            x0 = int(x_min[src_y, src_z])
+            x1 = int(x_max[src_y, src_z])
+        if x1 >= x0:
+            hull_mask[x0:x1 + 1, y_idx, z_idx] = True
+    return hull_mask
+
+
+def _clean_partitioned_hemi_masks(seg_fsavg: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Create hole-free left/right hemisphere masks covering the full brain mask."""
+    brain_mask = seg_fsavg > 0
+    left_vote, right_vote = hemi_masks_from_aseg(seg_fsavg)
+    left_core = np.logical_and(left_vote, brain_mask)
+    right_core = np.logical_and(right_vote, brain_mask)
+
+    undecided = np.logical_and(brain_mask, np.logical_not(np.logical_or(left_core, right_core)))
+    left_core_dt = distance_transform_edt(np.logical_not(left_core))
+    right_core_dt = distance_transform_edt(np.logical_not(right_core))
+    left_mask = np.logical_or(left_core, np.logical_and(undecided, left_core_dt <= right_core_dt))
+    right_mask = np.logical_and(brain_mask, np.logical_not(left_mask))
+
+    left_mask = np.logical_and(binary_fill_holes(left_mask), brain_mask)
+    right_mask = np.logical_and(binary_fill_holes(right_mask), brain_mask)
+
+    overlap = np.logical_and(left_mask, right_mask)
+    if np.any(overlap):
+        left_overlap = left_core_dt <= right_core_dt
+        left_mask = np.logical_or(
+            np.logical_and(left_mask, np.logical_not(overlap)),
+            np.logical_and(overlap, left_overlap),
+        )
+        right_mask = np.logical_and(brain_mask, np.logical_not(left_mask))
+
+    remainder = np.logical_and(brain_mask, np.logical_not(np.logical_or(left_mask, right_mask)))
+    if np.any(remainder):
+        left_mask = np.logical_or(left_mask, np.logical_and(remainder, left_core_dt <= right_core_dt))
+        right_mask = np.logical_and(brain_mask, np.logical_not(left_mask))
+
+    return left_mask, right_mask
+
+
+def _rotation_from_vectors(source: np.ndarray, target: np.ndarray) -> np.ndarray:
+    """Return a 3x3 rotation matrix mapping source onto target."""
+    source = source / np.linalg.norm(source)
+    target = target / np.linalg.norm(target)
+    cross = np.cross(source, target)
+    dot = float(np.clip(np.dot(source, target), -1.0, 1.0))
+    cross_norm = np.linalg.norm(cross)
+    if cross_norm < 1e-8:
+        if dot > 0:
+            return np.eye(3, dtype=float)
+        axis = np.array([0.0, 1.0, 0.0], dtype=float)
+        if abs(source[1]) > 0.9:
+            axis = np.array([0.0, 0.0, 1.0], dtype=float)
+        cross = np.cross(source, axis)
+        cross = cross / np.linalg.norm(cross)
+        cross_norm = 1.0
+        dot = -1.0
+    k = cross / cross_norm
+    kx, ky, kz = k
+    skew = np.array([
+        [0.0, -kz, ky],
+        [kz, 0.0, -kx],
+        [-ky, kx, 0.0],
+    ])
+    angle = np.arccos(dot)
+    return np.eye(3, dtype=float) + np.sin(angle) * skew + (1 - np.cos(angle)) * (skew @ skew)
+
+
+def _affine_from_rotation_and_center(rotation: np.ndarray, center: np.ndarray) -> AffineMatrix4x4:
+    """Build a 4x4 affine that rotates around a given center in voxel coordinates."""
+    affine = np.eye(4, dtype=float)
+    affine[:3, :3] = rotation
+    affine[:3, 3] = center - rotation @ center
+    return affine
+
+
+def refine_midplane_with_distance_maps(
+    orig2fsavg_vox2vox: AffineMatrix4x4,
+    aseg_nib: nibabelImage,
+    fsavg_shape: Shape3d,
+    base_middle_vox: float,
+    zero_band_vox: float = 0.5,
+    support_distance_vox: float = 24.0,
+    fit_band_vox: float = 20.0,
+    max_tilt_deg: float = 7.5,
+    max_center_shift_vox: float = 8.0,
+) -> MidplaneRefinementResult:
+    """Fit a midsagittal plane from left/right distance-map differences inside the brain hull."""
+    seg_data = np.asarray(aseg_nib.dataobj).astype(np.int32)
+    empty = np.zeros(fsavg_shape, dtype=np.float32)
+    empty_debug = MidplaneDebugVolumes(
+        distance_diff=empty,
+        candidate_mask=empty.astype(bool),
+        left_mask=empty.astype(bool),
+        right_mask=empty.astype(bool),
+    )
+    if not np.any(seg_data > 0):
+        logger.warning("Distance-map midplane refinement skipped: segmentation is empty.")
+        return MidplaneRefinementResult(
+            updated_vox2vox=orig2fsavg_vox2vox,
+            center_shift_vox=0.0,
+            diagnostics={},
+            debug_volumes=empty_debug,
+        )
+
+    seg_fsavg = resample_segmentation_to_fsavg(seg_data, orig2fsavg_vox2vox, fsavg_shape)
+    left_mask, right_mask = _clean_partitioned_hemi_masks(seg_fsavg)
+    brain_mask = seg_fsavg > 0
+    hull_mask = _make_fsavg_convex_hull_mask(brain_mask)
+
+    left_distance = distance_transform_edt(~left_mask)
+    right_distance = distance_transform_edt(~right_mask)
+    distance_diff = left_distance - right_distance
+    candidate_mask = (
+        hull_mask
+        & (np.abs(distance_diff) <= zero_band_vox)
+        & (np.minimum(left_distance, right_distance) <= support_distance_vox)
+        & (np.abs(np.arange(fsavg_shape[0])[:, np.newaxis, np.newaxis] - base_middle_vox) <= fit_band_vox)
+    )
+    debug_volumes = MidplaneDebugVolumes(
+        distance_diff=distance_diff.astype(np.float32),
+        candidate_mask=candidate_mask,
+        left_mask=left_mask,
+        right_mask=right_mask,
+    )
+    candidate_coords = np.argwhere(candidate_mask)
+    diagnostics: dict[str, object] = {
+        "candidate_count": int(candidate_coords.shape[0]),
+        "zero_band_vox": float(zero_band_vox),
+        "support_distance_vox": float(support_distance_vox),
+        "fit_band_vox": float(fit_band_vox),
+        "left_mask_voxels": int(np.count_nonzero(left_mask)),
+        "right_mask_voxels": int(np.count_nonzero(right_mask)),
+        "brain_mask_voxels": int(np.count_nonzero(brain_mask)),
+    }
+    if candidate_coords.shape[0] < 200:
+        logger.warning(
+            "Distance-map midplane refinement skipped: too few candidate voxels (%d).",
+            candidate_coords.shape[0],
+        )
+        diagnostics["rejected_reason"] = "too_few_candidates"
+        return MidplaneRefinementResult(
+            updated_vox2vox=orig2fsavg_vox2vox,
+            center_shift_vox=0.0,
+            diagnostics=diagnostics,
+            debug_volumes=debug_volumes,
+        )
+
+    x = candidate_coords[:, 0].astype(float)
+    y = candidate_coords[:, 1].astype(float)
+    z = candidate_coords[:, 2].astype(float)
+    design = np.column_stack([y, z, np.ones_like(x)])
+    coeffs, *_ = np.linalg.lstsq(design, x, rcond=None)
+    a_coef, b_coef, c_coef = [float(c) for c in coeffs]
+    fitted_x = design @ coeffs
+    rmse = float(np.sqrt(np.mean((fitted_x - x) ** 2)))
+
+    plane_normal = np.array([1.0, -a_coef, -b_coef], dtype=float)
+    plane_normal = plane_normal / np.linalg.norm(plane_normal)
+    x_axis = np.array([1.0, 0.0, 0.0], dtype=float)
+    tilt_deg = float(np.degrees(np.arccos(np.clip(np.dot(plane_normal, x_axis), -1.0, 1.0))))
+
+    yz_center = np.asarray(fsavg_shape[1:], dtype=float) / 2.0
+    plane_center = np.array([
+        a_coef * yz_center[0] + b_coef * yz_center[1] + c_coef,
+        yz_center[0],
+        yz_center[1],
+    ], dtype=float)
+    center_shift_vox = float(plane_center[0] - base_middle_vox)
+
+    diagnostics.update({
+        "plane_coefficients_xyz": [1.0, -a_coef, -b_coef, -c_coef],
+        "plane_center_vox": plane_center.tolist(),
+        "plane_fit_rmse_vox": rmse,
+        "plane_tilt_deg": tilt_deg,
+        "center_shift_vox": center_shift_vox,
+        "max_tilt_deg": float(max_tilt_deg),
+        "max_center_shift_vox": float(max_center_shift_vox),
+    })
+
+    if abs(center_shift_vox) > max_center_shift_vox:
+        logger.info(
+            "Distance-map midplane refinement rejected: center shift %.2f vox exceeds %.2f.",
+            center_shift_vox,
+            max_center_shift_vox,
+        )
+        diagnostics["rejected_reason"] = "center_shift_too_large"
+        return MidplaneRefinementResult(
+            updated_vox2vox=orig2fsavg_vox2vox,
+            center_shift_vox=0.0,
+            diagnostics=diagnostics,
+            debug_volumes=debug_volumes,
+        )
+    if tilt_deg > max_tilt_deg:
+        logger.info(
+            "Distance-map midplane refinement rejected: tilt %.2f deg exceeds %.2f deg.",
+            tilt_deg,
+            max_tilt_deg,
+        )
+        diagnostics["rejected_reason"] = "tilt_too_large"
+        return MidplaneRefinementResult(
+            updated_vox2vox=orig2fsavg_vox2vox,
+            center_shift_vox=0.0,
+            diagnostics=diagnostics,
+            debug_volumes=debug_volumes,
+        )
+
+    rotation = _rotation_from_vectors(plane_normal, x_axis)
+    rotate_affine = _affine_from_rotation_and_center(rotation, plane_center)
+    translate_affine = offset_affine([base_middle_vox - plane_center[0], 0, 0])
+    update_affine = translate_affine @ rotate_affine
+    diagnostics["update_affine"] = convert_numpy_to_json_serializable(update_affine)
+    diagnostics["rejected_reason"] = None
+    logger.info(
+        "Distance-map midplane refinement applied center shift %.2f vox with tilt %.2f deg (RMSE %.3f, candidates %d).",
+        center_shift_vox,
+        tilt_deg,
+        rmse,
+        candidate_coords.shape[0],
+    )
+    return MidplaneRefinementResult(
+        updated_vox2vox=update_affine @ orig2fsavg_vox2vox,
+        center_shift_vox=center_shift_vox,
+        diagnostics=diagnostics,
+        debug_volumes=debug_volumes,
+    )

--- a/CorpusCallosum/midplane_refinement.py
+++ b/CorpusCallosum/midplane_refinement.py
@@ -8,7 +8,7 @@ from skimage.morphology import convex_hull_image
 
 from CorpusCallosum.data.read_write import convert_numpy_to_json_serializable
 from CorpusCallosum.shape.postprocessing import offset_affine
-from FastSurferCNN.utils import AffineMatrix4x4, Shape3d, logging, nibabelImage
+from FastSurferCNN.utils import AffineMatrix4x4, Shape3d, logging
 from FastSurferCNN.utils.brainvolstats import hemi_masks_from_aseg
 
 logger = logging.get_logger(__name__)
@@ -75,7 +75,7 @@ def _make_fsavg_convex_hull_mask(brain_mask: np.ndarray) -> np.ndarray:
             x0 = int(x_min[src_y, src_z])
             x1 = int(x_max[src_y, src_z])
         if x1 >= x0:
-            hull_mask[x0:x1 + 1, y_idx, z_idx] = True
+            hull_mask[x0 : x1 + 1, y_idx, z_idx] = True
     return hull_mask
 
 
@@ -131,11 +131,13 @@ def _rotation_from_vectors(source: np.ndarray, target: np.ndarray) -> np.ndarray
         dot = -1.0
     k = cross / cross_norm
     kx, ky, kz = k
-    skew = np.array([
-        [0.0, -kz, ky],
-        [kz, 0.0, -kx],
-        [-ky, kx, 0.0],
-    ])
+    skew = np.array(
+        [
+            [0.0, -kz, ky],
+            [kz, 0.0, -kx],
+            [-ky, kx, 0.0],
+        ]
+    )
     angle = np.arccos(dot)
     return np.eye(3, dtype=float) + np.sin(angle) * skew + (1 - np.cos(angle)) * (skew @ skew)
 
@@ -150,7 +152,7 @@ def _affine_from_rotation_and_center(rotation: np.ndarray, center: np.ndarray) -
 
 def refine_midplane_with_distance_maps(
     orig2fsavg_vox2vox: AffineMatrix4x4,
-    aseg_nib: nibabelImage,
+    aseg_data: np.ndarray,
     fsavg_shape: Shape3d,
     base_middle_vox: float,
     zero_band_vox: float = 0.5,
@@ -160,7 +162,7 @@ def refine_midplane_with_distance_maps(
     max_center_shift_vox: float = 8.0,
 ) -> MidplaneRefinementResult:
     """Fit a midsagittal plane from left/right distance-map differences inside the brain hull."""
-    seg_data = np.asarray(aseg_nib.dataobj).astype(np.int32)
+    seg_data = aseg_data.astype(np.int32)
     empty = np.zeros(fsavg_shape, dtype=np.float32)
     empty_debug = MidplaneDebugVolumes(
         distance_diff=empty,
@@ -235,22 +237,27 @@ def refine_midplane_with_distance_maps(
     tilt_deg = float(np.degrees(np.arccos(np.clip(np.dot(plane_normal, x_axis), -1.0, 1.0))))
 
     yz_center = np.asarray(fsavg_shape[1:], dtype=float) / 2.0
-    plane_center = np.array([
-        a_coef * yz_center[0] + b_coef * yz_center[1] + c_coef,
-        yz_center[0],
-        yz_center[1],
-    ], dtype=float)
+    plane_center = np.array(
+        [
+            a_coef * yz_center[0] + b_coef * yz_center[1] + c_coef,
+            yz_center[0],
+            yz_center[1],
+        ],
+        dtype=float,
+    )
     center_shift_vox = float(plane_center[0] - base_middle_vox)
 
-    diagnostics.update({
-        "plane_coefficients_xyz": [1.0, -a_coef, -b_coef, -c_coef],
-        "plane_center_vox": plane_center.tolist(),
-        "plane_fit_rmse_vox": rmse,
-        "plane_tilt_deg": tilt_deg,
-        "center_shift_vox": center_shift_vox,
-        "max_tilt_deg": float(max_tilt_deg),
-        "max_center_shift_vox": float(max_center_shift_vox),
-    })
+    diagnostics.update(
+        {
+            "plane_coefficients_xyz": [1.0, -a_coef, -b_coef, -c_coef],
+            "plane_center_vox": plane_center.tolist(),
+            "plane_fit_rmse_vox": rmse,
+            "plane_tilt_deg": tilt_deg,
+            "center_shift_vox": center_shift_vox,
+            "max_tilt_deg": float(max_tilt_deg),
+            "max_center_shift_vox": float(max_center_shift_vox),
+        }
+    )
 
     if abs(center_shift_vox) > max_center_shift_vox:
         logger.info(

--- a/CorpusCallosum/registration/midsagittal_plane_alignment.py
+++ b/CorpusCallosum/registration/midsagittal_plane_alignment.py
@@ -25,14 +25,11 @@ logger = logging.get_logger(__name__)
 
 # FreeSurfer aseg left/right label pairs used for LR symmetry scoring.
 # Restricted to subcortical structures that are clearly unilateral (present on one side
-# only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded.
+# only in any given yz-slab).
 _ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
     (2, 41),  # Cerebral-White-Matter
-    (3, 42),  # Cerebral-Cortex
     (4, 43),  # Lateral-Ventricle
     (5, 44),  # Inf-Lat-Vent
-    (7, 46),  # Cerebellum-White-Matter
-    (8, 47),  # Cerebellum-Cortex
     (10, 49),  # Thalamus
     (11, 50),  # Caudate
     (12, 51),  # Putamen
@@ -787,7 +784,7 @@ def find_midplane_transform(
     aseg_img : nibabelImage
         Subject aseg segmentation image.
     midplane_method : str
-        Midplane strategy. Supported values are ``"center"``,
+        Midplane strategy. Supported values are ``"center"``, ``"fsaverage"``,
         ``"fsaverage_distance_map"``, and ``"fsaverage_symmetry"``.
 
     Returns
@@ -848,12 +845,15 @@ def find_midplane_transform(
             midline_shift_diagnostics=diagnostics,
         )
 
-    return MidplaneTransformResult(
-        orig2fsavg_vox2vox=orig2fsavg_vox2vox,
-        fsavg_vox2ras=fsavg_vox2ras,
-        fsavg_header_dict=fsavg_header_dict,
-        fsavg_shape=fsavg_shape,
-        base_middle_vox=base_middle_vox,
-        midline_shift_vox=0.0,
-        midline_shift_diagnostics={},
-    )
+    if midplane_method == "fsaverage":
+        return MidplaneTransformResult(
+            orig2fsavg_vox2vox=orig2fsavg_vox2vox,
+            fsavg_vox2ras=fsavg_vox2ras,
+            fsavg_header_dict=fsavg_header_dict,
+            fsavg_shape=fsavg_shape,
+            base_middle_vox=base_middle_vox,
+            midline_shift_vox=0.0,
+            midline_shift_diagnostics={},
+        )
+
+    raise ValueError(f"Unsupported midplane_method: {midplane_method!r}")

--- a/CorpusCallosum/registration/midsagittal_plane_alignment.py
+++ b/CorpusCallosum/registration/midsagittal_plane_alignment.py
@@ -444,7 +444,7 @@ def refine_midline_lr_shift(
     if max_shift_vox < 0 or step_vox <= 0:
         return orig2fsavg_vox2vox, 0, float("inf"), {}
 
-    seg_data = aseg_data.astype(np.int32)
+    seg_data = aseg_data
     left_ids, right_ids = _prepare_lr_pair_labels(seg_data)
     if left_ids.size == 0:
         logger.warning("Midline refinement skipped: no left/right label pairs found.")
@@ -628,7 +628,7 @@ def refine_midplane_with_distance_maps(
     MidplaneRefinementResult
         Updated transform, applied center shift, diagnostics, and debug volumes.
     """
-    seg_data = aseg_data.astype(np.int32)
+    seg_data = aseg_data
     empty = np.zeros(fsavg_shape, dtype=np.float32)
     empty_debug = MidplaneDebugVolumes(
         distance_diff=empty,

--- a/CorpusCallosum/registration/midsagittal_plane_alignment.py
+++ b/CorpusCallosum/registration/midsagittal_plane_alignment.py
@@ -46,6 +46,20 @@ _ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
 
 @dataclass(frozen=True)
 class MidplaneDebugVolumes:
+    """Debug volumes produced by distance-map midplane refinement.
+
+    Attributes
+    ----------
+    distance_diff : np.ndarray
+        Voxel-wise difference ``d_left - d_right`` in fsaverage space.
+    candidate_mask : np.ndarray
+        Boolean mask selecting voxels used for plane fitting.
+    left_mask : np.ndarray
+        Partitioned binary left-hemisphere mask in fsaverage space.
+    right_mask : np.ndarray
+        Partitioned binary right-hemisphere mask in fsaverage space.
+    """
+
     distance_diff: np.ndarray
     candidate_mask: np.ndarray
     left_mask: np.ndarray
@@ -54,6 +68,20 @@ class MidplaneDebugVolumes:
 
 @dataclass(frozen=True)
 class MidplaneRefinementResult:
+    """Container for distance-map refinement outputs.
+
+    Attributes
+    ----------
+    updated_vox2vox : AffineMatrix4x4
+        Updated subject-to-fsaverage voxel transform.
+    center_shift_vox : float
+        Estimated LR center shift in fsaverage voxels.
+    diagnostics : dict[str, object]
+        JSON-serializable diagnostics and rejection reasons.
+    debug_volumes : MidplaneDebugVolumes
+        Optional intermediate volumes for quality control and debugging.
+    """
+
     updated_vox2vox: AffineMatrix4x4
     center_shift_vox: float
     diagnostics: dict[str, object]
@@ -62,6 +90,26 @@ class MidplaneRefinementResult:
 
 @dataclass(frozen=True)
 class MidplaneTransformResult:
+    """Result returned by :func:`find_midplane_transform`.
+
+    Attributes
+    ----------
+    orig2fsavg_vox2vox : AffineMatrix4x4
+        Subject-to-fsaverage voxel transform after optional refinement.
+    fsavg_vox2ras : AffineMatrix4x4
+        fsaverage voxel-to-RAS transform used for downstream mapping.
+    fsavg_header_dict : MGHHeaderDict
+        Header metadata for the fsaverage-aligned volume.
+    fsavg_shape : Shape3d
+        Shape of the fsaverage-aligned target grid.
+    base_middle_vox : float
+        Baseline midsagittal x-coordinate in fsaverage voxel units.
+    midline_shift_vox : float
+        Applied LR shift (or estimated center shift) in voxel units.
+    midline_shift_diagnostics : dict[str, object]
+        Method-specific diagnostics for refinement decisions.
+    """
+
     orig2fsavg_vox2vox: AffineMatrix4x4
     fsavg_vox2ras: AffineMatrix4x4
     fsavg_header_dict: MGHHeaderDict
@@ -76,7 +124,26 @@ def resample_segmentation_to_fsavg(
     orig2fsavg_vox2vox: AffineMatrix4x4,
     fsavg_shape: Shape3d,
 ) -> np.ndarray:
-    """Resample a segmentation into fsaverage voxel space using nearest-neighbor interpolation."""
+    """Resample a segmentation into fsaverage voxel space.
+
+    Parameters
+    ----------
+    seg_data : np.ndarray
+        Input segmentation array in subject voxel space.
+    orig2fsavg_vox2vox : AffineMatrix4x4
+        Subject-to-fsaverage voxel transform.
+    fsavg_shape : Shape3d
+        Output shape in fsaverage voxel coordinates.
+
+    Returns
+    -------
+    np.ndarray
+        Resampled integer segmentation in fsaverage space.
+
+    Notes
+    -----
+    Nearest-neighbor interpolation is used to preserve discrete labels.
+    """
     return affine_transform(
         seg_data.astype(np.int32),
         np.linalg.inv(orig2fsavg_vox2vox),
@@ -89,7 +156,18 @@ def resample_segmentation_to_fsavg(
 
 
 def _make_fsavg_convex_hull_mask(brain_mask: np.ndarray) -> np.ndarray:
-    """Approximate the whole-brain convex hull in fsaverage voxel space."""
+    """Approximate a whole-brain hull mask in fsaverage voxel space.
+
+    Parameters
+    ----------
+    brain_mask : np.ndarray
+        Binary brain mask in fsaverage space.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean hull mask spanning valid x extents for each y-z location.
+    """
     yz_projection = brain_mask.any(axis=0)
     yz_hull = convex_hull_image(yz_projection)
 
@@ -121,7 +199,18 @@ def _make_fsavg_convex_hull_mask(brain_mask: np.ndarray) -> np.ndarray:
 
 
 def _clean_partitioned_hemi_masks(seg_fsavg: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Create hole-free left/right hemisphere masks covering the full brain mask."""
+    """Generate robust, hole-free left/right hemisphere masks.
+
+    Parameters
+    ----------
+    seg_fsavg : np.ndarray
+        Segmentation labels in fsaverage voxel space.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Left and right boolean masks that jointly cover the brain mask.
+    """
     brain_mask = seg_fsavg > 0
     left_vote, right_vote = hemi_masks_from_aseg(seg_fsavg)
     left_core = np.logical_and(left_vote, brain_mask)
@@ -154,7 +243,20 @@ def _clean_partitioned_hemi_masks(seg_fsavg: np.ndarray) -> tuple[np.ndarray, np
 
 
 def _rotation_from_vectors(source: np.ndarray, target: np.ndarray) -> np.ndarray:
-    """Return a 3x3 rotation matrix mapping source onto target."""
+    """Compute a 3x3 rotation matrix mapping ``source`` onto ``target``.
+
+    Parameters
+    ----------
+    source : np.ndarray
+        Source 3D direction vector.
+    target : np.ndarray
+        Target 3D direction vector.
+
+    Returns
+    -------
+    np.ndarray
+        Rotation matrix that aligns ``source`` with ``target``.
+    """
     source = source / np.linalg.norm(source)
     target = target / np.linalg.norm(target)
     cross = np.cross(source, target)
@@ -184,7 +286,20 @@ def _rotation_from_vectors(source: np.ndarray, target: np.ndarray) -> np.ndarray
 
 
 def _affine_from_rotation_and_center(rotation: np.ndarray, center: np.ndarray) -> AffineMatrix4x4:
-    """Build a 4x4 affine that rotates around a given center in voxel coordinates."""
+    """Construct an affine applying a rotation about a voxel-space center.
+
+    Parameters
+    ----------
+    rotation : np.ndarray
+        3x3 rotation matrix.
+    center : np.ndarray
+        Rotation center in voxel coordinates.
+
+    Returns
+    -------
+    AffineMatrix4x4
+        Homogeneous 4x4 affine transform.
+    """
     affine = np.eye(4, dtype=float)
     affine[:3, :3] = rotation
     affine[:3, 3] = center - rotation @ center
@@ -192,7 +307,18 @@ def _affine_from_rotation_and_center(rotation: np.ndarray, center: np.ndarray) -
 
 
 def _prepare_lr_pair_labels(seg_data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Create matched left/right label-id arrays from a FreeSurfer-style segmentation."""
+    """Create matched left/right aseg label arrays available in an input segmentation.
+
+    Parameters
+    ----------
+    seg_data : np.ndarray
+        FreeSurfer-style labeled segmentation volume.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Arrays of matched left and right label IDs present in ``seg_data``.
+    """
     label_set = set(np.unique(seg_data.astype(np.int32)).tolist())
     label_set.discard(0)
 
@@ -210,7 +336,29 @@ def _score_midline_shift(
     shift_vox: int,
     max_pairs_per_slice: int = 64,
 ) -> tuple[float, int]:
-    """Score a left-right shift candidate using mirrored anatomy close to the midline."""
+    """Score a candidate LR shift by mirrored label consistency near the midline.
+
+    Parameters
+    ----------
+    seg_in_fsavg : np.ndarray
+        Segmentation labels in fsaverage voxel space.
+    left_ids : np.ndarray
+        Label IDs considered left-hemisphere structures.
+    right_ids : np.ndarray
+        Label IDs considered right-hemisphere structures.
+    base_middle_vox : float
+        Baseline midsagittal x-coordinate in voxel units.
+    shift_vox : int
+        Candidate shift to evaluate relative to ``base_middle_vox``.
+    max_pairs_per_slice : int, default=64
+        Maximum sampled right-side voxels per z-slice for distance matching.
+
+    Returns
+    -------
+    tuple[float, int]
+        Median mirrored y-distance score and number of matched samples.
+        Lower scores indicate better LR consistency.
+    """
     if left_ids.size == 0 or right_ids.size == 0:
         return float("inf"), 0
 
@@ -218,7 +366,7 @@ def _score_midline_shift(
     if x_mid <= 1 or x_mid >= seg_in_fsavg.shape[0] - 2:
         return float("inf"), 0
 
-    slab_half = 12 # this is mm since we are in fsaverage space with 1mm voxels
+    slab_half = 12  # 12 voxels ~= 12 mm in fsaverage (1 mm isotropic grid)
     x0 = max(0, x_mid - slab_half)
     x1 = min(seg_in_fsavg.shape[0], x_mid + slab_half + 1)
     slab = seg_in_fsavg[x0:x1]
@@ -266,7 +414,33 @@ def refine_midline_lr_shift(
     max_shift_vox: int = 6,
     step_vox: int = 1,
 ) -> tuple[AffineMatrix4x4, int, float, dict[str, object]]:
-    """Refine the fsaverage alignment by a small left-right shift around the midsagittal plane."""
+    """Refine midsagittal alignment by searching small LR translations.
+
+    Parameters
+    ----------
+    orig2fsavg_vox2vox : AffineMatrix4x4
+        Initial subject-to-fsaverage voxel transform.
+    aseg_data : np.ndarray
+        Subject segmentation labels in native voxel space.
+    fsavg_shape : Shape3d
+        Shape of the fsaverage target grid.
+    base_middle_vox : float
+        Baseline midsagittal x-coordinate in fsaverage voxels.
+    max_shift_vox : int, default=6
+        Maximum absolute LR shift explored.
+    step_vox : int, default=1
+        Integer step size for the LR search.
+
+    Returns
+    -------
+    tuple[AffineMatrix4x4, int, float, dict[str, object]]
+        Updated transform, selected shift, selected score, and diagnostics.
+
+    Notes
+    -----
+    Candidate shifts are regularized and validated with conservative rejection
+    criteria (boundary hits, low support, and weak improvements over baseline).
+    """
     if max_shift_vox < 0 or step_vox <= 0:
         return orig2fsavg_vox2vox, 0, float("inf"), {}
 
@@ -373,7 +547,18 @@ def refine_midline_lr_shift(
 def register_centroids_to_fsavg(
     aseg_nib: nibabelImage,
 ) -> tuple[AffineMatrix4x4, AffineMatrix4x4, AffineMatrix4x4, MGHHeaderDict]:
-    """Perform centroid-based registration between subject and fsaverage space."""
+    """Estimate a rigid subject-to-fsaverage alignment from aseg centroids.
+
+    Parameters
+    ----------
+    aseg_nib : nibabelImage
+        Input aseg image in subject space.
+
+    Returns
+    -------
+    tuple[AffineMatrix4x4, AffineMatrix4x4, AffineMatrix4x4, MGHHeaderDict]
+        ``(aseg2fsavg_vox2vox, aseg2fsavg_ras2ras, fsavg_hires_vox2ras, fsavg_header)``.
+    """
     logger.info("Starting centroid registration")
 
     fsaverage_data_future = thread_executor().submit(load_fsaverage_data, FSAVERAGE_DATA_PATH)
@@ -415,7 +600,34 @@ def refine_midplane_with_distance_maps(
     max_tilt_deg: float = 7.5,
     max_center_shift_vox: float = 8.0,
 ) -> MidplaneRefinementResult:
-    """Fit a midsagittal plane from left/right distance-map differences inside the brain hull."""
+    """Fit a midsagittal plane from LR distance-map symmetry in fsaverage space.
+
+    Parameters
+    ----------
+    orig2fsavg_vox2vox : AffineMatrix4x4
+        Initial subject-to-fsaverage voxel transform.
+    aseg_data : np.ndarray
+        Subject segmentation labels in native voxel space.
+    fsavg_shape : Shape3d
+        Shape of the fsaverage target grid.
+    base_middle_vox : float
+        Baseline midsagittal x-coordinate in fsaverage voxels.
+    zero_band_vox : float, default=0.5
+        Absolute distance-difference threshold for candidate midplane voxels.
+    support_distance_vox : float, default=24.0
+        Maximum distance to either hemisphere mask for candidate support.
+    fit_band_vox : float, default=20.0
+        X-range around baseline center used for plane fitting.
+    max_tilt_deg : float, default=7.5
+        Maximum accepted angular tilt away from the LR axis.
+    max_center_shift_vox : float, default=8.0
+        Maximum accepted LR center shift from baseline.
+
+    Returns
+    -------
+    MidplaneRefinementResult
+        Updated transform, applied center shift, diagnostics, and debug volumes.
+    """
     seg_data = aseg_data.astype(np.int32)
     empty = np.zeros(fsavg_shape, dtype=np.float32)
     empty_debug = MidplaneDebugVolumes(
@@ -566,7 +778,23 @@ def find_midplane_transform(
     aseg_img: nibabelImage,
     midplane_method: str,
 ) -> MidplaneTransformResult:
-    """Determine the fsaverage-space transform and diagnostics for the requested midplane method."""
+    """Resolve the fsaverage midplane transform for a selected refinement method.
+
+    Parameters
+    ----------
+    orig : nibabelImage
+        Input conformed anatomical image.
+    aseg_img : nibabelImage
+        Subject aseg segmentation image.
+    midplane_method : str
+        Midplane strategy. Supported values are ``"center"``,
+        ``"fsaverage_distance_map"``, and ``"fsaverage_symmetry"``.
+
+    Returns
+    -------
+    MidplaneTransformResult
+        Transform bundle and method-specific diagnostics for downstream CC steps.
+    """
     vox_size_ras: tuple[float, float, float] = nib.as_closest_canonical(orig).header.get_zooms()
     vox_size = vox_size_ras[0], vox_size_ras[2], vox_size_ras[1]
     aseg_data = np.asarray(aseg_img.dataobj)

--- a/CorpusCallosum/registration/midsagittal_plane_alignment.py
+++ b/CorpusCallosum/registration/midsagittal_plane_alignment.py
@@ -8,10 +8,10 @@ from scipy.ndimage import affine_transform, binary_fill_holes, distance_transfor
 from skimage.morphology import convex_hull_image
 
 from CorpusCallosum.data.constants import FSAVERAGE_CENTROIDS_PATH, FSAVERAGE_DATA_PATH, FSAVERAGE_MIDDLE
-from CorpusCallosum.data.read_write import convert_numpy_to_json_serializable
 from CorpusCallosum.data.read_write import (
     MGHHeaderDict,
     calc_ras_centroids_from_seg,
+    convert_numpy_to_json_serializable,
     load_fsaverage_centroids,
     load_fsaverage_data,
 )

--- a/CorpusCallosum/registration/midsagittal_plane_alignment.py
+++ b/CorpusCallosum/registration/midsagittal_plane_alignment.py
@@ -23,26 +23,24 @@ from recon_surf.align_points import find_rigid
 
 logger = logging.get_logger(__name__)
 
-# Standard FreeSurfer aseg left/right label pairs used for LR symmetry scoring.
+# FreeSurfer aseg left/right label pairs used for LR symmetry scoring.
 # Restricted to subcortical structures that are clearly unilateral (present on one side
-# only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded
-# because they wrap both hemispheres throughout the y-z extent, driving all symmetry
-# scores to zero and making the shift selector uninformative.
+# only in any given yz-slab). Cortex (3/42) and cerebellum-cortex (8/47) are excluded.
 _ASEG_LR_PAIRS: tuple[tuple[int, int], ...] = (
-    (2, 41),
-    (3, 42),
-    (4, 43),
-    (5, 44),
-    (7, 46),
-    (8, 47),
-    (10, 49),
-    (11, 50),
-    (12, 51),
-    (13, 52),
-    (17, 53),
-    (18, 54),
-    (26, 58),
-    (28, 60),
+    (2, 41),  # Cerebral-White-Matter
+    (3, 42),  # Cerebral-Cortex
+    (4, 43),  # Lateral-Ventricle
+    (5, 44),  # Inf-Lat-Vent
+    (7, 46),  # Cerebellum-White-Matter
+    (8, 47),  # Cerebellum-Cortex
+    (10, 49),  # Thalamus
+    (11, 50),  # Caudate
+    (12, 51),  # Putamen
+    (13, 52),  # Pallidum
+    (17, 53),  # Hippocampus
+    (18, 54),  # Amygdala
+    (26, 58),  # Accumbens-Area
+    (28, 60),  # VentralDC
 )
 
 
@@ -220,7 +218,7 @@ def _score_midline_shift(
     if x_mid <= 1 or x_mid >= seg_in_fsavg.shape[0] - 2:
         return float("inf"), 0
 
-    slab_half = 12
+    slab_half = 12 # this is mm since we are in fsaverage space with 1mm voxels
     x0 = max(0, x_mid - slab_half)
     x1 = min(seg_in_fsavg.shape[0], x_mid + slab_half + 1)
     slab = seg_in_fsavg[x0:x1]

--- a/CorpusCallosum/shape/mesh.py
+++ b/CorpusCallosum/shape/mesh.py
@@ -655,6 +655,14 @@ class CCMesh(lapy.TriaMesh):
         self.__make_parent_folder(filename)
         return super().write_fssurf(filename, image=image)
 
+    @update_docstring(parent_doc=TriaMesh.write_vtk.__doc__)
+    def write_vtk(self, filename: Path | str) -> None:
+        """{parent_doc}
+        Also creates parent directory if needed before writing the file.
+        """
+        self.__make_parent_folder(filename)
+        return super().write_vtk(filename)
+
     def write_morph_data(self, filename: Path | str) -> None:
         """Write the thickness values as a FreeSurfer overlay file.
 

--- a/doc/api/CorpusCallosum.registration.rst
+++ b/doc/api/CorpusCallosum.registration.rst
@@ -1,0 +1,9 @@
+CorpusCallosum.registration
+===========================
+
+.. currentmodule:: CorpusCallosum.registration
+
+.. autosummary::
+    :toctree: generated/
+
+    midsagittal_plane_alignment

--- a/doc/api/CorpusCallosum.rst
+++ b/doc/api/CorpusCallosum.rst
@@ -8,4 +8,5 @@ CorpusCallosum
 
     fastsurfer_cc
     cc_visualization
+    registration
     paint_cc_into_pred

--- a/doc/api/CorpusCallosum.rst
+++ b/doc/api/CorpusCallosum.rst
@@ -8,5 +8,4 @@ CorpusCallosum
 
     fastsurfer_cc
     cc_visualization
-    registration
     paint_cc_into_pred

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -19,6 +19,7 @@ FastSurfer API
     CorpusCallosum.rst
     CorpusCallosum.data.rst
     CorpusCallosum.localization.rst
+    CorpusCallosum.registration.rst
     CorpusCallosum.segmentation.rst
     CorpusCallosum.shape.rst
     CorpusCallosum.transforms.rst

--- a/doc/overview/modules/CC.md
+++ b/doc/overview/modules/CC.md
@@ -6,8 +6,8 @@ Also segments the fornix, localizes the anterior and posterior commissure (AC an
 Overview
 --------
 This pipeline combines localization and segmentation deep learning models to:
-1. Detect AC (Anterior Commissure) and PC (Posterior Commissure) points
-2. Extract and align midplane slices
+1. Extract and align midsagittal slices
+2. Detect AC (Anterior Commissure) and PC (Posterior Commissure) points
 3. Segment the corpus callosum
 4. Perform advanced morphometry for corpus callosum, including subdivision, thickness analysis, and various shape metrics
 5. Generate visualizations and measurements

--- a/doc/scripts/fastsurfer_cc.rst
+++ b/doc/scripts/fastsurfer_cc.rst
@@ -26,8 +26,8 @@ The following section provides a detailed overview of the command-line interface
 
 Midplane extraction
 -------------------
-The ``--midplane_method`` flag controls how the corpus callosum pipeline refines the midsagittal plane before segmentation. The current implementation lives in ``CorpusCallosum/registration/midsagittal_plane_alignment.py``.
-When the corpus callosum segmentation does not align well with the mid-sagittal plane, can be changed for better results.
+The ``--midplane_method`` flag controls how the corpus callosum pipeline refines the midsagittal plane before segmentation. This is implemented in ``CorpusCallosum/registration/midsagittal_plane_alignment.py``.
+When the corpus callosum segmentation does not align well with the mid-sagittal plane, this option can be changed for better results.
 
 Available modes are:
 

--- a/doc/scripts/fastsurfer_cc.rst
+++ b/doc/scripts/fastsurfer_cc.rst
@@ -36,7 +36,7 @@ Available modes are:
 - ``center``: use the geometric center of the input volume without additional refinement
 - ``fsaverage_distance_map``: fit a midsagittal plane from left/right distance-map symmetry in fsaverage space
 
-The refinement after fsaverage alignment is intentionally conservative, expected to only make adjustments for unsual anatomies, or significant asymmetry.
+The refinement after fsaverage alignment is intentionally conservative, expected to only make adjustments for unusual anatomies, or significant asymmetry.
 
 
 

--- a/doc/scripts/fastsurfer_cc.rst
+++ b/doc/scripts/fastsurfer_cc.rst
@@ -22,6 +22,24 @@ The following section provides a detailed overview of the command-line interface
    :func: make_parser
    :prog: fastsurfer_cc.py
 
+
+
+Midplane extraction
+-------------------
+The ``--midplane_method`` flag controls how the corpus callosum pipeline refines the midsagittal plane before segmentation. The current implementation lives in ``CorpusCallosum/registration/midsagittal_plane_alignment.py``.
+When the corpus callosum segmentation does not align well with the mid-sagittal plane, can be changed for better results.
+
+Available modes are:
+
+- ``fsaverage_symmetry``: (default) Align to fsaverage, then search for a small left-right shift that minimizes mirrored aseg-label mismatch near the midline
+- ``fsaverage``: Align to fsaverage without additional refinement (matches publication)
+- ``center``: use the geometric center of the input volume without additional refinement
+- ``fsaverage_distance_map``: fit a midsagittal plane from left/right distance-map symmetry in fsaverage space
+
+The refinement after fsaverage alignment is intentionally conservative, expected to only make adjustments for unsual anatomies, or significant asymmetry.
+
+
+
 Quality Control
 ---------------
 The pipeline can produce a dedicated quality control image, showing the CC contour, AC/PC landmarks and thickness estimation.


### PR DESCRIPTION
This PR introduces a midplane refinement strategy for asymmetric brains.
The refinement strategy still relies on symmetry between structures but considers only structures close to the initially found mid-sagittal plane. This improves the midplane on previously challenging cases, while not affecting others.

The refinement can be disabled via flag. Also, it is not possible to completely skip midsagittal plane alignment for testing.