### PR TITLE
Unify the python version on a single pyproject key instead of scattered literals

### DIFF
--- a/.github/workflows/QUICKTEST.md
+++ b/.github/workflows/QUICKTEST.md
@@ -14,7 +14,7 @@ This job checks out the repository using the `actions/checkout@v2` action.
 ### Prepare Job
 This job sets up the necessary environments for the workflow. It depends on the successful completion of the `checkout` job. The environments set up in this job include:
 
-- Python 3.10, using the `astral-sh/setup-uv@v5` action.
+- Python at the shipped default version (`tool.python.version` in `pyproject.toml`), using the `astral-sh/setup-uv` action.
 - Go, using the `actions/setup-go@v5` action with version `1.13.1`.
 - Singularity, using the `eWaterCycle/setup-singularity@v7` action with version `3.8.3`.
 

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -139,11 +139,15 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.parse.outputs.DOCKER_IMAGE }}
-      - name: Setup uv and Python 3.11
+      - name: Setup uv and Python (shipped default)
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: '3.11'
-          # python 3.11 is needed to read pyproject.toml (tomllib)
+          # keep in sync with tool.python.version in pyproject.toml. It cannot be read from there:
+          # this step is what provides the interpreter that reads pyproject.toml in the first place.
+          # This python only reads toml and drives build.py; FastSurfer itself runs inside the
+          # container, so this value does not affect any test result. Any version >= 3.11 satisfies
+          # the stdlib tomllib requirement below.
+          python-version: '3.12'
       - name: Get the FreeSurfer version
         # we want to build the docker image, get what we want to do for freesurfer (read fslink from install_pruned.sh,
         if: steps.parse.outputs.CONTINUE == 'true' && (steps.parse.outputs.DOCKER_IMAGE == 'build-cached' || startsWith(steps.parse.outputs.DOCKER_IMAGE, 'pr/'))

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -30,19 +30,24 @@ permissions:
 
 jobs:
   image-test:
-    name: 'Run FastSurfer unit tests from test/image'
+    name: 'Run FastSurfer unit tests from test/${{ matrix.tests }}'
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       matrix:
-        tests: ["image"]
+        # image: image-processing unit tests. config: consistency of declared versions across
+        # pyproject.toml, the Dockerfile and the workflows (see test/config/test_python_version.py)
+        tests: ["image", "config"]
         pytest-flags: [""]
 
     steps:
       - uses: actions/checkout@v7
-      - name: Setup Python 3.10
+      - name: Setup Python 3.10 (oldest supported)
         uses: actions/setup-python@v7
         with:
+          # deliberately NOT tool.python.version (the shipped default): this job pins the lower
+          # bound from project.requires-python so that the supported-version claim stays tested.
+          # Bump this only when requires-python itself is raised.
           python-version: '3.10'
           architecture: 'x64'
           cache: 'pip' # caching pip dependencies

--- a/Tutorial/README.md
+++ b/Tutorial/README.md
@@ -54,7 +54,7 @@ need for running the application. You do not need to install anything else. See 
 If you decide against using docker, you need either python + pip or anaconda (conda) to install FastSurfer.
 
 #### 1. Python + pip
-Python 3.10 is generally recommended to run FastSurfer. In addition you will need the package manager pip to install the
+Python 3.12 is generally recommended to run FastSurfer (3.10 is the minimum supported version). In addition you will need the package manager pip to install the
 python dependencies used for FastSurfer (see requirements.txt in the main directory for a list). On Linux, pip is not 
 installed by default. You can install it via 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,22 +124,29 @@ source = 'https://github.com/Deep-MI/FastSurfer'
 tracker = 'https://github.com/Deep-MI/FastSurfer/issues'
 
 [tool.python]
-# The single python version FastSurfer is built and shipped with: the docker image, the CI jobs
-# and the macOS installer all derive their interpreter from this key.
+# The single exact python version FastSurfer is built and shipped with.
 #
