### PR TITLE
Fix strict conform voxel center to agree with FreeSurfer and earlier FastSurfer versions

### DIFF
--- a/FastSurferCNN/README.md
+++ b/FastSurferCNN/README.md
@@ -9,7 +9,9 @@ that specifically tailor network performance towards accurate segmentation of bo
 
 The network was trained with conformed images (UCHAR, 1-0.7 mm voxels and standard slice orientation). These 
 specifications are checked in the run_prediction.py script and the image is automatically conformed if it does not 
-comply.
+comply. The default strict path follows FreeSurfer-style conforming semantics for the resampling grid, while the
+native/soft orientation path keeps voxel-center semantics so reorder/flip-only transforms can roundtrip native
+geometry.
 
 <!-- before inference -->
 1. Inference
@@ -24,8 +26,10 @@ which certain options can be selected and set via the command line:
 * `--in_dir`: Path to the input volume directory (e.g `/your/path/to/ADNI/fs60`) or 
 * `--csv_file`: Path to csv-file listing input volume directories
 * `--t1`: name of the T1-weighted MRI_volume (like `mri_volume.mgz`, default: `orig.mgz`)
-* `--conformed_name`: name of the conformed MRI_volume (the input volume is always first conformed, if not already, and 
-  the result is saved under the given name, default: `orig.mgz`)
+* `--conformed_name`: name of the conformed MRI_volume (the input volume is prepared for inference first and the 
+  result is saved under the given name, default: `orig.mgz`). In the standard path this is the FastSurfer conform
+  image; for native/keepgeom-style processing the saved image stays in native geometry, with only intensity scaling
+  and dtype conversion as needed, while any soft reordering is temporary and only used internally for inference.
 * `--t`: search tag limits processing to subjects matching the pattern (e.g. sub-* or 1030*...)
 * `--sd`: Path to output directory (where should predictions be saved). Will be created if it does not already exist.
 * `--seg_log`: name of log-file (information about processing is stored here; If not set, logs will not be saved). Saved

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -282,6 +282,10 @@ class Reorientation:
     """
     A class to organize data reorientation to canonical orientations.
 
+    Strict conform-style reorientations default to the same image-center convention as FreeSurfer
+    (``shape / 2``). Soft/native reorientations that only reorder or flip axes opt into the voxel-center
+    convention (``(shape - 1) / 2``) explicitly so they can roundtrip native geometry without resampling.
+
     Attributes
     ----------
     source_affine : AffineMatrix4x4
@@ -304,6 +308,7 @@ class Reorientation:
         self.source_shape = source_shape
         self.target_shape = source_shape
         self.tol = tol
+        self.voxel_center = False
 
     @property
     def vox2vox(self) -> AffineMatrix4x4:
@@ -334,7 +339,10 @@ class Reorientation:
         """
         Determine the affine matrix to reorder and flip/interpolate data from source_affine to orientation.
 
-        The resulting transform is a vox2vox from source to target.
+        The resulting transform is a vox2vox from source to target. Strict orientations (for example ``"LIA"``)
+        use the FreeSurfer conform center convention by default, while ``"soft-..."`` and ``"native"``
+        reorientations preserve the voxel-center convention explicitly so discrete reorder/flip transforms can
+        be mapped back to native space exactly.
 
         Parameters
         ----------
@@ -393,7 +401,13 @@ class Reorientation:
         # second run, now with correct ordering of output voxel sizes in vox2ras
         target_strict_affine: AffineMatrix3x3 = ornt2vox2vox(_reorder_ornt, (1,) * 3, vox_size_in_target)[:3, :3]
         if not is_soft:
-            return cls.from_target_affine(source_affine, target_strict_affine, shape, target_shape, tol)
+            return cls.from_target_affine(
+                source_affine,
+                target_strict_affine,
+                shape,
+                target_shape,
+                tol,
+            )
 
         source_ornt = io_orientation(source_affine)
         target_ornt = axcodes2ornt(_target_orientation, AXCODES)
@@ -405,9 +419,9 @@ class Reorientation:
 
         same_target_shape = target_shape is None or np.array_equal(np.asarray(target_shape), np.asarray(shape))
         if same_target_shape and not does_vox2vox_rot_require_interpolation(soft_rot_mat, vox_eps=tol, rot_eps=tol):
