### PR TITLE
Fix aniso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /rough_work/**
 /scripts/**
 /doc-build/**
+/checkpoints/**
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CorpusCallosum/data/read_write.py
+++ b/CorpusCallosum/data/read_write.py
@@ -97,7 +97,7 @@ def convert_numpy_to_json_serializable(obj: object) -> object:
         return [convert_numpy_to_json_serializable(item) for item in obj]
     elif isinstance(obj, np.ndarray):
         return obj.tolist()
-    elif isinstance(obj, (np.integer, np.floating)):
+    elif isinstance(obj, np.integer | np.floating):
         # Handle numpy scalar types
         return obj.item()
     else:

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -957,7 +957,7 @@ def main(
     additional_metrics["cc_num_failed_slices"] = num_failed_slices
 
     # get ac and pc in all spaces
-    ac_coords_vox_3d, pc_coords_vox_3d = [np.hstack((0, c)) for c in (ac_coords_vox, pc_coords_vox)]
+    ac_coords_vox_3d, pc_coords_vox_3d = (np.hstack((0, c)) for c in (ac_coords_vox, pc_coords_vox))
     ac_coords_3d, pc_coords_3d = nib.affines.apply_affine(
         np.linalg.inv(fsavg2midslice_vox2vox),
         (ac_coords_vox_3d, pc_coords_vox_3d),

--- a/CorpusCallosum/paint_cc_into_pred.py
+++ b/CorpusCallosum/paint_cc_into_pred.py
@@ -25,7 +25,7 @@ import numpy as np
 from scipy import ndimage
 
 from CorpusCallosum.data.constants import FORNIX_LABEL, SUBSEGMENT_LABELS
-from FastSurferCNN.data_loader.conform import is_conform
+from FastSurferCNN.data_loader.conform import Reorientation, is_conform
 from FastSurferCNN.data_loader.data_utils import load_image
 from FastSurferCNN.reduce_to_aseg import reduce_to_aseg_and_save
 from FastSurferCNN.utils import Mask2d, Mask3d, Shape3d, logging
@@ -104,6 +104,15 @@ def make_parser() -> argparse.ArgumentParser:
         required=False,
         help="optionally also reduce the resulting segmentation to aseg and save separately.",
         default=None,
+    )
+    parser.add_argument(
+        "--keepgeom",
+        "--native_image",
+        dest="keepgeom",
+        action="store_true",
+        help="Keep native geometry (orientation and voxel size). If set, allows processing "
+             "images with matching native geometry.",
+        default=False,
     )
     return parser
 
@@ -385,6 +394,59 @@ def correct_wm_ventricles(
     return corrected_pred
 
 
+def correct_wm_ventricles_in_lia(
+    aseg_cc: np.ndarray[Shape3d, np.dtype[int]],
+    fornix_mask: Mask3d,
+    affine: np.ndarray,
+    voxel_size: tuple[float, float, float],
+    close_gap_size_mm: float = 3.0,
+) -> np.ndarray[Shape3d, np.dtype[int]]:
+    """Run WM/ventricle gap correction in LIA orientation and map back.
+
+    Parameters
+    ----------
+    aseg_cc : np.ndarray
+        Segmentation with CC already painted in, in native orientation.
+    fornix_mask : np.ndarray
+        Fornix mask in native orientation.
+    affine : np.ndarray
+        Native image affine.
+    voxel_size : tuple[float, float, float]
+        Native voxel sizes.
+    close_gap_size_mm : float, default=3.0
+        Maximum size of the gap to fill in millimeters.
+
+    Returns
+    -------
+    np.ndarray
+        Corrected segmentation map in the original/native orientation.
+    """
+    native_to_lia = Reorientation.from_target_orientation(
+        affine,
+        "soft LIA",
+        aseg_cc.shape,
+        np.asarray(voxel_size),
+    )
+
+    if not native_to_lia.is_identity():
+        logger.info(
+            "Running WM/ventricle gap correction in temporary LIA orientation; output will be mapped back to native geometry."
+        )
+
+    aseg_cc_lia = native_to_lia(aseg_cc, order=0)
+    fornix_mask_lia = native_to_lia(fornix_mask, order=0)
+    voxel_size_lia = tuple(native_to_lia.reorder_axes(np.asarray(voxel_size)).tolist())
+
+    corrected_lia = correct_wm_ventricles(
+        aseg_cc_lia,
+        fornix_mask_lia,
+        voxel_size_lia,
+        close_gap_size_mm=close_gap_size_mm,
+    )
+    corrected_native = native_to_lia.inverse(corrected_lia, order=0)
+    return corrected_native.astype(aseg_cc.dtype, copy=False)
+
+
 if __name__ == "__main__":
 
     # Command Line options are error checking done here
@@ -398,7 +460,11 @@ if __name__ == "__main__":
     (cc_seg_image, cc_seg_data), (aseg_image, aseg_data) = tmap(load_image, (options.input_cc, options.input_pred))
 
     def _is_conform(img, dtype, verbose):
-        return is_conform(img, vox_size=None, img_size=None, verbose=verbose, dtype=dtype)
+        # When keepgeom is True, skip orientation check (allow any orientation and voxel size)
+        # When keepgeom is False, check only dtype and LIA orientation (voxel size/dimensions still ignored)
+        # This allows processing of slightly anisotropic data in both modes
+        orientation = None if options.keepgeom else "lia"
+        return is_conform(img, vox_size=None, img_size=None, verbose=verbose, dtype=dtype, orientation=orientation)
 
     conform_args = (cc_seg_image, aseg_image), (np.uint8, np.integer)
     conform_checks = list(thread_executor().map(partial(_is_conform, verbose=False), *conform_args))
@@ -411,10 +477,17 @@ if __name__ == "__main__":
                 _is_conform(img, dtype, verbose=True)
                 names.append(name)
                 dtypes.append(dtype.name if hasattr(dtype, "name") else str(dtype))
-        sys.exit(
-            f"Error: {' and '.join(names)} input image is not conformed (LIA orientation, {'/'.join(dtypes)} dtype). "
-            "Please conform the image(s) using the conform.py script."
-        )
+        error_msg = f"Error: {' and '.join(names)} input image"
+        if options.keepgeom:
+            error_msg += f" has incorrect dtype (expected {'/'.join(dtypes)})."
+        else:
+            error_msg += f" is not conformed (LIA orientation, {'/'.join(dtypes)} dtype). "
+            error_msg += "Please conform the image(s) using the conform.py script or use --keepgeom/--native_image."
+        sys.exit(error_msg)
+
+    if cc_seg_data.shape != aseg_data.shape:
+        sys.exit("Error: The aseg and corpus callosum images do not have the same shape.")
+
     if not np.allclose(cc_seg_image.affine, aseg_image.affine):
         sys.exit("Error: The affine matrices of the aseg and the corpus callosum images are not the same.")
 
@@ -429,8 +502,13 @@ if __name__ == "__main__":
 
     # Apply ventricle gap filling corrections
     fornix_mask = cc_seg_data == FORNIX_LABEL
-    voxel_size = tuple(aseg_image.header.get_zooms())
-    pred_corrected = correct_wm_ventricles(aseg_data, fornix_mask, voxel_size)
+    voxel_size = tuple(aseg_image.header.get_zooms()[:3])
+    pred_corrected = correct_wm_ventricles_in_lia(
+        aseg_data,
+        fornix_mask,
+        aseg_image.affine,
+        voxel_size,
+    )
 
     logger.info(f"Writing segmentation with corpus callosum to: {options.output}")
     pred_with_cc_fin = nib.MGHImage(pred_corrected, aseg_image.affine, aseg_image.header)

--- a/CorpusCallosum/paint_cc_into_pred.py
+++ b/CorpusCallosum/paint_cc_into_pred.py
@@ -430,7 +430,8 @@ def correct_wm_ventricles_in_lia(
 
     if not native_to_lia.is_identity():
         logger.info(
-            "Running WM/ventricle gap correction in temporary LIA orientation; output will be mapped back to native geometry."
+            "Running WM/ventricle gap correction in temporary LIA orientation; "
+            "output will be mapped back to native geometry."
         )
 
     aseg_cc_lia = native_to_lia(aseg_cc, order=0)

--- a/CorpusCallosum/registration/midsagittal_plane_alignment.py
+++ b/CorpusCallosum/registration/midsagittal_plane_alignment.py
@@ -690,7 +690,7 @@ def refine_midplane_with_distance_maps(
     z = candidate_coords[:, 2].astype(float)
     design = np.column_stack([y, z, np.ones_like(x)])
     coeffs, *_ = np.linalg.lstsq(design, x, rcond=None)
-    a_coef, b_coef, c_coef = [float(c) for c in coeffs]
+    a_coef, b_coef, c_coef = (float(c) for c in coeffs)
     fitted_x = design @ coeffs
     rmse = float(np.sqrt(np.mean((fitted_x - x) ** 2)))
 

--- a/CorpusCallosum/shape/mesh.py
+++ b/CorpusCallosum/shape/mesh.py
@@ -551,7 +551,7 @@ class CCMesh(lapy.TriaMesh):
             from nibabel.freesurfer.mghformat import MGHHeader
 
             # if header is a file, load its header from the file
-            if isinstance(ref_header, (str, Path)):
+            if isinstance(ref_header, str | Path):
                 ref_header = nib.load(ref_header).header
             # if header is not already an MGHHeader, convert it to MGHHeader, so we have the get_vox2ras_tkr function
             mgh_header = ref_header if isinstance(ref_header, MGHHeader) else MGHHeader.from_header(ref_header)

--- a/CorpusCallosum/utils/visualization.py
+++ b/CorpusCallosum/utils/visualization.py
@@ -259,7 +259,7 @@ def plot_contours(
 
         if output_path is None:
             return plt.show()
-        for _output_path in (output_path if isinstance(output_path, (list, tuple)) else [output_path]):
+        for _output_path in (output_path if isinstance(output_path, list | tuple) else [output_path]):
             Path(_output_path).parent.mkdir(parents=True, exist_ok=True)
             fig.savefig(_output_path, dpi=300, bbox_inches="tight")
     return None

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -24,7 +24,13 @@ from typing import TYPE_CHECKING, Literal, TypedDict, TypeVar, cast
 import nibabel as nib
 import numpy as np
 import torch
-from nibabel.orientations import aff2axcodes, axcodes2ornt, io_orientation
+from nibabel.orientations import (
+    aff2axcodes,
+    axcodes2ornt,
+    inv_ornt_aff,
+    io_orientation,
+    ornt_transform,
+)
 from numpy import typing as npt
 
 from FastSurferCNN.utils import (
@@ -389,12 +395,10 @@ class Reorientation:
         if not is_soft:
             return cls.from_target_affine(source_affine, target_strict_affine, shape, target_shape, tol)
 
-        rot_mat = np.linalg.inv(_source_affine[:3, :3]) @ target_strict_affine
-
-        if np.allclose(rot_mat, np.round(rot_mat), atol=tol):
-            rot_mat = np.round(rot_mat)
-
-        return cls.from_vox2vox(source_affine, rot_mat, shape, target_shape, tol)
+        source_ornt = io_orientation(source_affine)
+        target_ornt = axcodes2ornt(_target_orientation, AXCODES)
+        vox2vox = inv_ornt_aff(ornt_transform(source_ornt, target_ornt), shape)
+        return cls.from_vox2vox(source_affine, vox2vox, shape, target_shape, tol)
 
     @classmethod
     def from_target_affine(

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -738,7 +738,10 @@ def apply_vox2vox(
                 else:
                     raise TypeError("image_data has a device attribute but is not a torch.Tensor!")
             else:
-                image_data = np.squeeze(image_data, axis=tuple(range(3, image_data.ndim)))  # ty:ignore[invalid-assignment]
+                image_data = np.squeeze(  # ty:ignore[invalid-assignment]
+                    image_data,
+                    axis=tuple(range(3, image_data.ndim)),
+                )
         # if the output has the same number of frames as the input
         elif image_data.shape[3:] == out_shape[3:]:
             # add a frame dimension to vox2vox
@@ -1189,11 +1192,11 @@ def ornt2vox2vox(ornt: OrntArrayType, shape: npt.ArrayLike, scale: npt.ArrayLike
     dim = _ornt.shape[0]
     if scale is None:
         _scale = np.ones((dim,))
-    elif isinstance(scale, (int, float)):
+    elif isinstance(scale, int | float):
         _scale = np.full((dim,), scale)
     else:
         _scale = np.asarray(scale).flatten()
-        if not isinstance(_scale, (Sequence, np.ndarray)) or not np.issubdtype(_scale.dtype, np.number):
+        if not isinstance(_scale, Sequence | np.ndarray) or not np.issubdtype(_scale.dtype, np.number):
             raise ValueError("scale must be None, a scalar or an sequence/array of shape (ornt.shape[0])!")
         elif _scale.size == 1:
             _scale = np.full((dim,), _scale.item())
@@ -1356,7 +1359,7 @@ def is_conform(
         checks["Dtype None"] = "IGNORED", dtype_text
     else:
         _dtype: npt.DTypeLike = to_dtype(dtype)
-        if isinstance(_dtype, (str, np.dtype)):
+        if isinstance(_dtype, str | np.dtype):
             _dtype_name = np.dtype(_dtype).name
         elif isinstance(_dtype, type):
             _dtype_name = _dtype.__name__

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -397,8 +397,17 @@ class Reorientation:
 
         source_ornt = io_orientation(source_affine)
         target_ornt = axcodes2ornt(_target_orientation, AXCODES)
-        vox2vox = inv_ornt_aff(ornt_transform(source_ornt, target_ornt), shape)
-        return cls.from_vox2vox(source_affine, vox2vox, shape, target_shape, tol)
+        discrete_vox2vox = inv_ornt_aff(ornt_transform(source_ornt, target_ornt), shape)
+        soft_rot_mat = np.linalg.inv(_source_affine[:3, :3]) @ target_strict_affine
+
+        if np.allclose(soft_rot_mat, np.round(soft_rot_mat), atol=tol):
+            soft_rot_mat = np.round(soft_rot_mat)
+
+        same_target_shape = target_shape is None or np.array_equal(np.asarray(target_shape), np.asarray(shape))
+        if same_target_shape and not does_vox2vox_rot_require_interpolation(soft_rot_mat, vox_eps=tol, rot_eps=tol):
+            return cls.from_vox2vox(source_affine, discrete_vox2vox, shape, target_shape, tol)
+
+        return cls.from_vox2vox(source_affine, soft_rot_mat, shape, target_shape, tol)
 
     @classmethod
     def from_target_affine(

--- a/FastSurferCNN/version.py
+++ b/FastSurferCNN/version.py
@@ -533,7 +533,7 @@ def read_and_close_version(project_file: TextIO | PathLike | None = None) -> str
         _project_file = open(DEFAULTS.PROJECT_TOML)
     elif hasattr(project_file, "read"):
         _project_file = cast(TextIO, project_file)
-    elif isinstance(project_file, (PathLike, Path)):
+    elif isinstance(project_file, PathLike | Path):
         _project_file = open(project_file)
     else:
         raise TypeError("project_file must be TextIO, PathLike, or None!")

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1310,6 +1310,7 @@ then
       # add CC into aparc.DKTatlas+aseg.deep.mgz and aseg.auto.mgz as mri_cc did before.
       cmd=($python "$CorpusCallosumDir/paint_cc_into_pred.py" -in_cc "$callosum_seg" -in_pred "$asegdkt_segfile"
            "-out" "$asegdkt_withcc_segfile" "-aseg" "$aseg_auto_segfile")
+      if [[ "$native_image" != "false" ]] ; then cmd+=(--keepgeom) ; fi
       echo_quoted "${cmd[@]}"
       "${wrap[@]}" "${cmd[@]}"
       if [[ "${PIPESTATUS[0]}" != 0 ]] ; then echo "ERROR: asegdkt cc inpainting failed!" ; exit 1 ; fi

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -827,8 +827,7 @@ fi
 
 if [[ "$run_surf_pipeline" == "true" ]] && [[ "$native_image" != "false" ]]
 then
-  echo "ERROR: The surface pipeline is not compatible with the options --native_image or "
-  echo "  --keepgeom."
+  echo "ERROR: The surface pipeline is not compatible with --native_image (alias --keepgeom)."
   exit 1
 fi
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -385,6 +385,8 @@ function verify_threads() {
 
 # PARSE Command line
 inputargs=("$@")
+printf -v invocation_command '%q ' "$THIS_SCRIPT" "${inputargs[@]}"
+invocation_command="${invocation_command% }"
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -973,6 +975,7 @@ if [[ -f "$seg_log" ]]; then log_existed="true" ; else log_existed="false" ; fi
   date 2>&1
   echo ""
   echo "Log file for FastSurfer pipeline, run_fastsurfer.sh and segmentation(s)"
+  echo "Invocation: $invocation_command"
 } | tee -a "$seg_log"
 
 ### IF tmpLF exists, it has been created with a warning or similar, copy that warning to seg_log now
@@ -985,8 +988,19 @@ trap "{ echo \"run_fastsurfer.sh terminated via signal at \$(date -R)!\" | tee -
 
 # create the build log, file with all version info in parallel
 # uses ${version_cache_args}, which is filled exactly if a build_cache file exists
-printf "%s %s\n%s\n" "$THIS_SCRIPT" "${inputargs[*]}" "$(date -R)" >> "$build_log"
-timeout 20 $python "$FASTSURFER_HOME/FastSurferCNN/version.py" --sections all -o "$build_log" "${version_cache_args[@]}" &
+(
+  if timeout 20 $python "$FASTSURFER_HOME/FastSurferCNN/version.py" --sections all -o "$build_log" "${version_cache_args[@]}"
+  then
+    {
+      echo ""
+      echo "=========="
+      echo "invocation:"
+      echo "=========="
+      echo "$invocation_command"
+      date -R
+    } >> "$build_log"
+  fi
+) &
 
 if [[ "$run_seg_pipeline" != "true" ]]
 then

--- a/test/image/test_orientation_transform.py
+++ b/test/image/test_orientation_transform.py
@@ -200,6 +200,28 @@ def test_affine_from_target_orientation(random_affine: AffineMatrix4x4, img_size
     assert actual == expected, f"affine_for_target_orientation did not yield a transformation to {orientation}!"
 
 
+def test_affine_from_target_orientation_soft_non_cubic_roundtrip():
+    """Soft reorientation on non-cubic inputs must remain a discrete reorder/flip without cropping."""
+    shape = (5, 3, 7)
+    source_ornt = nib.orientations.axcodes2ornt("prs", ("lr", "pa", "is"))
+    target_ornt = nib.orientations.axcodes2ornt("lia", ("lr", "pa", "is"))
+    affine = np.eye(4)
+    affine[:3, :3] = 0
+    affine[source_ornt[:, 0].astype(np.int16), np.arange(3)] = source_ornt[:, 1]
+
+    obj = Reorientation.from_target_orientation(affine, "soft LIA", shape)
+    expected = nib.orientations.inv_ornt_aff(nib.orientations.ornt_transform(source_ornt, target_ornt), shape)
+    assert obj.vox2vox == approx(expected)
+
+    data = np.zeros(shape, dtype=np.uint8)
+    data[1:4, 1:3, 2:6] = 1
+
+    lia = apply_vox2vox(data, obj.vox2vox, out_shape=obj.target_shape, order=0)
+    back = apply_vox2vox(lia, obj.inverse.vox2vox, out_shape=obj.inverse.target_shape, order=0)
+
+    assert back == approx(data), "Soft reorientation roundtrip cropped or shifted non-cubic input data."
+
+
 def test_Reorientation_target_shape(
         strict_orientation: StrictOrientationType,
         in_shape: Shape3d,

--- a/test/image/test_orientation_transform.py
+++ b/test/image/test_orientation_transform.py
@@ -4,7 +4,7 @@ from logging import getLogger
 import nibabel as nib
 import numpy as np
 import pytest
-from nibabel.orientations import aff2axcodes
+from nibabel.orientations import aff2axcodes, io_orientation
 from numpy import typing as npt
 from pytest import approx
 from scipy.ndimage import affine_transform
@@ -220,6 +220,38 @@ def test_affine_from_target_orientation_soft_non_cubic_roundtrip():
     back = apply_vox2vox(lia, obj.inverse.vox2vox, out_shape=obj.inverse.target_shape, order=0)
 
     assert back == approx(data), "Soft reorientation roundtrip cropped or shifted non-cubic input data."
+
+
+def test_affine_from_target_orientation_soft_keepgeom_roundtrip():
+    """Soft reorientation with native geometry must stay discrete for keepgeom-like cases."""
+    shape = (32, 24, 32)
+    target_ornt = nib.orientations.axcodes2ornt("lia", ("lr", "pa", "is"))
+
+    affine = np.eye(4)
+    affine[:3, :3] = np.asarray(
+        [
+            [-0.02, 0.80, 0.05],
+            [-0.79, -0.03, 0.13],
+            [0.13, -0.05, 0.79],
+        ]
+    )
+    zooms = np.linalg.norm(affine[:3, :3], axis=0)
+    source_ornt = io_orientation(affine)
+
+    obj = Reorientation.from_target_orientation(affine, "soft LIA", shape, zooms)
+    expected = nib.orientations.inv_ornt_aff(nib.orientations.ornt_transform(source_ornt, target_ornt), shape)
+
+    assert obj.vox2vox == approx(expected)
+    assert "".join(aff2axcodes(affine, ("lr", "pa", "is"))).lower() == "prs"
+    assert "".join(aff2axcodes(obj.target_affine, ("lr", "pa", "is"))).lower() == "lia"
+
+    data = np.zeros(shape, dtype=np.uint8)
+    data[8:16, 6:14, 10:22] = 1
+
+    lia = apply_vox2vox(data, obj.vox2vox, out_shape=obj.target_shape, order=0)
+    back = apply_vox2vox(lia, obj.inverse.vox2vox, out_shape=obj.inverse.target_shape, order=0)
+
+    assert back == approx(data), "Soft keepgeom reorientation should roundtrip exactly for label data."
 
 
 def test_Reorientation_target_shape(


### PR DESCRIPTION
Fixes:
- write invocation of run_fastsurfer to log files (was overwritten by version.py, now writes into the seg and build logs)
- bug where segmentations were cropped when using keepgeom in special cases. 
- CC can now draw its result back into aparc+aseg.dkt if both images are native geometry
- CC now can also fill WM and background voxels for those cases (due to internal re-orientation to soft LIA in a new wrapper)