-# This is deliberately NOT project.requires-python. The two answer different questions:
-#   requires-python is the support floor, a *range*, and is what pip enforces for anyone doing
-#     `pip install fastsurfer`. The unittest CI job pins itself to that floor on purpose, so the
-#     oldest-supported claim stays tested.
-#   tool.python.version is the one *exact* version we build against. Wheels are cp3XX-tagged, so
-#     anything shipping a pre-resolved environment needs an exact version, not a lower bound.
+# Who uses it today:
+#   - tools/Docker/build.py reads this key and passes it to the build as PYTHON_VERSION. The
+#     docker image is currently the only consumer that truly derives its interpreter from here.
+#   - Two places keep a hardcoded copy because neither can read this file: the ARG PYTHON_VERSION
+#     default in tools/Docker/Dockerfile (a Dockerfile cannot parse toml) and the python-version
+#     in .github/workflows/quicktest.yaml (that step provides the interpreter which then reads
+#     this file). test/config/test_python_version.py asserts both against this key.
+#   - NOT the macOS installer: tools/macos_build/build_release_package.sh still derives its
+#     interpreter from project.requires-python, i.e. from the floor. Repointing it at this key is
+#     pending in the macOS packaging work.
+#   - NOT .github/workflows/unittest.yaml, which pins the requires-python floor on purpose.
 #
-# Raising this version also requires:
-#   - re-exporting requirements.txt for the new interpreter (tools/export_pip-r.sh)
-#   - the ARG PYTHON_VERSION default in tools/Docker/Dockerfile (a Dockerfile cannot read this
-#     file) and the python-version in .github/workflows/quicktest.yaml (that step provides the
-#     interpreter that reads this file). Both are asserted against this key by
-#     test/config/test_python_version.py, so CI will tell you if you miss one.
+# This key is deliberately separate from project.requires-python, which answers a different
+# question: requires-python is the support *floor*, a range, and is what pip enforces for anyone
+# doing `pip install fastsurfer`. This key is the one *exact* version we build against, which a
+# range cannot express -- wheels are cp3XX-tagged, so anything shipping a pre-resolved
+# environment needs an exact version.
+#
+# Raising this version also requires updating the following, none of which can read this key:
+#   - requirements.txt, re-exported for the new interpreter (tools/export_pip-r.sh)
+#   - the two hardcoded copies listed above (CI will fail if you miss one)
 #   - the version quoted in user-facing docs: doc/overview/INSTALL.md, README.md,
 #     Tutorial/README.md
 version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,27 @@ documentation = 'https://fastsurfer.org'
 source = 'https://github.com/Deep-MI/FastSurfer'
 tracker = 'https://github.com/Deep-MI/FastSurfer/issues'
 
+[tool.python]
+# The single python version FastSurfer is built and shipped with: the docker image, the CI jobs
+# and the macOS installer all derive their interpreter from this key.
+#
+# This is deliberately NOT project.requires-python. The two answer different questions:
+#   requires-python is the support floor, a *range*, and is what pip enforces for anyone doing
+#     `pip install fastsurfer`. The unittest CI job pins itself to that floor on purpose, so the
+#     oldest-supported claim stays tested.
+#   tool.python.version is the one *exact* version we build against. Wheels are cp3XX-tagged, so
+#     anything shipping a pre-resolved environment needs an exact version, not a lower bound.
+#
+# Raising this version also requires:
+#   - re-exporting requirements.txt for the new interpreter (tools/export_pip-r.sh)
+#   - the ARG PYTHON_VERSION default in tools/Docker/Dockerfile (a Dockerfile cannot read this
+#     file) and the python-version in .github/workflows/quicktest.yaml (that step provides the
+#     interpreter that reads this file). Both are asserted against this key by
+#     test/config/test_python_version.py, so CI will tell you if you miss one.
+#   - the version quoted in user-facing docs: doc/overview/INSTALL.md, README.md,
+#     Tutorial/README.md
+version = "3.12"
+
 [tool.freesurfer]
 version = "7.4.1"
 # The following URLs use the {version} placeholder, which should be replaced

