### PR TITLE
CC surface alignment + subsegment ordering

### DIFF
--- a/CorpusCallosum/cc_visualization.py
+++ b/CorpusCallosum/cc_visualization.py
@@ -8,7 +8,7 @@ import numpy as np
 from neuroreg import LTA
 
 from CorpusCallosum.data.fsaverage_cc_template import load_fsaverage_cc_template
-from CorpusCallosum.shape.contour import CCContour
+from CorpusCallosum.shape.contour import CCContour, contours_for_analysis_width
 from CorpusCallosum.shape.mesh import CCMesh
 from FastSurferCNN.utils.logging import get_logger, setup_logging
 
@@ -48,7 +48,7 @@ def make_parser() -> argparse.ArgumentParser:
         "--resolution",
         type=float,
         default=1.0,
-        help="Resolution in mm for the mesh.",
+        help="Legacy spacing in mm used when template contour files do not store slice positions.",
         metavar="RESOLUTION"
     )
     parser.add_argument(
@@ -173,6 +173,40 @@ def load_contours_from_template_dir(
     return contours
 
 
+def _upright_reference_from_template(
+        template_dir: Path,
+        output_dir: Path,
+) -> tuple[nib.spatialimages.SpatialHeader | None, np.ndarray | None]:
+    """Return the display header and RAS-to-voxel transform for CC mesh output.
+
+    ``CCMesh.from_contours`` creates vertices in the CC upright/fsaverage RAS
+    coordinate system. FreeSurfer surface files, however, store vertices in
+    surface RAS (tkRAS). Lapy's ``write_fssurf(..., image=header)`` performs
+    that voxel-to-tkRAS conversion and stamps the surface with the supplied
+    header's volume_info. Therefore callers must first convert mesh RAS to voxel
+    coordinates in the same volume whose header is passed to ``write_fssurf``.
+
+    For Freeview inspection with orig.mgz, the preferred path uses orig.mgz plus
+    ``cc_up.lta``. The LTA maps orig scanner RAS to upright/fsaverage RAS, so
+    ``inv(LTA @ orig.affine)`` maps mesh RAS directly to orig voxel coordinates.
+    If only an upright volume is available, the fallback writes a surface for
+    that upright volume instead.
+    """
+    orig_image = template_dir / "mri" / "orig.mgz"
+    upright_lta = template_dir / "mri" / "transforms" / "cc_up.lta"
+    if orig_image.exists() and upright_lta.exists():
+        image = nib.load(orig_image)
+        upright_vox2ras = LTA.read(upright_lta).r2r() @ image.affine
+        return image.header, np.linalg.inv(upright_vox2ras)
+
+    upright_image = output_dir / "mri" / "upright.mgz"
+    if upright_image.exists():
+        image = nib.load(upright_image)
+        return image.header, np.linalg.inv(image.affine)
+
+    return None, None
+
+
 def main(
         template_dir: str | Path,
         output_dir: str | Path,
@@ -184,11 +218,12 @@ def main(
         twoD: bool = False,
 ) -> Literal[0] | str:
     """Visualize corpus callosum templates in 2D or 3D."""
+    template_dir = Path(template_dir)
     output_dir = Path(output_dir)
     color_range = tuple(color_range) if color_range is not None else None
 
     contours = load_contours_from_template_dir(
-        Path(template_dir), resolution=resolution, smoothing_window=smoothing_window,
+        template_dir, resolution=resolution, smoothing_window=smoothing_window,
     )
 
     # 2D visualization
@@ -213,17 +248,19 @@ def main(
         return 0
 
     # 3D visualization
-    cc_mesh = CCMesh.from_contours(contours, smooth=0)
+    surface_mesh = CCMesh.from_contours(contours_for_analysis_width(contours), smooth=0)
+    header, mesh_ras2vox = _upright_reference_from_template(template_dir, output_dir)
 
-    if Path(output_dir / "mri" / "upright.mgz").exists():
-        header = nib.load(output_dir / "mri" / "upright.mgz").header
-    # we need to get the upright image header, which is the same as cc_up.lta applied to orig.
-    elif Path(template_dir / "mri/orig.mgz").exists() and Path(template_dir / "mri/transforms/cc_up.lta").exists():
-        image = nib.load(template_dir / "mri" / "orig.mgz")
-        transformed_affine = LTA.read(template_dir / "mri/transforms/cc_up.lta").r2r() @ image.affine
-        header = nib.MGHImage(image.dataobj, transformed_affine, header=image.header.copy()).header
+    if mesh_ras2vox is not None:
+        # Convert from CC upright/fsaverage RAS into the voxel coordinates of
+        # the same volume whose header is passed below.
+        # write_fssurf/snap_cc_picture then use the header's vox2ras-tkr to
+        # write/display vertices in the FreeSurfer coordinate frame expected by
+        # Freeview. Skipping this step treats millimeter RAS coordinates as voxel
+        # indices and shifts the surface far away from the MRI.
+        freeview_mesh = surface_mesh.to_vox_coordinates(mesh_ras2vox)
     else:
-        header = None
+        freeview_mesh = surface_mesh
 
     plot_kwargs = dict(
         colormap=colormap,
@@ -231,17 +268,17 @@ def main(
         thickness_overlay=True,
         legend=legend or "",
     )
-    cc_mesh.plot_mesh(**plot_kwargs)
-    cc_mesh.plot_mesh(output_path=str(output_dir / "cc_mesh.html"), **plot_kwargs)
+    surface_mesh.plot_mesh(**plot_kwargs)
+    surface_mesh.plot_mesh(output_path=str(output_dir / "cc_mesh.html"), **plot_kwargs)
 
     logger.info(f"Writing vtk file to {output_dir / 'cc_mesh.vtk'}")
-    cc_mesh.write_vtk(str(output_dir / "cc_mesh.vtk"))
+    surface_mesh.write_vtk(str(output_dir / "cc_mesh.vtk"))
     logger.info(f"Writing freesurfer surface file to {output_dir / 'cc_mesh.fssurf'}")
-    cc_mesh.write_fssurf(str(output_dir / "cc_mesh.fssurf"), image=header)
+    freeview_mesh.write_fssurf(str(output_dir / "cc_mesh.fssurf"), image=header)
     logger.info(f"Writing freesurfer overlay file to {output_dir / 'cc_mesh_overlay.curv'}")
-    cc_mesh.write_morph_data(str(output_dir / "cc_mesh_overlay.curv"))
+    surface_mesh.write_morph_data(str(output_dir / "cc_mesh_overlay.curv"))
     try:
-        cc_mesh.snap_cc_picture(str(output_dir / "cc_mesh_snap.png"), ref_header=header)
+        freeview_mesh.snap_cc_picture(str(output_dir / "cc_mesh_snap.png"), ref_header=header)
         logger.info(f"Writing 3D snapshot image to {output_dir / 'cc_mesh_snap.png'}")
     except Exception:
         logger.warning("The cc_visualization script requires whippersnappy>=2.1 to makes screenshots, install with "

--- a/CorpusCallosum/cc_visualization.py
+++ b/CorpusCallosum/cc_visualization.py
@@ -27,7 +27,9 @@ def make_parser() -> argparse.ArgumentParser:
             "thickness_values_<idx>.txt, and optionally contour_<idx>.txt "
             "and thickness_measurement_points_<idx>.txt. If contour_<idx>.txt "
             "and thickness_measurement_points_<idx>.txt are not provided, "
-            "uses fsaverage template."
+            "uses fsaverage template. For FreeSurfer surfaces in orig.mgz "
+            "reference space, also provide mri/orig.mgz and "
+            "mri/transforms/cc_up.lta in this directory."
         ),
         metavar="TEMPLATE_DIR",
         default=None,
@@ -41,7 +43,10 @@ def make_parser() -> argparse.ArgumentParser:
                              "cc_mesh.vtk - VTK mesh file format "
                              "cc_mesh.fssurf - FreeSurfer surface file "
                              "cc_mesh_overlay.curv - FreeSurfer curvature overlay file "
-                             "cc_mesh_snap.png - Screenshot/snapshot of the 3D mesh (requires whippersnappy>=2.1)",
+                             "cc_mesh_snap.png - Screenshot/snapshot of the 3D mesh (requires whippersnappy>=2.1). "
+                             "If template_dir does not contain orig.mgz and cc_up.lta, "
+                             "output_dir/mri/upright.mgz is used as the fallback reference when available; "
+                             "otherwise FreeSurfer surfaces are written without a reference space.",
                         metavar="OUTPUT_DIR"
                         )
     parser.add_argument(
@@ -260,6 +265,12 @@ def main(
         # indices and shifts the surface far away from the MRI.
         freeview_mesh = surface_mesh.to_vox_coordinates(mesh_ras2vox)
     else:
+        logger.warning(
+            "Writing FreeSurfer surface outputs without a reference space. "
+            "The surface vertices remain in CC upright RAS coordinates and may not align with an MRI in Freeview. "
+            "Provide template_dir/mri/orig.mgz with template_dir/mri/transforms/cc_up.lta, "
+            "or output_dir/mri/upright.mgz, to write the surface in a reference space.",
+        )
         freeview_mesh = surface_mesh
 
     plot_kwargs = dict(

--- a/CorpusCallosum/data/constants.py
+++ b/CorpusCallosum/data/constants.py
@@ -23,6 +23,8 @@ FSAVERAGE_REGISTRATION_LABELS = (
     251, 252, 253, 254, 255,
 )
 FSAVERAGE_MIDDLE = 128  # Middle slice index in fsaverage space
+# Width of the corpus callosum slab used for segmentation, measures, and surfaces.
+CC_ANALYSIS_WIDTH_MM = 5.0
 CC_LABEL = 192  # Label value for corpus callosum in segmentation
 FORNIX_LABEL = 250  # Label value for fornix in segmentation
 THIRD_VENTRICLE_LABEL = 4  # Label value for third ventricle in segmentation

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -29,6 +29,7 @@ from nibabel.freesurfer.mghformat import MGHHeader
 from scipy.ndimage import affine_transform
 
 from CorpusCallosum.data.constants import (
+    CC_ANALYSIS_WIDTH_MM,
     CC_LABEL,
     DEFAULT_INPUT_PATHS,
     DEFAULT_OUTPUT_PATHS,
@@ -460,7 +461,8 @@ def localize_ac_pc(
     third_ventricle_center = np.argwhere(third_ventricle_mask).mean(axis=0)
     third_ventricle_center_vox = apply_transform_to_pt(third_ventricle_center, orig2midslice_vox2vox, inv=False)
 
-    # get 5 mm of slices with 3 slices per inference (cropping num_slices_to_analyze + 2 slices around the center)
+    # Get the analysis-width slab with 3 slices per inference
+    # (cropping num_slices_to_analyze + 2 slices around the center).
     ac_coords, pc_coords = localization_inference.run_inference_on_slice(
         model_localization,
         _midslices_fut.result(),
@@ -709,16 +711,17 @@ def main(
             logger.error(error_message)
             return error_message
 
-    # 5 mm around the midplane (guaranteed to be aligned RAS by as_closest_canonical)
+    # Analysis-width slab around the midplane (guaranteed to be aligned RAS by as_closest_canonical).
     vox_size_ras: tuple[float, float, float] = nib.as_closest_canonical(orig).header.get_zooms()
     vox_size = vox_size_ras[0], vox_size_ras[2], vox_size_ras[1]  # convert from RAS to LIA
-    slices_to_analyze = int(np.ceil(5 / vox_size[0]))
+    slices_to_analyze = int(np.ceil(CC_ANALYSIS_WIDTH_MM / vox_size[0]))
     # slices_to_analyze must be odd
     if slices_to_analyze % 2 == 0:
         slices_to_analyze += 1
 
     logger.info(
-        f"Segmenting {slices_to_analyze} slices (5 mm width at {vox_size[0]:.3f} mm resolution, "
+        f"Segmenting {slices_to_analyze} slices ({CC_ANALYSIS_WIDTH_MM:g} mm width at "
+        f"{vox_size[0]:.3f} mm resolution, "
         "center around the mid-sagittal plane)"
     )
 
@@ -834,7 +837,7 @@ def main(
         slice_results, slice_io_futures, cc_contours, num_failed_slices = recon_cc_surf_measures_multi(
             segmentation=cc_fn_seg_labels,
             slice_selection=slice_selection,
-            upright_header=fsavg_header,
+            orig_header=orig.header,
             fsavg2midslab_vox2vox=fsavg2midslab_vox2vox,
             fsavg_vox2ras=fsavg_vox2ras,
             orig2fsavg_vox2vox=orig2fsavg_vox2vox,
@@ -933,7 +936,7 @@ def main(
     additional_metrics = {}
 
     cc_num_voxel = segmentation_postprocessing.get_cc_num_voxel(
-        desired_width_mm=5,
+        desired_width_mm=CC_ANALYSIS_WIDTH_MM,
         cc_mask=np.equal(cc_fn_seg_labels, CC_LABEL),
         voxel_size=vox_size,  # in LIA order
     )
@@ -946,7 +949,7 @@ def main(
             f"CC voxel count: {cc_num_voxel} at {voxel_volume:.2f} mm^3 voxel volume => "
             f"{cc_num_voxel * voxel_volume:.2f} mm^3"
         )
-        cc_volume_contour = calculate_cc_volume_contour(valid_cc_contours, width=5.0)
+        cc_volume_contour = calculate_cc_volume_contour(valid_cc_contours, width=CC_ANALYSIS_WIDTH_MM)
         logger.info(f"CC volume contour: {cc_volume_contour}")
     else:
         cc_volume_contour = None

--- a/CorpusCallosum/shape/contour.py
+++ b/CorpusCallosum/shape/contour.py
@@ -37,6 +37,7 @@ import scipy.interpolate
 from scipy.ndimage import gaussian_filter1d
 
 import FastSurferCNN.utils.logging as logging
+from CorpusCallosum.data.constants import CC_ANALYSIS_WIDTH_MM
 from CorpusCallosum.shape.endpoint_heuristic import find_cc_endpoints, smooth_contour
 from CorpusCallosum.shape.thickness import cc_thickness
 from CorpusCallosum.utils.types import Points2dType
@@ -832,7 +833,7 @@ class CCContour:
         return cls(contour_ras[:, 1:], None, endpoint_idx, z_position=slice_vox2ras[0, 3])
 
 
-def calculate_volume(contours: list[CCContour], width: float = 5.0) -> float:
+def calculate_volume(contours: list[CCContour], width: float = CC_ANALYSIS_WIDTH_MM) -> float:
     """Calculate the volume of the corpus callosum.
 
     This method calculates the volume of a slab of the CC centered on the midplane.
@@ -842,7 +843,7 @@ def calculate_volume(contours: list[CCContour], width: float = 5.0) -> float:
 
     Parameters
     ----------
-    width : float, default=5.0
+    width : float, default=CC_ANALYSIS_WIDTH_MM
         The width of the slab centered on the midplane to calculate the volume for (in mm).
 
     Returns
@@ -883,3 +884,40 @@ def calculate_volume(contours: list[CCContour], width: float = 5.0) -> float:
         volume += areas[i] * effective_width
 
     return volume
+
+
+def contours_for_analysis_width(contours: list[CCContour]) -> list[CCContour]:
+    """Return contour copies with LR positions spanning a fixed display width.
+
+    The CC segmentation mask is sampled on image slices, so its realized width
+    depends on the voxel size and the odd number of slices needed to cover the
+    requested analysis slab. The surface representation, however, is the
+    continuous slab itself. For meshes we therefore place the available contours
+    evenly across that physical width.
+
+    The contour list follows increasing slab voxel index order. In the upright
+    CC volume, the slab voxel axis has a negative RAS left/right direction, so
+    increasing slice indices correspond to decreasing mesh LR RAS coordinates.
+    Assign the display positions from ``+CC_ANALYSIS_WIDTH_MM / 2`` down to
+    ``-CC_ANALYSIS_WIDTH_MM / 2`` to preserve that orientation.
+
+    This function intentionally returns copies. Measurement code can continue to
+    use the original slice-center coordinates, while visualization/surface
+    output gets the fixed physical slab width expected by Freeview inspection.
+    """
+    if not contours:
+        return []
+
+    surface_contours = [contour.copy() for contour in contours]
+    if len(surface_contours) == 1:
+        surface_contours[0].z_position = 0.0
+        return surface_contours
+
+    half_width = CC_ANALYSIS_WIDTH_MM / 2.0
+    for contour, z_position in zip(
+        surface_contours,
+        np.linspace(half_width, -half_width, len(surface_contours)),
+        strict=True,
+    ):
+        contour.z_position = float(z_position)
+    return surface_contours

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -18,12 +18,11 @@ from pathlib import Path
 from typing import get_args
 
 import numpy as np
-from nibabel.freesurfer.mghformat import MGHHeader
 from numpy import typing as npt
 
 import FastSurferCNN.utils.logging as logging
 from CorpusCallosum.data.constants import CC_LABEL, SUBSEGMENT_LABELS
-from CorpusCallosum.shape.contour import CCContour
+from CorpusCallosum.shape.contour import CCContour, contours_for_analysis_width
 from CorpusCallosum.shape.curvature import calculate_curvature_metrics
 from CorpusCallosum.shape.endpoint_heuristic import connect_diagonally_connected_components
 from CorpusCallosum.shape.mesh import CCMesh
@@ -43,7 +42,7 @@ from CorpusCallosum.utils.types import (
     SubdivisionMethod,
 )
 from CorpusCallosum.utils.visualization import plot_contours
-from FastSurferCNN.utils import AffineMatrix4x4, Image3d, Mask2d, Shape2d, Shape3d, Vector2d
+from FastSurferCNN.utils import AffineMatrix4x4, Image3d, Mask2d, Shape2d, Shape3d, Vector2d, nibabelHeader
 from FastSurferCNN.utils.common import SubjectDirectory, update_docstring
 from FastSurferCNN.utils.parallel import process_executor, thread_executor
 
@@ -86,7 +85,7 @@ def offset_affine(offset: npt.ArrayLike) -> AffineMatrix4x4:
 def recon_cc_surf_measures_multi(
     segmentation: np.ndarray[Shape3d, np.dtype[np.int_]],
     slice_selection: SliceSelection,
-    upright_header: MGHHeader,
+    orig_header: nibabelHeader,
     fsavg2midslab_vox2vox: AffineMatrix4x4,
     fsavg_vox2ras: AffineMatrix4x4,
     orig2fsavg_vox2vox: AffineMatrix4x4,
@@ -107,8 +106,9 @@ def recon_cc_surf_measures_multi(
         3D segmentation array in LIA orientation.
     slice_selection : str
         Which slices to process ('middle', 'all', or slice number).
-    upright_header : MGHHeader
-        The header of the upright image.
+    orig_header : nibabelHeader
+        Header of the conformed orig image. Surface files intended for
+        inspection with orig.mgz must be written with this geometry metadata.
     fsavg2midslab_vox2vox : AffineMatrix4x4
         The vox2vox transformation matrix from fsaverage (upright) space to the segmentation slab.
     fsavg_vox2ras : np.ndarray
@@ -262,7 +262,10 @@ def recon_cc_surf_measures_multi(
     mesh_outputs = ("html", "mesh", "thickness_overlay", "surf", "thickness_image")
     if len(cc_contours) > 1 and any(wants_output(f"cc_{n}") for n in mesh_outputs):
         _cc_contours = thread_executor().map(_resample_thickness, cc_contours)
-        cc_mesh = CCMesh.from_contours(list(_cc_contours), smooth=1)
+        # Surface vertices represent the continuous analysis slab. The
+        # discrete segmentation mask can be slightly wider/narrower depending on
+        # voxel size, so do not reuse slice-center spacing for mesh output.
+        cc_mesh = CCMesh.from_contours(contours_for_analysis_width(list(_cc_contours)), smooth=1)
         if wants_output("cc_html"):
             logger.info(f"Saving CC 3D visualization to {output_path('cc_html')}")
             io_futures.append(run(cc_mesh.plot_mesh, output_path=output_path("cc_html")))
@@ -278,20 +281,24 @@ def recon_cc_surf_measures_multi(
             io_futures.append(run(cc_mesh.write_morph_data, overlay_file_path))
 
         if any(wants_output(f"cc_{n}") for n in ("thickness_image", "surf")):
-            # the mesh is generated in upright coordinates, so we need to also transform to orig coordinates
-            # Mesh is fsavg_midplane (RAS); we need to transform to voxel coordinates
-            # fsavg ras is also on the midslice, so this is fine and we multiply in the IA and SP offsets
+            # The mesh is generated in upright/fsaverage RAS coordinates.
+            # Convert it to orig voxel coordinates, then pass orig_header to
+            # write_fssurf/snap_cc_picture. Lapy interprets vertices as voxel
+            # coordinates when an image/header is supplied and converts them to
+            # FreeSurfer tkRAS while stamping the surface with that header's
+            # volume_info. Using an upright-volume header here makes Freeview
+            # place the surface relative to that volume instead of orig.mgz.
             cc_mesh_orig = cc_mesh.to_vox_coordinates(mesh_ras2vox=np.linalg.inv(fsavg_vox2ras @ orig2fsavg_vox2vox))
             if wants_output("cc_surf"):
                 surf_file_path = output_path("cc_surf")
                 logger.info(f"Saving surf file to {surf_file_path}")
-                io_futures.append(run(cc_mesh_orig.write_fssurf, surf_file_path, image=upright_header))
+                io_futures.append(run(cc_mesh_orig.write_fssurf, surf_file_path, image=orig_header))
 
             if wants_output("cc_thickness_image"):
                 thickness_image_path = output_path("cc_thickness_image")
                 logger.info(f"Saving thickness image to {thickness_image_path}")
                 try:
-                    cc_mesh_orig.snap_cc_picture(thickness_image_path, ref_header=upright_header)
+                    cc_mesh_orig.snap_cc_picture(thickness_image_path, ref_header=orig_header)
                 except Exception as e:
                     logger.error(
                         "Generation of the thickness image failed (see below). Please ensure that whippersnappy and "

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -259,8 +259,18 @@ def recon_cc_surf_measures_multi(
             io_futures.append(run(cc_contours[j].save_contour, template_dir / f"contour_{j}.txt"))
             io_futures.append(run(cc_contours[j].save_thickness_values, template_dir / f"thickness_values_{j}.txt"))
 
+    num_failed_slices = num_slices - len(cc_contours)
+
     mesh_outputs = ("html", "mesh", "thickness_overlay", "surf", "thickness_image")
     if len(cc_contours) > 1 and any(wants_output(f"cc_{n}") for n in mesh_outputs):
+        if num_failed_slices > 0:
+            logger.warning(
+                "Skipping CC surface/mesh outputs because morphometry failed for "
+                f"{num_failed_slices} of {num_slices} requested slices. "
+                "Surface generation requires a complete slice set to preserve the physical slab spacing.",
+            )
+            return slice_cc_measures, io_futures, cc_contours, num_failed_slices
+
         _cc_contours = thread_executor().map(_resample_thickness, cc_contours)
         # Surface vertices represent the continuous analysis slab. The
         # discrete segmentation mask can be slightly wider/narrower depending on
@@ -310,7 +320,7 @@ def recon_cc_surf_measures_multi(
             logger.error("Error: No valid slices were found for postprocessing")
             raise ValueError("No valid slices were found for postprocessing")
 
-    return slice_cc_measures, io_futures, cc_contours, num_slices - len(cc_contours)
+    return slice_cc_measures, io_futures, cc_contours, num_failed_slices
 
 
 def _resample_thickness(contour: CCContour) -> CCContour:

--- a/CorpusCallosum/shape/postprocessing.py
+++ b/CorpusCallosum/shape/postprocessing.py
@@ -551,6 +551,24 @@ def test_left_of_line(
     return np.greater(cross_products, 0)
 
 
+def test_posterior_of_line(
+        coords_as: Points2dType,
+        line_start: Vector2d,
+        line_end: Vector2d,
+) -> np.ndarray[tuple[int], np.dtype[np.bool_]]:
+    """Test whether points in AS coordinates are posterior to a subdivision line.
+
+    Subdivision lines are stored as the two intersections with the contour. The
+    order of those intersections depends on contour traversal and is not an
+    anatomical direction. Determine which side is anterior by testing a point one
+    millimeter anterior to the line midpoint, then return the opposite side.
+    """
+    left_of_line = test_left_of_line(coords_as, line_start, line_end)
+    anterior_probe = (line_start + line_end) / 2.0 + np.array([1.0, 0.0])
+    anterior_is_left = bool(test_left_of_line(anterior_probe, line_start, line_end))
+    return np.logical_not(left_of_line) if anterior_is_left else left_of_line
+
+
 def make_subdivision_mask(
     slice_shape: Shape2d,
     subdivision_lines: list[Points2dType],
@@ -609,13 +627,13 @@ def make_subdivision_mask(
         # line_start and line_end are the intersection points of the CC subsegmentation boundary and the contour line
         line_start, line_end = segment_points
 
-        # --> find all voxels posterior to the line in question
-        # Vectorized test: find all points to the right of line (line_start->line_end)
-        # right_of_line == posterior to line
-        points_left_of_line = test_left_of_line(coords_ras[0, ..., 1:], line_start, line_end)
+        # Find all voxels posterior to the line in question. The line endpoint
+        # order is not anatomically stable, so do not use a raw left/right test
+        # of line_start -> line_end here.
+        points_posterior_of_line = test_posterior_of_line(coords_ras[0, ..., 1:], line_start, line_end)
         
-        # All points to the right of this line belong to the next segment or beyond
-        subdivision_mask[points_left_of_line] = label
+        # All points posterior to this line belong to the next segment or beyond.
+        subdivision_mask[points_posterior_of_line] = label
         
         if plot: # interactive debug plot
             import matplotlib.pyplot as plt


### PR DESCRIPTION
This PR contains two commits.

1. Fixed corpus callosum surface alignment. The generated CC surfaces are now correctly mapped with the volume. This was previously not the case for the isolated visualization script. Both visualzation and main script also had a bug where an offset would be in the surface if the image size would differ after resampling to fsaverage resolution (i.e. the original image would have not the same world-size as fsaverage)

2. In some cases CC subsegments labels were flipped in the segmentation output. This was due to an unreliable heuristic determining anterior and posterior segments in the contour.

Both changes were tested with a testsuite of 8 cases, with multiple resolutions, orientations and challenging anatomy using visual inspection and automated testing.