-            return cls.from_vox2vox(source_affine, discrete_vox2vox, shape, target_shape, tol)
+            return cls.from_vox2vox(source_affine, discrete_vox2vox, shape, target_shape, tol, voxel_center=True)
 
-        return cls.from_vox2vox(source_affine, soft_rot_mat, shape, target_shape, tol)
+        return cls.from_vox2vox(source_affine, soft_rot_mat, shape, target_shape, tol, voxel_center=True)
 
     @classmethod
     def from_target_affine(
@@ -417,6 +431,8 @@ class Reorientation:
             shape: npt.ArrayLike,
             target_shape: npt.ArrayLike | None = None,
             tol: float = 1e-6,
+            *,
+            voxel_center: bool = False,
     ) -> SelfReorientation:
         """
         Determine the affine matrix to reorder and flip/interpolate data from source_affine to orientation.
@@ -441,6 +457,12 @@ class Reorientation:
         Reorientation
             An object holding the source_affine and the vox2vox transform to reorient data from source_affine to
             target_orientation.
+
+        Other Parameters
+        ----------------
+        voxel_center : bool, default=False
+            Whether to use the voxel-center convention ``(shape - 1) / 2``. The default ``False`` matches
+            FreeSurfer-style strict conforming. Soft/native callers should pass ``True``.
         """
         if target_affine.shape == (4, 4):
             v2v = np.linalg.inv(source_affine) @ target_affine
@@ -456,7 +478,14 @@ class Reorientation:
         else:
             raise ValueError(f"target_affine must be of shape (3, 3), (4, 4) or (3, 4), but was {target_affine.shape}.")
 
-        return cls.from_vox2vox(source_affine, v2v, shape, target_shape, tol)
+        return cls.from_vox2vox(
+            source_affine,
+            v2v,
+            shape,
+            target_shape,
+            tol,
+            voxel_center=voxel_center,
+        )
 
     @classmethod
     def from_vox2vox(
@@ -466,6 +495,8 @@ class Reorientation:
             shape: npt.ArrayLike,
             target_shape: npt.ArrayLike | None = None,
             tol: float = 1e-6,
+            *,
+            voxel_center: bool = False,
     ) -> SelfReorientation:
         """
         Determine the affine matrix to reorder and flip/interpolate data from source_affine to orientation.
@@ -493,6 +524,12 @@ class Reorientation:
             An object holding the source_affine and the vox2vox transform to reorient data from source_affine to
             target_orientation.
 
+        Other Parameters
+        ----------------
+        voxel_center : bool, default=False
+            Whether to use the voxel-center convention ``(shape - 1) / 2``. The default ``False`` matches
+            FreeSurfer-style strict conforming. Soft/native callers should pass ``True``.
+
         See Also
         --------
         FastSurferCNN.data_loader.conform.apply_vox2vox : Apply a vox2vox matrix to a 3D image.
@@ -503,9 +540,15 @@ class Reorientation:
         obj = cls(source_affine, _shape, tol)
 
         _target_shape = _shape if target_shape is None else np.asarray(target_shape, dtype=np.int64)
+        obj.voxel_center = voxel_center
         if vox2vox.shape == (3, 3):
-            # make center stay consistent, so in_voxcenter and and out_voxcenter should have same ras coordinates
-            translation = _translation_to_fix_center(vox2vox, _shape, _target_shape)
+            # make center stay consistent, so in_voxcenter and out_voxcenter should have same ras coordinates
+            translation = _translation_to_fix_center(
+                vox2vox,
+                _shape,
+                _target_shape,
+                voxel_center=voxel_center,
+            )
 
             # expand the rotation matrix to 4x4 by 0 and translation
             rot_cols = np.concatenate([vox2vox, np.zeros((1, 3))], axis=0)
@@ -584,6 +627,7 @@ class Reorientation:
                 self.target_shape,
                 self.reorder_axes(self.source_shape),
                 self.tol,
+                voxel_center=self.voxel_center,
             )
 
     def reorder_axes(self, vector: np.ndarray[tuple[Literal[3]], np.dtype[ScalarType]]) \
@@ -1121,9 +1165,14 @@ def _translation_to_fix_center(
         vox2vox_o2i: AffineMatrix4x4 | AffineMatrix3x3,
         shape: IntVector3d,
         target_shape: IntVector3d | None = None,
+        *,
+        voxel_center: bool = True,
 ) -> Vector3d:
     """
     Calculate the translation to keep the center of the image fixed after applying the vox2vox transformation.