--- a/test/config/test_python_version.py
+++ b/test/config/test_python_version.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Guard the single-source-of-truth for the shipped python version.
+
+``tool.python.version`` in pyproject.toml is the one place the interpreter FastSurfer is built
+with is declared. Two consumers cannot read it and therefore hold hardcoded copies:
+
+* the ``ARG PYTHON_VERSION`` default in tools/Docker/Dockerfile -- a Dockerfile cannot parse a
+  toml file at build time,
+* the ``python-version`` in .github/workflows/quicktest.yaml -- that step *provides* the
+  interpreter which later reads pyproject.toml.
+
+Without these tests, bumping the key leaves those copies behind silently. The failure mode is a
+confusing build rather than a red test, which is exactly what this module prevents.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+FASTSURFER_HOME = Path(__file__).parent.parent.parent
+PYPROJECT = FASTSURFER_HOME / "pyproject.toml"
+DOCKERFILE = FASTSURFER_HOME / "tools" / "Docker" / "Dockerfile"
+BUILD_PY = FASTSURFER_HOME / "tools" / "Docker" / "build.py"
+QUICKTEST_YAML = FASTSURFER_HOME / ".github" / "workflows" / "quicktest.yaml"
+UNITTEST_YAML = FASTSURFER_HOME / ".github" / "workflows" / "unittest.yaml"
+
+
+def _load_pyproject() -> dict:
+    """
+    Parse pyproject.toml, tolerating the absence of a toml parser.
+
+    tomllib is stdlib only from python 3.11, and the unittest CI job deliberately runs on the
+    oldest supported version, so neither tomllib nor tomli is guaranteed. Fall back to a narrow
+    regex over just the two keys this module needs rather than adding a test-only dependency.
+
+    Returns
+    -------
+    dict
+        A mapping with the "python_version" and "requires_python" keys.
+    """
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        try:
+            import tomli as tomllib
+        except ImportError:
+            tomllib = None
+
+    if tomllib is not None:
+        with open(PYPROJECT, "rb") as fp:
+            parsed = tomllib.load(fp)
+        return {
+            "python_version": parsed["tool"]["python"]["version"],
+            "requires_python": parsed["project"]["requires-python"],
+        }
+
+    text = PYPROJECT.read_text()
+    # scope to the [tool.python] section so an unrelated `version =` cannot match
+    section = re.search(r"^\[tool\.python]$(.*?)^\[", text, re.M | re.S)
+    assert section is not None, f"no [tool.python] section in {PYPROJECT}"
+    version = re.search(r"^version\s*=\s*[\"']([^\"']+)[\"']", section.group(1), re.M)
+    assert version is not None, f"no version key in the [tool.python] section of {PYPROJECT}"
+    requires = re.search(r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M)
+    assert requires is not None, f"no requires-python in {PYPROJECT}"
+    return {"python_version": version.group(1), "requires_python": requires.group(1)}
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    """
+    Provide the declared python versions.
+
+    Returns
+    -------
+    dict
+        A mapping with the "python_version" and "requires_python" keys.
+    """
+    return _load_pyproject()
+
+
+def test_shipped_version_is_a_bare_minor_version(config: dict) -> None:
+    """Check the key is an exact "major.minor", since consumers interpolate it verbatim."""
+    version = config["python_version"]
+    assert re.fullmatch(r"\d+\.\d+", version), (
+        f"tool.python.version is {version!r}, but it is interpolated straight into "
+        f"'python<version>' and 'brew install python@<version>', so it must be a bare "
+        f"major.minor with no specifier or patch level"
+    )
+
+
+def test_shipped_version_satisfies_the_support_floor(config: dict) -> None:
+    """Check the shipped version is not older than the declared support floor."""
+    floor_spec = config["requires_python"]
+    floor = re.sub(r"^[><=~!]+", "", floor_spec.split(",")[0]).strip()
+    shipped = tuple(int(part) for part in config["python_version"].split("."))
+    assert shipped >= tuple(int(part) for part in floor.split(".")), (
+        f"tool.python.version ({config['python_version']}) is older than the "
+        f"project.requires-python floor ({floor_spec})"
+    )
+
+
+def test_dockerfile_arg_default_matches(config: dict) -> None:
+    """Check the Dockerfile ARG fallback agrees with the key it cannot read."""
+    match = re.search(r"^ARG PYTHON_VERSION=\"([^\"]+)\"", DOCKERFILE.read_text(), re.M)
+    assert match is not None, f"no 'ARG PYTHON_VERSION=\"...\"' found in {DOCKERFILE}"
+    assert match.group(1) == config["python_version"], (
+        f"{DOCKERFILE.name} pins python {match.group(1)} but tool.python.version is "
+        f"{config['python_version']}; the ARG default is the fallback for a direct `docker build` "
+        f"and has to be updated alongside the key"
+    )
+
+
+def test_build_py_forwards_the_key() -> None:
+    """Check build.py passes the key through instead of hardcoding a version."""
+    text = BUILD_PY.read_text()
+    assert "PYTHON_VERSION={pyproject_python['version']}" in text, (
+        f"{BUILD_PY.name} no longer forwards PYTHON_VERSION from pyproject.toml; the docker image "
+        f"would silently fall back to the Dockerfile ARG default"
+    )
+
+
+def test_quicktest_workflow_matches(config: dict) -> None:
+    """Check the quicktest runner interpreter tracks the shipped default."""
+    versions = re.findall(r"^\s*python-version:\s*['\"]([^'\"]+)['\"]", QUICKTEST_YAML.read_text(), re.M)
+    assert versions, f"no python-version found in {QUICKTEST_YAML}"
+    for version in versions:
+        assert version == config["python_version"], (
+            f"{QUICKTEST_YAML.name} pins python {version} but tool.python.version is "
+            f"{config['python_version']}; this value cannot be read from pyproject.toml because "
+            f"it provides the interpreter that reads it, so it must be bumped by hand"
+        )
+
+
+def test_unittest_workflow_pins_the_support_floor(config: dict) -> None:
+    """Check the unittest job still tests the oldest supported version, not the shipped one."""
+    floor_spec = config["requires_python"]
+    floor = re.sub(r"^[><=~!]+", "", floor_spec.split(",")[0]).strip()
+    versions = re.findall(r"^\s*python-version:\s*['\"]([^'\"]+)['\"]", UNITTEST_YAML.read_text(), re.M)
+    assert versions, f"no python-version found in {UNITTEST_YAML}"
+    for version in versions:
+        assert version == floor, (
+            f"{UNITTEST_YAML.name} pins python {version}, but it should pin the "
+            f"project.requires-python floor ({floor}). This job is the only thing that tests the "
+            f"oldest-supported claim; pointing it at the shipped default would drop that coverage"
+        )

