### PR TITLE
CC documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ _Faber J*, Kuegler D*, Bahrami E*, et al. (*co-first). CerebNet: A fast and reli
 
 _Estrada S, Kuegler D, Bahrami E, Xu P, Mousa D, Breteler MMB, Aziz NA, Reuter M. FastSurfer-HypVINN: Automated sub-segmentation of the hypothalamus and adjacent structures on high-resolutional brain MRI. Imaging Neuroscience 2023; 1 1–32. https://doi.org/10.1162/imag_a_00034_
 
-_Pollak C, Diers K, Estrada S, Kuegler D, Reuter M, FastSurfer-CC: A robust, accurate, and comprehensive framework for corpus callosum morphometry, pre-print on arXiv: https://doi.org/10.48550/arXiv.2511.16471_
+_Pollak C, Diers K, Estrada S, Kuegler D, Reuter M. FastSurfer-CC: A robust, accurate, and comprehensive framework for corpus callosum morphometry. Imaging Neuroscience 2026. https://doi.org/10.1162/IMAG.a.1221_
 
 Extensions:
 

--- a/doc/overview/OUTPUT_FILES.md
+++ b/doc/overview/OUTPUT_FILES.md
@@ -32,7 +32,7 @@ The Corpus Callosum module outputs the files in the table shown below. It create
 | stats           | callosum.CC.midslice.json      | cc     | measurements from the mid-sagittal slice (landmarks, area, thickness, etc.)                               |
 | stats           | callosum.CC.all_slices.json    | cc     | comprehensive per-slice analysis       |
 | qc_snapshots    | callosum.png                   | cc     | debug visualization of CC contours, AC, PC and thickness (only with run_fastsurfer.sh `--qc_snap`)                                       |
-| qc_snapshots    | callosum_thickness.png         | cc     | 3D thickness visualization (only with run_fastsurfer.sh `--qc_snap`)                                                   |
+| qc_snapshots    | callosum.thickness.png         | cc     | 3D thickness visualization (only with run_fastsurfer.sh `--qc_snap`)                                                   |
 | qc_snapshots    | corpus_callosum.html           | cc     | interactive 3D mesh visualization (only with run_fastsurfer.sh `--qc_snap`)                                                    |
 | surf            | callosum.surf                  | cc     | 3D Corpus Callosum mesh in FreeSurfer surface format (open with freeview)              |
 | surf            | callosum.thickness.w           | cc     | FreeSurfer overlay file containing thickness values (open with callosum.surf in freeview)                   |

--- a/doc/overview/modules/CC.md
+++ b/doc/overview/modules/CC.md
@@ -12,9 +12,19 @@ This pipeline combines localization and segmentation deep learning models to:
 4. Perform advanced morphometry for corpus callosum, including subdivision, thickness analysis, and various shape metrics
 5. Generate visualizations and measurements
 
+FastSurfer-CC identifies the midsagittal slab for corpus callosum analysis, segments the corpus callosum and fornix,
+localizes AC and PC landmarks for head-pose standardization, and derives area, thickness, length, curvature, volume,
+and subdivision measures for downstream statistical analysis.
+
 The output files are described [here](../OUTPUT_FILES.md#corpus-callosum-module).
 The structure of the JSON files describing corpus callosum measures is documented below.
 Advanced options, like custom subdivision schemes and quality control are described in the [FastSurfer-CC documentation](../../scripts/fastsurfer_cc.rst).
+
+References
+----------
+If you use FastSurfer-CC in your research, please cite:
+
+*Pollak C, Diers K, Estrada S, Kuegler D, Reuter M. FastSurfer-CC: A robust, accurate, and comprehensive framework for corpus callosum morphometry. Imaging Neuroscience 2026. https://doi.org/10.1162/IMAG.a.1221*
 
 JSON Output Structure
 ---------------------

--- a/doc/scripts/fastsurfer_cc.rst
+++ b/doc/scripts/fastsurfer_cc.rst
@@ -1,9 +1,9 @@
 CorpusCallosum: fastsurfer_cc.py
 ================================
 .. note::
-   We recommend to run FastSurfer-CC with the standard `run_fastsurfer.sh` interfaces (see :doc:`/overview/FLAGS`)!
+   We recommend running FastSurfer-CC with the standard ``run_fastsurfer.sh`` interface (see :doc:`RUN_FASTSURFER`)!
 
-   This is an expert documentation for of FastSurfer CC, which can be run independently with the advanced interface provided here. However, the FastSurfer segmentation is still required as input.
+   This page documents expert usage of FastSurfer-CC, which can be run independently with the advanced interface provided here. However, the FastSurfer segmentation is still required as input.
 
 
 ..
@@ -53,7 +53,7 @@ An example call with all quality control outputs is:
 
     python3 fastsurfer_cc.py --sd /data/subjects --sid sub001 \
         --qc_image /data/qc/sub001/qc_snapshots/callosum.png \
-        --thickness_image /data/qc/sub001/qc_snapshots/callosum_thickness.png \
+        --thickness_image /data/qc/sub001/qc_snapshots/callosum.thickness.png \
         --upright_volume /data/qc/sub001/mri/upright_volume.mgz
 
 Custom Subdivision Schemes


### PR DESCRIPTION
This pull request makes several documentation updates to improve clarity, accuracy, and consistency regarding the FastSurfer-CC corpus callosum module. The main changes include updating references to published articles, standardizing file naming conventions, expanding the module description, and improving documentation formatting.

**Added FastSurfer-CC citation**

- Updated the FastSurfer-CC publication reference to reflect its publication in Imaging Neuroscience 2026, replacing the previous arXiv preprint citation in both the main `README.md` and the module documentation.
- Added a dedicated "References" section to the corpus callosum module documentation

**Other doc improvements**

- Standardized the file name for the 3D thickness visualization output from `callosum_thickness.png` to `callosum.thickness.png` in both the output files overview and example usage, ensuring consistency across documentation.
- Improved phrasing and formatting in the expert documentation for FastSurfer-CC, including clearer recommendations for running the tool and better code formatting for interface references.
- Expanded the module overview to provide a clearer, more comprehensive summary of the FastSurfer-CC pipeline’s steps and outputs.