+
+    This low-level helper keeps the voxel-center convention by default because it is also used by
+    discrete orientation helpers such as :func:`ornt2vox2vox`.
 
     Parameters
     ----------
@@ -1133,6 +1182,9 @@ def _translation_to_fix_center(
         The shape of the input data.
     target_shape: IntVector3d, optional
         The shape of the output data (in input data order, not target order), defaults to the same as shape.
+    voxel_center : bool, default=True
+        Whether to conserve the voxel-center convention ``(shape - 1) / 2``. Set to ``False`` to use the
+        FreeSurfer conform convention ``shape / 2`` instead.
 
     Returns
     -------
@@ -1140,9 +1192,12 @@ def _translation_to_fix_center(
         The translation to keep the center of the image fixed after applying the vox2vox transformation.
     """
     _target_shape = shape if target_shape is None else target_shape
-    in_voxcenter = (np.asarray(shape) - 1) / 2
+    center_offset = 1 if voxel_center else 0
+    in_voxcenter = (np.asarray(shape) - center_offset) / 2
     vox2vox4 = np.pad(vox2vox_o2i[:3, :3], ((0, 1), (0, 1)))
-    out_voxcenter = (_target_shape[io_orientation(vox2vox4.T)[:, 0].astype(np.int64)] - 1) / 2
+    out_voxcenter = (
+        _target_shape[io_orientation(vox2vox4.T)[:, 0].astype(np.int64)] - center_offset
+    ) / 2
     #    voxO2ras @ voxO2voxI @ voxI_coord = voxO2ras @ voxO_coord
     # => voxO_coord = voxI2voxO @ voxI_coord = voxI2voxO_rot @ voxI_coord + voxI2voxO_trans
     # => voxO2voxI_trans = voxO_coord - voxI2voxO_rot @ voxI_coord
@@ -1171,6 +1226,9 @@ def target_shape_from_shape_scale(shape: npt.ArrayLike, scale: npt.ArrayLike) ->
 def ornt2vox2vox(ornt: OrntArrayType, shape: npt.ArrayLike, scale: npt.ArrayLike | None = None) -> AffineMatrix4x4:
     """
     Calculate the mid-centered vox2vox matrix of the orientation transform `ornt` (operation, not target orientation).
+
+    This helper keeps the voxel-center convention ``(shape - 1) / 2`` so pure axis reorder/flip transforms
+    stay compatible with nibabel orientation utilities and can be inverted without introducing a half-voxel shift.
 
     Parameters
     ----------
@@ -1217,10 +1275,6 @@ def ornt2vox2vox(ornt: OrntArrayType, shape: npt.ArrayLike, scale: npt.ArrayLike
     if _shape.size != dim:
         raise ValueError(f"The length of shape needs to be equal ornt.shape[0] ({dim})!")
     target_shape = target_shape_from_shape_scale(_shape, _scale)
-    if scale is None:
-        _out_center = (_shape - 1) / 2
-    else:
-        _out_center = (target_shape - 1) / 2
 
     # reorder, then flip
     vox2vox = np.zeros((dim + 1,) * 2, dtype=float)

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -407,6 +407,7 @@ class Reorientation:
                 shape,
                 target_shape,
                 tol,
+                voxel_center=False,
             )
 
         source_ornt = io_orientation(source_affine)

--- a/HypVINN/utils/img_processing_utils.py
+++ b/HypVINN/utils/img_processing_utils.py
@@ -78,7 +78,12 @@ def save_segmentation(
     pred_arr = hypo_map_subseg_2_fsseg(pred_arr)
     orig_img = cast(nibabelImage, nib.load(orig_path))
 
-    reorient = Reorientation.from_target_affine(ras_affine, orig_img.affine, labels_cc.shape)
+    reorient = Reorientation.from_target_affine(
+        ras_affine,
+        orig_img.affine,
+        labels_cc.shape,
+        voxel_center=False,
+    )
     LOGGER.info(f"Orig data orientation : {aff2axcodes(orig_img.affine)}")
 
     for data, name in ((pred_arr, "segmentation"), (labels_cc, "mask")):
@@ -152,7 +157,12 @@ def save_logits(
     LOGGER.info(f"Orig data orientation: {aff2axcodes(orig_img.affine)}")
     header: nibabelHeader = Nifti1Image.header_class.from_header(orig_img.header)
     header.set_data_type(np.float32)
-    reorient = Reorientation.from_target_affine(ras_affine, orig_img.affine, logits.shape)
+    reorient = Reorientation.from_target_affine(
+        ras_affine,
+        orig_img.affine,
+        logits.shape,
+        voxel_center=False,
+    )
     nifti_img = nib.Nifti1Image(
         reorient(logits.astype(np.float32)),
         affine=orig_img.affine,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Modules (all run by default):
    - requires a T1w image ([notes on input images](#requirements-to-input-images)), supports high-res (up to 0.7mm, experimental beyond that).
    - performs bias-field correction and calculates volume statistics corrected for partial volume effects (skipped if `--no_biasfield` is passed).
 2. `cc`: [CorpusCallosum](CorpusCallosum/README.md) for corpus callosum segmentation and shape analysis (deactivate with `--no_cc`)
-   - requires `asegdkt_segfile` (segmentation) and conformed mri (orig.mgz), outputs CC segmentation, thickness, and shape metrics.
+   - requires `asegdkt_segfile` (segmentation) and `orig.mgz` from the segmentation stage. In the standard pipeline this image is in FastSurfer conform space; with `--seg_only --keepgeom` it stays in native geometry, with only intensity scaling and dtype conversion as needed. Outputs include CC segmentation, thickness, and shape metrics.
    - standardizes brain orientation based on AC/PC landmarks (orient_volume.lta).
 3. `cereb:` [CerebNet](CerebNet/README.md) for cerebellum sub-segmentation (deactivate with `--no_cereb`)
    - requires `asegdkt_segfile`, outputs cerebellar sub-segmentation with detailed WM/GM delineation.

--- a/doc/scripts/RUN_FASTSURFER.md
+++ b/doc/scripts/RUN_FASTSURFER.md
@@ -22,7 +22,7 @@ Required arguments
 ------------------
 * `--sd`: Output directory \$SUBJECTS_DIR (equivalent to FreeSurfer setup --> $SUBJECTS_DIR/sid/mri; $SUBJECTS_DIR/sid/surf ... will be created).
 * `--sid`: Subject ID for directory inside \$SUBJECTS_DIR to be created ($SUBJECTS_DIR/sid/...)
-* `--t1`: T1 full head input (does not need to be bias corrected, global path). The network was trained with conformed images (UCHAR, cubic volume, 0.7mm - 1mm voxels and standard slice orientation; typically 256x256x256 at 1mm and larger cubes for higher-resolution isotropic inputs). These specifications are checked in the run_prediction.py script and the image is automatically conformed if it does not comply. Note, outputs will be in the conformed space used by FastSurfer, which is similar to FreeSurfer conform space but not guaranteed to match `mri_convert -c` exactly.
+* `--t1`: T1 full head input (does not need to be bias corrected, global path). The network was trained with conformed images (UCHAR, cubic volume, 0.7mm - 1mm voxels and standard slice orientation; typically 256x256x256 at 1mm and larger cubes for higher-resolution isotropic inputs). These specifications are checked in the run_prediction.py script and the image is automatically conformed if it does not comply. By default, outputs are written in the FastSurfer conform space used for segmentation, which closely follows FreeSurfer conforming in `mri_convert -c`. The `--keepgeom` path is the exception: it uses an internal soft-LIA reordering for the 2D networks and maps results back to native geometry before writing outputs.
 
 ### Conditionally required
 Required for Docker when running surface module:
@@ -42,7 +42,7 @@ Optional arguments
 * `--lesion_mask <path to file>`: Path to a binary lesion mask in the same space as the T1 input. If provided, FastSurfer will wrap the segmentation and surface pipelines with lesion inpainting using LIT. This experimental feature is useful for images with tumors or other large lesions; review LIT-modified outputs before downstream use.
 * `--cereb_segfile`: Name of the cerebellum segmentation file. If not provided, this intermediate DL-based segmentation will not be stored, but only the merged segmentation will be stored (see --main_segfile <filename>). Requires an ABSOLUTE Path! Default location: \$SUBJECTS_DIR/\$sid/mri/cerebellum.CerebNet.nii.gz
 * `--no_biasfield`: Deactivate the biasfield correction and calculation of partial volume-corrected statistics in the segmentation modules. HypVINN does run but expects that biasfields are corrected externally.
-* `--native_image` or `--keepgeom`: **Only supported for `--seg_only`**, segment in native image space (keep orientation, image size and voxel size of the input image), this also includes experimental support for anisotropic images (no extreme anisotropy).
+* `--native_image` or `--keepgeom`: **Only supported for `--seg_only`**. Preserve the native image geometry (orientation, image size, and voxel size) for saved outputs. Internally, FastSurfer may temporarily reorder/flip the image to a soft-LIA layout so the 2D networks still see the expected plane ordering, but written outputs stay in native geometry; only intensity scaling and dtype conversion are applied as needed. This also includes experimental support for anisotropic images (no extreme anisotropy).
 
 ### Surface pipeline arguments
 * `--surf_only`: Only run the surface pipeline. The segmentation created by FastSurferVINN must already exist in this case.

--- a/test/image/test_orientation_transform.py
+++ b/test/image/test_orientation_transform.py
@@ -54,7 +54,7 @@ def test_translation_fix_center(
         in_shape: Shape3d,
         out_shape: Shape3d,
 ):
-    """Tests whether the translation fix for a vox2vox transformation matrix is correct"""
+    """Low-level center fixing keeps the historical voxel-center convention used by ornt2vox2vox."""
     _in_shape = np.asarray(in_shape)
     _out_shape = np.asarray(out_shape)
 
@@ -67,7 +67,12 @@ def test_translation_fix_center(
     # expected vox center
     expected = (_out_shape - 1) / 2
     # Note, translation_to_fix_center wants the shape in input order space!
-    vox2vox_ras2strict[:3, 3] = _translation_to_fix_center(vox2vox_ras2strict, _in_shape, _out_shape[ornt[:, 0]])
+    vox2vox_ras2strict[:3, 3] = _translation_to_fix_center(
+        vox2vox_ras2strict,
+        _in_shape,
+        _out_shape[ornt[:, 0]],
+        voxel_center=True,
+    )
     # actual center
     actual = (np.linalg.inv(vox2vox_ras2strict) @ np.append((_in_shape - 1) / 2, 1))[:3]
     assert actual == approx(expected), "Inconsistent image centers to fix center from ornt2vox2vox!"
@@ -252,6 +257,31 @@ def test_affine_from_target_orientation_soft_keepgeom_roundtrip():
     back = apply_vox2vox(lia, obj.inverse.vox2vox, out_shape=obj.inverse.target_shape, order=0)
 
     assert back == approx(data), "Soft keepgeom reorientation should roundtrip exactly for label data."
+
+
+def test_affine_from_target_orientation_strict_uses_freesurfer_center():
+    """Strict conform should keep FreeSurfer's shape/2 center convention for resampling."""
+    shape = (256, 256, 196)
+    target_shape = (256, 256, 256)
+    affine = np.array(
+        [
+            [0.0, 0.0, 1.2, -112.942001],
+            [-1.0547, 0.0, 0.0, 169.707001],
+            [0.0, -1.0547, 0.0, 86.2425],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
+    obj = Reorientation.from_target_orientation(affine, "LIA", shape, np.ones((3,)), target_shape)
+    rotation = obj.target_affine[:3, :3]
+
+    fs_expected = (affine @ np.append(np.asarray(shape) / 2, 1))[:3] - rotation @ (np.asarray(obj.target_shape) / 2)
+    voxel_center_expected = (
+        affine @ np.append((np.asarray(shape) - 1) / 2, 1)
+    )[:3] - rotation @ ((np.asarray(obj.target_shape) - 1) / 2)
+
+    assert obj.target_affine[:3, 3] == approx(fs_expected)
+    assert obj.target_affine[:3, 3] != approx(voxel_center_expected)
 
 
 def test_Reorientation_target_shape(


### PR DESCRIPTION
The new voxel center convention (shape-1)/2 is problematic when performing strict conform. It leads to different image interpolation (not only shifts) compared to earlier FastSurfer versions and to FreeSurfer. As our ground truth for validation lies in the FreeSurfer space, DICE scores cannot be computed directly any longer. 

We therefore switch back to FreeSurfer conventions for the center as shape/2 in the strict conform path. 
Keepgeom/native_image still uses the (shape-1)/2 voxel center, to be compatible with nibabel and to allow round trip conversions without any shifts/cropping. 

The third potential situation (soft-LIA but actual re-slicing due to e.g. voxel size changes) has not been tested, and could still be buggy. It is also not used in the FreeSurfer processing pipeline. 