--- a/test/config/test_python_version.py
+++ b/test/config/test_python_version.py
@@ -15,8 +15,9 @@
 """
 Guard the single-source-of-truth for the shipped python version.
 
-``tool.python.version`` in pyproject.toml is the one place the interpreter FastSurfer is built
-with is declared. Two consumers cannot read it and therefore hold hardcoded copies:
+``tool.python.version`` in pyproject.toml declares the exact interpreter FastSurfer is built
+with. tools/Docker/build.py reads it directly, but two consumers cannot and therefore hold
+hardcoded copies:
 
 * the ``ARG PYTHON_VERSION`` default in tools/Docker/Dockerfile -- a Dockerfile cannot parse a
   toml file at build time,

--- a/test/config/test_python_version.py
+++ b/test/config/test_python_version.py
@@ -82,6 +82,59 @@ def _load_pyproject() -> dict:
     return {"python_version": version.group(1), "requires_python": requires.group(1)}
 
 
+def _as_tuple(version: str) -> tuple[int, ...]:
+    """
+    Turn a dotted version string into a comparable tuple.
+
+    Parameters
+    ----------
+    version : str
+        A dotted version, e.g. "3.10".
+
+    Returns
+    -------
+    tuple of int
+        The numeric components, e.g. (3, 10).
+    """
+    return tuple(int(part) for part in version.split("."))
+
+
+def _support_floor(requires_python: str) -> str:
+    """
+    Extract the lower bound from a project.requires-python specifier set.
+
+    requires-python is a PEP 440 specifier set whose comma-separated clauses are *unordered*, so
+    the lower bound cannot be assumed to come first: ">=3.10,<4" and "<4,>=3.10" are equivalent.
+    Only clauses that actually impose a lower bound are considered, and if several do, the
+    tightest one is the effective floor.
+
+    Uses packaging rather than a regex because packaging is a declared runtime dependency of this
+    project (see project.dependencies), so it is present wherever the test suite runs. That is not
+    true of tomli, which is why _load_pyproject above has to hand-roll a fallback.
+
+    Parameters
+    ----------
+    requires_python : str
+        The raw project.requires-python value, e.g. ">=3.10" or "<4,>=3.10".
+
+    Returns
+    -------
+    str
+        The version of the tightest lower-bound clause, e.g. "3.10".
+    """
+    from packaging.specifiers import SpecifierSet
+
+    lower_bounds = [
+        clause for clause in SpecifierSet(requires_python) if clause.operator in (">=", "~=", "==")
+    ]
+    assert lower_bounds, (
+        f"project.requires-python is {requires_python!r}, which declares no lower bound "
+        f"(>=, ~= or ==). The unittest workflow pins the oldest supported version, so a floor "
+        f"has to be derivable; add one or teach _support_floor about the new form"
+    )
+    return max(lower_bounds, key=lambda clause: _as_tuple(clause.version)).version
+
+
 @pytest.fixture(scope="module")
 def config() -> dict:
     """
@@ -107,12 +160,10 @@ def test_shipped_version_is_a_bare_minor_version(config: dict) -> None:
 
 def test_shipped_version_satisfies_the_support_floor(config: dict) -> None:
     """Check the shipped version is not older than the declared support floor."""
