### PR TITLE
Accept voxel sizes within float noise of 1mm (e.g. 1.0000001)

### DIFF
--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -1581,13 +1581,10 @@ def conformed_vox_img_size(
             _conformed_vox_size = MAX_VOX_SIZE
         target_vox_size = np.full((3,), _conformed_vox_size)
     # this is similar to mri_convert --conform_size <float>
-    elif isinstance(vox_size, float | int):
-        # round to vox_eps precision so header float noise (e.g. 1.0000001) counts as the nominal
-        # voxel size (1.0) instead of being rejected as > 1mm
-        rounded_vox_size = round(float(vox_size), decimals)
-        if not 0.0 < rounded_vox_size <= MAX_VOX_SIZE:
-            raise ValueError(f"Invalid value for vox_size passed: {vox_size}.")
-        target_vox_size = np.full((3,), rounded_vox_size)
+    # round to vox_eps precision so header float noise (e.g. 1.0000001) counts as the nominal voxel
+    # size (1.0) instead of being rejected as > 1mm
+    elif isinstance(vox_size, float | int) and 0.0 < (_vox := round(float(vox_size), decimals)) <= MAX_VOX_SIZE:
+        target_vox_size = np.full((3,), _vox)
     elif vox_size is None:
         target_vox_size = None
     else:

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -1581,8 +1581,13 @@ def conformed_vox_img_size(
             _conformed_vox_size = MAX_VOX_SIZE
         target_vox_size = np.full((3,), _conformed_vox_size)
     # this is similar to mri_convert --conform_size <float>
-    elif isinstance(vox_size, float | int) and 0.0 < vox_size <= MAX_VOX_SIZE:
-        target_vox_size = np.full((3,), vox_size)
+    elif isinstance(vox_size, float | int):
+        # round to vox_eps precision so header float noise (e.g. 1.0000001) counts as the nominal
+        # voxel size (1.0) instead of being rejected as > 1mm
+        rounded_vox_size = round(float(vox_size), decimals)
+        if not 0.0 < rounded_vox_size <= MAX_VOX_SIZE:
+            raise ValueError(f"Invalid value for vox_size passed: {vox_size}.")
+        target_vox_size = np.full((3,), rounded_vox_size)
     elif vox_size is None:
         target_vox_size = None
     else:

--- a/FastSurferCNN/utils/arg_types.py
+++ b/FastSurferCNN/utils/arg_types.py
@@ -164,7 +164,9 @@ def float_gt_zero_and_le_one(a: str | float) -> float | None:
     """
     if a is None or isinstance(a, str) and a.lower() in ["none", "infinity"]:
         return None
-    a_float = float(a)
+    # round to 1e-4 precision (the default vox_eps used in conform) so that float noise in a voxel
+    # size read from a header, such as 1.0000001 from a noisy 1mm image, is accepted as 1.0
+    a_float = round(float(a), 4)
     if 0.0 < a_float <= 1.0:
         return a_float
     else:

--- a/FastSurferCNN/utils/arg_types.py
+++ b/FastSurferCNN/utils/arg_types.py
@@ -95,19 +95,25 @@ def vox_size(a: str | float | None) -> VoxSizeOption:
     str or float or None
         If 'auto' or 'min' is provided, it returns a string('auto' or 'min').
         If a valid voxel size (between 0 and 1) is provided, it returns a float.
-        If 'any' or 'keep', it returns None.
+        If 'any', 'keep', 'none' or 'infinity', it returns None.
 
     Raises
     ------
     ValueError
         If the argument is not "min", "auto" or convertible to a float between 0 and 1.
     """
-    if a is None or isinstance(a, str) and a.lower() in ["any", "keep"]:
+    if a is None or isinstance(a, str) and a.lower() in ["any", "keep", "none", "infinity"]:
         return None
     if isinstance(a, str) and a.lower() in ["auto", "min"]:
         return "min"
     try:
-        return float_gt_zero_and_le_one(a)
+        a_float = float(a)
+        # voxel sizes are typically read from a float32 header, so a nominal 1mm image can report
+        # 1.0000001 and would be rejected by the 1mm cap; snap noise below vox_eps (the tolerance
+        # conform compares voxel sizes with) to exactly 1.0, while 1.1 is still rejected
+        if abs(a_float - 1.0) <= 1e-4:
+            a_float = 1.0
+        return float_gt_zero_and_le_one(a_float)
     except ValueError as e:
         raise ValueError(e.args[0] + " Additionally, vox_size may be 'min'.") from None
 
@@ -164,9 +170,7 @@ def float_gt_zero_and_le_one(a: str | float) -> float | None:
     """
     if a is None or isinstance(a, str) and a.lower() in ["none", "infinity"]:
         return None
-    # round to 1e-4 precision (the default vox_eps used in conform) so that float noise in a voxel
-    # size read from a header, such as 1.0000001 from a noisy 1mm image, is accepted as 1.0
-    a_float = round(float(a), 4)
+    a_float = float(a)
     if 0.0 < a_float <= 1.0:
         return a_float
     else:

--- a/test/image/test_vox_size_noise.py
+++ b/test/image/test_vox_size_noise.py
@@ -1,0 +1,72 @@
+"""Regression tests for voxel sizes that carry float32 header noise, e.g. 1.0000001 instead of 1.
+
+recon-surf.sh reads the voxel size of the (already conformed) t1 from its header and passes it on
+as an explicit ``--vox_size <float>``, so a nominal 1mm image whose header stores 1.0000001 used to
+abort the pipeline at the ``0 < vox_size <= 1`` cap. These tests cover the three layers this passes
+through: the argparse type, the conform.py CLI parser, and conformed_vox_img_size.
+"""
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from FastSurferCNN.data_loader.conform import conformed_vox_img_size, make_parser
+from FastSurferCNN.utils.arg_types import float_gt_zero_and_le_one, vox_size
+
+
+@pytest.fixture
+def noisy_1mm_image() -> nib.MGHImage:
+    """A 256^3 LIA image whose header reports a 1mm voxel size only up to float32 noise."""
+    affine = np.array([[-1.0000001, 0, 0, 0], [0, 0, 1.0, 0], [0, -0.99999994, 0, 0], [0, 0, 0, 1.0]])
+    img = nib.MGHImage(np.zeros((256,) * 3, dtype=np.uint8), affine)
+    img.header.set_zooms((np.float32(1.0000001), np.float32(0.99999994), np.float32(1.0)))
+    return img
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # 1mm up to float noise, as read from a header -- snapped to exactly 1.0
+        ("1.0000001", 1.0), ("0.99999994", 1.0), (1.0000001, 1.0),
+        # ... but only around 1mm: hires voxel sizes are passed through unmodified
+        ("0.68359375", 0.68359375), ("0.8000005", 0.8000005),
+        # the keywords, which are resolved before the numeric conversion
+        ("min", "min"), ("any", None), ("none", None), ("infinity", None), (None, None),
+    ],
+)
+def test_vox_size(value, expected):
+    """vox_size() tolerates float noise around 1mm without affecting any other input."""
+    assert vox_size(value) == expected
+
+
+@pytest.mark.parametrize("value", ["1.001", "1.1"])
+def test_vox_size_rejects_sizes_above_1mm(value):
+    """Voxel sizes that are genuinely coarser than 1mm are still rejected."""
+    with pytest.raises(ValueError):
+        vox_size(value)
+
+
+def test_float_gt_zero_and_le_one_stays_strict():
+    """The shared validator (also used for --robust and --conform_to_1mm_threshold) is unchanged."""
+    with pytest.raises(ValueError):
+        float_gt_zero_and_le_one("1.0000001")
+
+
+def test_parser_accepts_noisy_1mm_vox_size():
+    """The failing call from recon-surf.sh: conform.py --check_only --vox_size 1.0000001."""
+    args = make_parser().parse_args(["-i", "orig.mgz", "--check_only", "--vox_size", "1.0000001", "--dtype", "any"])
+    assert args.vox_size == 1.0
+
+
+@pytest.mark.parametrize("value", ["min", 1.0000001])
+def test_conformed_vox_img_size_noisy_1mm(noisy_1mm_image, value):
+    """A noisy 1mm image is already conformed, for both --vox_size min and an explicit size."""
+    target_vox_size, target_img_size = conformed_vox_img_size(noisy_1mm_image, value, "auto")
+    assert target_vox_size == pytest.approx(np.ones(3))
+    assert np.array_equal(target_img_size, np.full(3, 256))
+
+
+def test_conformed_vox_img_size_rejects_sizes_above_1mm(noisy_1mm_image):
+    """Voxel sizes coarser than 1mm by more than float noise are still rejected."""
+    with pytest.raises(ValueError):
+        conformed_vox_img_size(noisy_1mm_image, 1.1, "auto")


### PR DESCRIPTION
recon-surf forwards the voxel size read from a (possibly noisy) header as an
explicit --vox_size, so a 1mm image with 1.0000001 in the header was rejected by
the <= 1.0 cap in both the CLI arg validator and conformed_vox_img_size. Round
numeric voxel sizes to vox_eps precision before the cap so 1.0000001 is treated
as 1.0, while genuinely larger sizes (e.g. 1.1) are still rejected.

Addresses comment in #850 