### PR TITLE
Macbuild: upx not needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'fastsurfer'
-version = '2.5.1'
+version = '2.6.0-dev'
 description = 'A fast and accurate deep-learning based neuroimaging pipeline'
 readme = 'README.md'
 license = {file = 'LICENSE'}

--- a/tools/build/install_fs_pruned.sh
+++ b/tools/build/install_fs_pruned.sh
@@ -427,12 +427,20 @@ do
   cp -r "$fss/$file" "$fsd/$file"
 done
 
-# pack if desired with upx (do this before adding all the links
+# pack if desired with upx (do this before adding all the links)
 if [[ "$upx" == "true" ]] ; then
-  echo "finding executables in $fsd/bin/..."
-  exe=($(find "$fsd/bin" -exec file {} \; | grep ELF | cut -d: -f1))
-  echo "packing $fsd/bin/ executables (this can take a while) ..."
-  upx -9 "${exe[@]}"
+  if [[ -z "$(command -v upx)" ]] ; then
+    echo "UPX requested, but the 'upx' command was not found on PATH; skipping executable packing."
+  else
+    echo "finding executables in $fsd/bin/..."
+    exe=($(find "$fsd/bin" -exec file {} \; | grep ELF | cut -d: -f1))
+    if [[ "${#exe[@]}" -eq 0 ]] ; then
+      echo "No UPX-packable executables found in $fsd/bin, skipping."
+    else
+      echo "packing $fsd/bin/ executables (this can take a while) ..."
+      upx -9 "${exe[@]}"
+    fi
+  fi
 fi
 
 # Modify fsbindings Python package to allow calling scripts like asegstats2table directly:

--- a/tools/macos_build/build_release_package.sh
+++ b/tools/macos_build/build_release_package.sh
@@ -51,7 +51,7 @@ rsync -av --progress "$FASTSURFER_HOME/" "$FASTSURFER_TO_PACKAGE" \
       --exclude .git
 
 # install freesurfer into temp folder
-"$tools_dir/build/install_fs_pruned.sh" "$STAGED_DIR" --upx --url "$URL_TO_FREESURFER"
+"$tools_dir/build/install_fs_pruned.sh" "$STAGED_DIR" --url "$URL_TO_FREESURFER"
 
 if [[ ! -d "$STAGED_DIR/freesurfer" ]]
 then


### PR DESCRIPTION
Minor changes:
- Mac build was passing --upx but upx is not installed leading to an error message
- It also should not use upx, so --upx is removed when calling install_fs_prunned.sh
- Added guard around upx block to first check if upx binary exists to avoid error 
- Also bumped pyproject.toml version to next minor dev (2.6.0-dev)