-    floor_spec = config["requires_python"]
-    floor = re.sub(r"^[><=~!]+", "", floor_spec.split(",")[0]).strip()
-    shipped = tuple(int(part) for part in config["python_version"].split("."))
-    assert shipped >= tuple(int(part) for part in floor.split(".")), (
+    floor = _support_floor(config["requires_python"])
+    assert _as_tuple(config["python_version"]) >= _as_tuple(floor), (
         f"tool.python.version ({config['python_version']}) is older than the "
-        f"project.requires-python floor ({floor_spec})"
+        f"project.requires-python floor ({config['requires_python']!r}, floor {floor})"
     )
 
 
@@ -150,12 +201,12 @@ def test_quicktest_workflow_matches(config: dict) -> None:
 
 def test_unittest_workflow_pins_the_support_floor(config: dict) -> None:
     """Check the unittest job still tests the oldest supported version, not the shipped one."""
-    floor_spec = config["requires_python"]
-    floor = re.sub(r"^[><=~!]+", "", floor_spec.split(",")[0]).strip()
+    floor = _support_floor(config["requires_python"])
     versions = re.findall(r"^\s*python-version:\s*['\"]([^'\"]+)['\"]", UNITTEST_YAML.read_text(), re.M)
     assert versions, f"no python-version found in {UNITTEST_YAML}"
     for version in versions:
-        assert version == floor, (
+        # compare at major.minor, the granularity setup-python is pinned at
+        assert _as_tuple(version)[:2] == _as_tuple(floor)[:2], (
             f"{UNITTEST_YAML.name} pins python {version}, but it should pin the "
             f"project.requires-python floor ({floor}). This job is the only thing that tests the "
             f"oldest-supported claim; pointing it at the shipped default would drop that coverage"

--- a/tools/Docker/Dockerfile
+++ b/tools/Docker/Dockerfile
@@ -36,8 +36,11 @@
 #   The version of uv to use to build the python environment.
 #   - default: 0.9.22
 # - PYTHON_VERSION:
-#   The python version to use for the virtual environment.
-#   - default: 3.12
+#   The python version to use for the virtual environment. build.py always passes this explicitly
+#   from tool.python.version in pyproject.toml, which is the single source of truth; the ARG
+#   default only applies to a direct `docker build` and is checked against that key by
+#   test/config/test_python_version.py.
+#   - default: see tool.python.version in pyproject.toml
 # - FREESURFER_VERSION:
 #   The freesurfer version used in the image.
 #   - default: 7.4.1

--- a/tools/Docker/build.py
+++ b/tools/Docker/build.py
@@ -661,6 +661,7 @@ def main(
         pyproject_toml = tomllib.load(fp)
         pyproject_repository_url = pyproject_toml["project"]["urls"]["source"]
         pyproject_freesurfer = pyproject_toml["tool"]["freesurfer"]
+        pyproject_python = pyproject_toml["tool"]["python"]
 
     if target not in get_args(Target):
         raise ValueError(f"Invalid target: {target}")
@@ -679,6 +680,9 @@ def main(
         f"FREESURFER_VERSION={pyproject_freesurfer['version']}",
         f"INSECURE_FLAG={'--insecure' if insecure else ''}",
         f"PINNED_REQUIREMENTS={'true' if pinned_requirements else 'false'}",
+        # a Dockerfile ARG cannot read pyproject.toml, so the version is passed in here; the
+        # ARG default in the Dockerfile is only a fallback for a direct `docker build`
+        f"PYTHON_VERSION={pyproject_python['version']}",
     ]
     if debug:
         kwargs["build_arg"].append("DEBUG=true")


### PR DESCRIPTION

- `tool.python.version` is now the one place the shipped interpreter is declared: `build.py` forwards it to docker as `PYTHON_VERSION`, and the quicktest runner moves 3.11 -> 3.12 (3.11 was only ever needed for stdlib tomllib, which 3.12 also has; that interpreter just reads toml and drives the build, so no test result changes).

- `project.requires-python` stays the support floor, and the unittest job keeps pinning that floor deliberately, so the oldest-supported claim stays tested.

- Two consumers cannot read the key: the Dockerfile ARG default and the quicktest python-version, which provides the interpreter that reads `pyproject.toml`. Both are now asserted against it by `test/config/test_python_version.py`, run by the existing pytest job, so a bump that misses one fails CI instead of producing a confusing build.

- The macOS installer still derives its interpreter from requires-python; repointing it at the new key follows in the macOS packaging branch.