### PR TITLE
Fix: Propagate the real exit code from time_it instead of always exiting 0

### DIFF
--- a/recon_surf/functions.sh
+++ b/recon_surf/functions.sh
@@ -75,7 +75,11 @@ function time_it()
     echo "WARNING: Using time_it, but time seems to fail. Not timing..."
     "${cmd[@]}"
   fi
-  if [[ "${PIPESTATUS[0]}" != 0 ]] ; then exit "${PIPESTATUS[0]}" ; fi
+  # Capture the status before testing it. A test is itself a command, so it overwrites PIPESTATUS:
+  # reading PIPESTATUS again inside the branch yields the status of the test (0), not of cmd, which
+  # made this exit 0 on failure -- stopping the pipeline while reporting success.
+  local exit_status="${PIPESTATUS[0]}"
+  if [[ "$exit_status" != 0 ]] ; then exit "$exit_status" ; fi
 }
 
 function RunIt()


### PR DESCRIPTION
## Propagate the real exit code from `time_it`

`time_it` in `recon_surf/functions.sh` detected a failing command, stopped the script, and then
exited **0** — reporting success. Every module invocation in `run_fastsurfer.sh` goes through it, so
module failures were invisible to callers.

### Root cause

`functions.sh` read `PIPESTATUS[0]` twice:

```bash
if [[ "${PIPESTATUS[0]}" != 0 ]] ; then exit "${PIPESTATUS[0]}" ; fi
```

The condition sees the wrapped command's real status, but `[[ ]]` is itself a command and overwrites
`PIPESTATUS`. By the time `exit`'s argument is expanded, `PIPESTATUS[0]` is the *test's* status,
which is always 0.

### Fix

Capture the status before testing it.

### Scope

One call site. `functions.sh` has three other `PIPESTATUS` checks (`RunIt`, `run_it`, and the one
emitted into the command file), but those read it **only inside the condition** — evaluated before
`[[ ]]` completes — and then `exit 1` literally, so they were never affected. Verified that `run_it`
with a failing command still exits 1 and stops.

### Impact

`time_it` is the wrapper for every module invocation in `run_fastsurfer.sh` (20 call sites via
`wrap=("time_it" "$exec_time_log")`): asegdkt, biasfield, CerebNet, HypVINN, CorpusCallosum, LIT and
recon-surf. Previously a module failure stopped the run but exited 0, so:

- callers, CI and batch wrappers saw success
- `brun_fastsurfer.sh` counted a failed subject as completed

After this change those failures surface with the module's real exit code.

**This may make runs that previously appeared to pass report failure.** That is the intended
behaviour, but it is worth a quicktest run before merging, since that is exactly where a previously
masked failure would now become visible.

### Testing

Exit-code propagation verified in both branches: the untimed path (`timecmd` empty, as on macOS
where `fs_time` does not work) and the `fs_time` path (via a stub, so it is covered on any host).

Found while working on the macOS installer PR; unrelated to packaging and platform-independent, so
split out into its own branch off `dev`.
