### PR TITLE
Fix wrong conform arguments for T2 and numpy2 related change

### DIFF
--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -93,7 +93,7 @@ def sitk_from_mgh(img: nib.MGHImage) -> sitk.Image:
     data = np.swapaxes(np.asanyarray(img.dataobj), 0, 2)
     # sitk can only create image with system native endianness
     if not data.dtype.isnative:
-        data = data.byteswap().newbyteorder()
+        data = data.byteswap().view(data.dtype.newbyteorder())
     # create image from array
     img_sitk = sitk.GetImageFromArray(data)
     # Get direction from MDC, need to change sign of dim 0 and 1

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -621,7 +621,6 @@ then
 fi
 
 check_create_subjects_dir_properties "$sd"
-export SUBJECTS_DIR="$sd"
 
 if [[ -z "$subject" ]]
 then

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1243,7 +1243,7 @@ then
       # do not terminate if this fails
 
       echo "INFO: Robust scaling (partial conforming) of T2 image..."
-      cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_strict_lia --no_iso_vox --no_img_size
+      cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --orientation native --vox_size any --img_size any
            -i "$t2" -o "$conformed_name_t2")
       echo_quoted "${cmd[@]}"
       "${wrap[@]}" "${cmd[@]}" 2>&1
@@ -1269,7 +1269,7 @@ then
       fi
     else
       # no biasfield, but a t2 is passed; presumably, this is biasfield corrected
-      cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --no_strict_lia --no_iso_vox --no_img_size
+      cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --orientation native --vox_size any --img_size any
            -i "$t2" -o "$norm_name_t2")
       {
         echo "INFO: Robustly rescaling $t2 to uchar ($norm_name_t2), which is"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -621,6 +621,7 @@ then
 fi
 
 check_create_subjects_dir_properties "$sd"
+export SUBJECTS_DIR="$sd"
 
 if [[ -z "$subject" ]]
 then


### PR DESCRIPTION
This should fix two bugs in stable where FastSurfer fails when given a T2. Conform.py seems has changed its arguments, but they were not adjusted for the T2 processing. 

Creating this as a draft to be edited by the module maintainers. I only ran testing for one case.