### PR TITLE
Fix quicktest: stop it failing every dependabot PR, and add fixes

### DIFF
--- a/.github/actions/load-processed/action.yml
+++ b/.github/actions/load-processed/action.yml
@@ -16,6 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Load cached subject directory
+      id: local
       shell: bash
       run: |
         mkdir -p ${{ inputs.subjects-dir }}
@@ -23,7 +24,19 @@ runs:
           echo "The expected subject directory ${{ inputs.subjects-dir }}/${{ inputs.subject-id }} already exists!"
           exit 1
         fi
+        # run-fastsurfer processes into DATA_DIR on this runner, so within one job the artifact it
+        # uploaded does not have to be fetched back again. Moving is safe because that upload runs
+        # before this; DATA_DIR is unset in a job that only tests, which is when the download below
+        # applies.
+        if [[ -n "$DATA_DIR" ]] && [[ -d "$DATA_DIR/${{ inputs.subject-id }}" ]] ; then
+          echo "Taking ${{ inputs.subject-id }} from $DATA_DIR, it was processed on this runner."
+          mv "$DATA_DIR/${{ inputs.subject-id }}" "${{ inputs.subjects-dir }}/${{ inputs.subject-id }}"
+          echo "ON_RUNNER=true" >> $GITHUB_OUTPUT
+        else
+          echo "ON_RUNNER=false" >> $GITHUB_OUTPUT
+        fi
     - name: Recover processed files
+      if: steps.local.outputs.ON_RUNNER == 'false'
       uses: actions/download-artifact@v8
       with:
         name: fastsurfer-${{ github.sha }}-${{ inputs.subject-id }}

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -53,9 +53,8 @@ runs:
         DATA_DIR=$(dirname $(pwd))/data
         echo "DATA_DIR=$DATA_DIR" >> $GITHUB_ENV  # DATA_DIR is used in the next 2 steps as well
         mkdir -p $DATA_DIR
-        # named explicitly, because GitHub withholds the secrets these come from when a
-        # pull_request run belongs to a fork, and an empty value is otherwise hard to recognise:
-        # curl without --fail would store the error page as the T1 and fail much later
+        # checked explicitly: GitHub withholds these secrets from a pull_request run on a fork, and
+        # an empty one has to be caught here rather than as a confusing failure much later
         for var in IMAGE_HREF LICENSE ; do
           if [[ -z "${!var}" ]] ; then
             echo "$var is empty. A pull_request run on a fork does not receive the secrets, by"
@@ -118,13 +117,6 @@ runs:
         if [[ "${{ contains( inputs.extra-args, '--surf_only' ) }}" == "0" ]] ; then docker container rm seg_container ; fi
         if [[ "${{ contains( inputs.extra-args, '--seg_only' ) }}" == "0" ]] ; then docker container rm surf_container ; fi
         echo "::endgroup::"
-        echo "::group::Save ${{ inputs.subject-id }} as an artifact"
-    - name: Create archive of Processed subject-data
-      shell: bash
-      if: ${{ always() && (steps.prep.outputs.IMAGE_LOADED != 0 || steps.load-docker.outcome == 'success') }}
-      run: |
-        # Archive data code
-        tar cfz "$DATA_DIR/${{ inputs.subject-id }}.tar.gz" -C "$DATA_DIR" "${{ inputs.subject-id }}"
     - name: Save processed data
       if: ${{ always() && (steps.prep.outputs.IMAGE_LOADED != 0 || steps.load-docker.outcome == 'success') }}
       uses: actions/upload-artifact@v7

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -45,6 +45,7 @@ runs:
       continue-on-error: false
       env:
         IMAGE_HREF: ${{ inputs.image-href }}
+        LICENSE: ${{ inputs.license }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
       run: |
         # Preparation code
@@ -52,8 +53,20 @@ runs:
         DATA_DIR=$(dirname $(pwd))/data
         echo "DATA_DIR=$DATA_DIR" >> $GITHUB_ENV  # DATA_DIR is used in the next 2 steps as well
         mkdir -p $DATA_DIR
-        echo "${{ inputs.license }}" > $DATA_DIR/.fs_license
-        curl -L -k "$IMAGE_HREF" -o "$DATA_DIR/T1${{ inputs.file-extension }}"
+        # named explicitly, because GitHub withholds the secrets these come from when a
+        # pull_request run belongs to a fork, and an empty value is otherwise hard to recognise:
+        # curl without --fail would store the error page as the T1 and fail much later
+        for var in IMAGE_HREF LICENSE ; do
+          if [[ -z "${!var}" ]] ; then
+            echo "$var is empty. If this is a pull_request run on a fork, it cannot have the"
+            echo "  secrets; start the quicktest workflow by hand with docker-image=pr/<no> instead."
+            exit 1
+          fi
+        done
+        # via the environment, so that a license containing a quote or a backtick cannot end up
+        # being interpreted as part of this script
+        printf '%s\n' "$LICENSE" > $DATA_DIR/.fs_license
+        curl --fail -L -k "$IMAGE_HREF" -o "$DATA_DIR/T1${{ inputs.file-extension }}"
         if [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--threads/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--parallel/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--fs_license/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--sd/}" ]] || [[ "$EXTRA_ARGS" != "${EXTRA_ARGS/--sid/}" ]] ; then
           echo "--threads, --parallel, --fs_license, --sid, --sd are not allowed in extra-args!"
           exit 1

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -58,8 +58,8 @@ runs:
         # curl without --fail would store the error page as the T1 and fail much later
         for var in IMAGE_HREF LICENSE ; do
           if [[ -z "${!var}" ]] ; then
-            echo "$var is empty. If this is a pull_request run on a fork, it cannot have the"
-            echo "  secrets; start the quicktest workflow by hand with docker-image=pr/<no> instead."
+            echo "$var is empty. A pull_request run on a fork does not receive the secrets, by"
+            echo "  design; merge the branch into a branch of this repository and test that instead."
             exit 1
           fi
         done

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -23,6 +23,10 @@ inputs:
     required: true
     type: string
     description: "The url to the reference file to download for comparison"
+  checkout-ref:
+    default: ""
+    type: string
+    description: "The ref to check the tests out from (default: the ref that triggered the run)"
   junit-file:
     default: /tmp/quicktest.junit.xml
     type: string
@@ -32,6 +36,10 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v7
+      with:
+        # otherwise this overwrites the checkout the calling job made and the tests come from the
+        # default branch, which for docker-image=pr/<no> is not the code the image was built from
+        ref: ${{ inputs.checkout-ref }}
     - name: Setup uv and Python 3.10
       uses: astral-sh/setup-uv@v10.0.1
       with:
@@ -44,7 +52,13 @@ runs:
       run: |
         echo "::group::Prepare processed and reference data"
         mkdir -p $REF_DIR
-        curl -k "$CASE_HREF" -o "$REF_DIR/ref-download-data"
+        if [[ -z "$CASE_HREF" ]] ; then
+          echo "CASE_HREF is empty, so the reference data cannot be downloaded. If this is a"
+          echo "  pull_request run on a fork, it cannot have the secrets."
+          exit 1
+        fi
+        # --fail, so that an error page is not unpacked as if it were the reference archive
+        curl --fail -k "$CASE_HREF" -o "$REF_DIR/ref-download-data"
         tar xf "$REF_DIR/ref-download-data" -C "$REF_DIR"
         rm -f "$REF_DIR/ref-download-data"
         echo "::endgroup::"

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -23,10 +23,6 @@ inputs:
     required: true
     type: string
     description: "The url to the reference file to download for comparison"
-  checkout-ref:
-    default: ""
-    type: string
-    description: "The ref to check the tests out from (default: the ref that triggered the run)"
   junit-file:
     default: /tmp/quicktest.junit.xml
     type: string
@@ -37,9 +33,9 @@ runs:
   steps:
     - uses: actions/checkout@v7
       with:
-        # otherwise this overwrites the checkout the calling job made and the tests come from the
-        # default branch, which for docker-image=pr/<no> is not the code the image was built from
-        ref: ${{ inputs.checkout-ref }}
+        # the commit, not the branch or the merge ref: this re-checks out on top of what the calling
+        # job already has, and both have to be the commit the image was built from
+        ref: ${{ github.sha }}
     - name: Setup uv and Python 3.10
       uses: astral-sh/setup-uv@v10.0.1
       with:

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,10 +1,9 @@
-# This workflow file is a reusable workflow that will process a single T1 image with docker.
-# The docker image can be built by workflow build-docker or on dockerhub (input image).
-# The image will be downloaded
-# The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
+# Compares one processed subject against reference data with the quicktest pytest suite.
+# The calling job has to have checked this repository out, and either processed the subject on the
+# same runner or produced the artifact that load-processed fetches.
 
-name: 'Run Fastsurfer'
-description: 'Runs FastSurfer'
+name: 'Run quicktest'
+description: 'Runs the quicktest suite against reference data'
 
 inputs:
   subject-id:
@@ -31,11 +30,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v7
-      with:
-        # the commit, not the branch or the merge ref: this re-checks out on top of what the calling
-        # job already has, and both have to be the commit the image was built from
-        ref: ${{ github.sha }}
     - name: Setup uv and Python 3.10
       uses: astral-sh/setup-uv@v10.0.1
       with:

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -3,8 +3,13 @@ name: quicktest
 # File: quicktest.yaml
 # Functionality: This workflow runs FastSurfer on MRI data and runs pytest to check if the results are acceptable. It
 #  also checks if the FastSurfer environment and output already exist, and if not, it creates them.
-# Usage: This workflow is triggered on a pull request to the dev and main branch. It can also be triggered manually
-#  with workflow-dispatch.
+# Usage: There are two ways to run this, both restricted to this repository. Attach the label
+#  "quicktest" to a pull request, which tests the merge of it into its base and reports on the pull
+#  request. Or run it from the Actions tab (workflow-dispatch) on any branch, which tests that
+#  branch as it stands and reports on the run; that is also how reference data is produced. A pull
+#  request from a fork is skipped: GitHub gives it no secrets, and must not, because the code under
+#  test runs in the same job as the FreeSurfer license. Merge such a branch into a branch of this
+#  repository and use either way above.
 # Expected Secrets:
 #  - QUICKTEST_IMAGE_HREF_08mm: URL to a sample 0.8mm image
 #  - QUICKTEST_IMAGE_HREF_1mm: URL to a sample 1mm image
@@ -56,10 +61,14 @@ jobs:
     name: 'Check and build the current docker image'
     runs-on: ubuntu-latest
     timeout-minutes: 180
-    # a labeled event fires for every label, because GitHub offers no way to filter by label name
-    # in the trigger. Deciding here rather than in a step keeps a runner from starting at all for
-    # the labels dependabot attaches to its own pull requests.
-    if: github.event_name != 'pull_request' || github.event.label.name == 'quicktest'
+    # the first clause admits a workflow-dispatch, the rest a pull request. A labeled event fires for
+    # every label, because GitHub cannot filter by label name in the trigger, so deciding here rather
+    # than in a step keeps a runner from starting for the labels dependabot attaches, and makes a run
+    # that does not apply, such as one on a fork, come out as skipped rather than passed or failed.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.label.name == 'quicktest'
+          && github.event.pull_request.head.repo.full_name == github.repository)
     outputs:
       continue: ${{ steps.parse.outputs.CONTINUE }}
       docker-image: ${{ steps.parse.outputs.DOCKER_IMAGE }}
@@ -91,20 +100,23 @@ jobs:
           gh_header=(-H "Accept: application/vnd.github+json"
                      -H "X-GitHub-Api-Version: 2022-11-28")
           # collected in variables and written once at the end, so that a later decision cannot
-          # leave two values of the same key in the output file
+          # leave two values of the same key in the output file. A refusal exits non-zero rather
+          # than falling through: reaching the end with the tests skipped would report this workflow
+          # as passed without it having tested anything.
           continue_tests="false"
           docker_image="build-cached"
           if [[ "${{ github.event_name }}" == "pull_request" ]]
           then
             if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]
             then
-              # GitHub withholds the secrets from a pull_request run on a fork, so the image url and
-              # the FreeSurfer license would both arrive empty and the run would fail after building
-              echo "Pull request ${{ github.event.number }} comes from the fork"
-              echo "  '${{ github.event.pull_request.head.repo.full_name }}', which does not receive the"
-              echo "  secrets this workflow needs, and must not: its code runs in a job that holds the"
-              echo "  FreeSurfer license. Merge the branch into a branch of this repository and label"
-              echo "  a pull request from there instead."
+              # not reachable: the condition on this job skips a fork, so that such a run reads as
+              # skipped. Kept as a guard, because the license is in the job this decides for, and a
+              # condition that stops holding should be loud rather than silent.
+              echo "Refusing to run: pull request ${{ github.event.number }} comes from"
+              echo "  '${{ github.event.pull_request.head.repo.full_name }}', so its code would run in a"
+              echo "  job that holds the FreeSurfer license. The condition on this job should have"
+              echo "  skipped the run, which means that condition no longer holds."
+              exit 1
             else
               continue_tests="true"
             fi
@@ -117,12 +129,15 @@ jobs:
             echo "This workflow is not defined for the event ${{ github.event_name }}!"
             exit 1
           fi
-          # quoted, because a bot login such as dependabot[bot] is a glob pattern unquoted
+          # a failure rather than a skip, unlike the cases the job condition covers: whether the
+          # sender is a collaborator takes an api call, which a job condition cannot make, so the job
+          # is already running by the time we know. Being refused is an error, not a run that does
+          # not apply. Quoted, because a bot login such as dependabot[bot] is a glob unquoted.
           if [[ "$continue_tests" == "true" ]] \
              && ! gh api "${gh_header[@]}" "/repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}"
           then
             echo "Only collaborators explicitly listed as collaborators can trigger this workflow!"
-            continue_tests="false"
+            exit 1
           fi
           {
             echo "CONTINUE=$continue_tests"

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -13,10 +13,10 @@ name: quicktest
 #  - QUICKTEST_LICENSE: content of a FreeSurfer license file
 
 concurrency:
-  # maybe the group here should actually not depend on the ref (only number would mean there are
-  # not concurrent runs of the same pr) -- but then we should probably add the branch name (for
-  # manually triggered workflows)
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  # the pull request number, or the dispatched branch when there is none. github.event.ref used to
+  # be part of this, but the pull_request payload has no ref, so every run of a pull request shared
+  # one group whether or not that was intended.
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -56,9 +56,14 @@ jobs:
     name: 'Check and build the current docker image'
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    # a labeled event fires for every label, because GitHub offers no way to filter by label name
+    # in the trigger. Deciding here rather than in a step keeps a runner from starting at all for
+    # the labels dependabot attaches to its own pull requests.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'quicktest'
     outputs:
       continue: ${{ steps.parse.outputs.CONTINUE }}
       docker-image: ${{ steps.parse.outputs.DOCKER_IMAGE }}
+      checkout-ref: ${{ steps.parse.outputs.CHECKOUT_REF }}
       extra-args: ${{ steps.parse.outputs.EXTRA_ARGS }}
       fs-build-image: ${{ steps.parse-version.outputs.FS_BUILD_IMAGE }}
       fs-version: ${{ steps.parse-version.outputs.FS_VERSION }}
@@ -86,40 +91,53 @@ jobs:
           
           gh_header=(-H "Accept: application/vnd.github+json"
                      -H "X-GitHub-Api-Version: 2022-11-28")
+          # collected in variables and written once at the end, so that a later decision cannot
+          # leave two values of the same key in the output file
+          continue_tests="false"
+          docker_image="build-cached"
+          checkout_ref=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]
           then
-            if [[ "${{ github.event.action }}" != "labeled" ]] && [[ "${{ github.event.action }}" != "unlabeled" ]]
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]
             then
-              # not a label-related action, should not be triggered
-              echo "The Workflow '${{ github.workflow }}' was triggered by 'pull_request' of type"
-              echo "  '${{ github.event.action }}' but should only be triggered by 'labeled' or 'unlabeled' actions."
-              echo "CONTINUE=false" > $GITHUB_OUTPUT
-            elif [[ "${{ github.event.label.name }}" == "quicktest" ]]
-            then
-              echo "CONTINUE=true" > $GITHUB_OUTPUT
+              # GitHub withholds the secrets from a pull_request run on a fork, so the image url and
+              # the FreeSurfer license would both arrive empty and the run would fail after building
+              echo "Pull request ${{ github.event.number }} comes from the fork"
+              echo "  '${{ github.event.pull_request.head.repo.full_name }}', which does not receive the"
+              echo "  secrets this workflow needs. Start the workflow by hand instead and pass"
+              echo "  docker-image=pr/${{ github.event.number }} to test this pull request."
             else
-              echo "This is a different label that was attached."
-              echo "CONTINUE=false" > $GITHUB_OUTPUT
+              continue_tests="true"
             fi
-            echo "DOCKER_IMAGE=build-cached" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]
           then
             # the inputs context is only useful/set in the workflow dispatch event case
-            if [[ "${{ inputs.docker-image }}" == "" ]] ; then
-              echo "DOCKER_IMAGE=build-cached" > $GITHUB_OUTPUT
-            else
-              echo "DOCKER_IMAGE=${{ inputs.docker-image }}" > $GITHUB_OUTPUT
+            continue_tests="true"
+            if [[ -n "${{ inputs.docker-image }}" ]] ; then docker_image="${{ inputs.docker-image }}" ; fi
+            if [[ "$docker_image" == pr/* ]]
+            then
+              # refs/pull/<no>/head exists in this repository even when the pull request comes from
+              # a fork, which is what makes this the way to test one. The image is then built from
+              # that ref here, so what the test job consumes is this build and not a registry tag.
+              checkout_ref="refs/pull/${docker_image#pr/}/head"
+              docker_image="build-cached"
             fi
-            echo "CONTINUE=true" >> $GITHUB_OUTPUT
           else #  this event has no specific rules (invalid)
             echo "This workflow is not defined for the event ${{ github.event_name }}!"
             exit 1
           fi
-          if ! gh api "${gh_header[@]}" /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}
+          # quoted, because a bot login such as dependabot[bot] is a glob pattern unquoted
+          if [[ "$continue_tests" == "true" ]] \
+             && ! gh api "${gh_header[@]}" "/repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}"
           then
             echo "Only collaborators explicitly listed as collaborators can trigger this workflow!"
-            echo "CONTINUE=false" >> $GITHUB_OUTPUT
+            continue_tests="false"
           fi
+          {
+            echo "CONTINUE=$continue_tests"
+            echo "DOCKER_IMAGE=$docker_image"
+            echo "CHECKOUT_REF=$checkout_ref"
+          } >> "$GITHUB_OUTPUT"
           # later, we might want to extract additional run options from the pr text or issue comments
           # these should just be added here 
           # https://api.github.com/repos/${{ github.repository }}/issues/${{ github.number }}
@@ -127,16 +145,17 @@ jobs:
           # this may also need adaptations in the test script at the bottom
           echo "EXTRA_ARGS=" >> $GITHUB_OUTPUT
       - name: Checkout repository
-        # DOCKER_IMAGE is build-cached => we want to build, check this repository out to build the docker image
+        # DOCKER_IMAGE is build-cached => we want to build, check out what we build from. CHECKOUT_REF
+        # is empty except for docker-image=pr/<no>, and empty is checkout's own default.
         if: steps.parse.outputs.CONTINUE == 'true' && steps.parse.outputs.DOCKER_IMAGE == 'build-cached'
         uses: actions/checkout@v7
-      - name: Checkout repository
-        # DOCKER_IMAGE starts with pr/*** => we want to build, check the PR out to build the docker image
-        if: steps.parse.outputs.CONTINUE == 'true' && startsWith(steps.parse.outputs.DOCKER_IMAGE, 'pr/')
-        uses: actions/checkout@v7
         with:
-          ref: ${{ steps.parse.outputs.DOCKER_IMAGE }}
+          ref: ${{ steps.parse.outputs.CHECKOUT_REF }}
       - name: Setup uv and Python (shipped default)
+        # the same condition as the build steps below: without it this step, and in particular the
+        # cache it saves in its post step, ran even when the workflow had decided to do nothing,
+        # which failed the job for every label dependabot attaches to a pull request
+        if: steps.parse.outputs.CONTINUE == 'true' && steps.parse.outputs.DOCKER_IMAGE == 'build-cached'
         uses: astral-sh/setup-uv@v7
         with:
           # keep in sync with tool.python.version in pyproject.toml. It cannot be read from there:
@@ -147,7 +166,7 @@ jobs:
           python-version: '3.12'
       - name: Get the FreeSurfer version
         # we want to build the docker image, get what we want to do for freesurfer (read fslink from install_pruned.sh,
-        if: steps.parse.outputs.CONTINUE == 'true' && (steps.parse.outputs.DOCKER_IMAGE == 'build-cached' || startsWith(steps.parse.outputs.DOCKER_IMAGE, 'pr/'))
+        if: steps.parse.outputs.CONTINUE == 'true' && steps.parse.outputs.DOCKER_IMAGE == 'build-cached'
         shell: bash
         id: parse-version
         run: |
@@ -197,6 +216,10 @@ jobs:
     steps:
       - name: Check out the repository that is to be tested
         uses: actions/checkout@v7
+        with:
+          # the same ref the image was built from, so that the tests match the image. Empty except
+          # for docker-image=pr/<no>, where the default would be this workflow's branch instead.
+          ref: ${{ needs.build-docker.outputs.checkout-ref }}
       - name: Run FastSurfer for ${{ matrix.subject-id }} with the previously created docker container
         uses: Deep-MI/FastSurfer/.github/actions/run-fastsurfer@dev
         with:
@@ -214,6 +237,7 @@ jobs:
           subjects-dir: ${{ env.SUBJECTS_DIR }}
           reference-dir: ${{ env.REFERENCE_DIR }}
           case-href: ${{ secrets[matrix.case-key] }}
+          checkout-ref: ${{ needs.build-docker.outputs.checkout-ref }}
           junit-file: /tmp/fastsurfer-quicktest-${{ matrix.subject-id }}.junit.xml
   annotation:
     name: Annotate test results as checks

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       docker-image:
-        description: 'Which docker image should be used to run this test (build-cached => build from git, also pr/<#no> for a pull request of this repository, not of a fork)'
+        description: 'Which docker image should be used to run this test (build-cached => build from the branch this runs on, or the name of an image to pull)'
         default: build-cached
         type: string
       freesurfer-build-image:
@@ -63,7 +63,6 @@ jobs:
     outputs:
       continue: ${{ steps.parse.outputs.CONTINUE }}
       docker-image: ${{ steps.parse.outputs.DOCKER_IMAGE }}
-      checkout-ref: ${{ steps.parse.outputs.CHECKOUT_REF }}
       extra-args: ${{ steps.parse.outputs.EXTRA_ARGS }}
       fs-build-image: ${{ steps.parse-version.outputs.FS_BUILD_IMAGE }}
       fs-version: ${{ steps.parse-version.outputs.FS_VERSION }}
@@ -95,7 +94,6 @@ jobs:
           # leave two values of the same key in the output file
           continue_tests="false"
           docker_image="build-cached"
-          checkout_ref=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]
           then
             if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]
@@ -115,36 +113,6 @@ jobs:
             # the inputs context is only useful/set in the workflow dispatch event case
             continue_tests="true"
             if [[ -n "${{ inputs.docker-image }}" ]] ; then docker_image="${{ inputs.docker-image }}" ; fi
-            if [[ "$docker_image" == pr/* ]]
-            then
-              pr_number="${docker_image#pr/}"
-              if [[ ! "$pr_number" =~ ^[0-9]+$ ]]
-              then
-                echo "docker-image has to be pr/<number>, but is '$docker_image'."
-                exit 1
-              fi
-              # the head commit rather than refs/pull/<no>/head, which moves: the build job and the
-              # test jobs resolve the ref separately, so a push during the build would leave the
-              # tests running a different commit than the image was built from
-              if ! pr_head="$(gh api "${gh_header[@]}" "/repos/${{ github.repository }}/pulls/$pr_number" \
-                              --jq '[.head.sha, (.head.repo.full_name // "")] | @tsv')"
-              then
-                echo "Could not resolve pull request $pr_number."
-                exit 1
-              fi
-              IFS=$'\t' read -r checkout_ref pr_repo <<< "$pr_head"
-              # the code of the pull request is built and run in a job that holds the FreeSurfer
-              # license, so it has to come from this repository. There is no gate that would make a
-              # fork safe here: whoever approves it, the fork's code still runs with the license.
-              if [[ "$pr_repo" != "${{ github.repository }}" ]]
-              then
-                echo "Pull request $pr_number comes from '$pr_repo' rather than this repository, so"
-                echo "  running it would expose the FreeSurfer license to code we do not control."
-                echo "  Merge the branch into a branch of this repository and test that instead."
-                exit 1
-              fi
-              docker_image="build-cached"
-            fi
           else #  this event has no specific rules (invalid)
             echo "This workflow is not defined for the event ${{ github.event_name }}!"
             exit 1
@@ -159,7 +127,6 @@ jobs:
           {
             echo "CONTINUE=$continue_tests"
             echo "DOCKER_IMAGE=$docker_image"
-            echo "CHECKOUT_REF=$checkout_ref"
           } >> "$GITHUB_OUTPUT"
           # later, we might want to extract additional run options from the pr text or issue comments
           # these should just be added here 
@@ -168,12 +135,15 @@ jobs:
           # this may also need adaptations in the test script at the bottom
           echo "EXTRA_ARGS=" >> $GITHUB_OUTPUT
       - name: Checkout repository
-        # DOCKER_IMAGE is build-cached => we want to build, check out what we build from. CHECKOUT_REF
-        # is empty except for docker-image=pr/<no>, and empty is checkout's own default.
+        # DOCKER_IMAGE is build-cached => we want to build, check this repository out to build the
+        # docker image
         if: steps.parse.outputs.CONTINUE == 'true' && steps.parse.outputs.DOCKER_IMAGE == 'build-cached'
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.parse.outputs.CHECKOUT_REF }}
+          # the commit rather than the branch or the merge ref, both of which move: the build job
+          # and the test jobs check out separately, twenty minutes apart, so a push in between would
+          # otherwise leave the tests running a different commit than the image was built from
+          ref: ${{ github.sha }}
       - name: Setup uv and Python (shipped default)
         # the same condition as the build steps below: without it this step, and in particular the
         # cache it saves in its post step, ran even when the workflow had decided to do nothing,
@@ -240,9 +210,8 @@ jobs:
       - name: Check out the repository that is to be tested
         uses: actions/checkout@v7
         with:
-          # the same ref the image was built from, so that the tests match the image. Empty except
-          # for docker-image=pr/<no>, where the default would be this workflow's branch instead.
-          ref: ${{ needs.build-docker.outputs.checkout-ref }}
+          # the same commit the image was built from, see the build job
+          ref: ${{ github.sha }}
       - name: Run FastSurfer for ${{ matrix.subject-id }} with the previously created docker container
         uses: Deep-MI/FastSurfer/.github/actions/run-fastsurfer@dev
         with:
@@ -260,7 +229,6 @@ jobs:
           subjects-dir: ${{ env.SUBJECTS_DIR }}
           reference-dir: ${{ env.REFERENCE_DIR }}
           case-href: ${{ secrets[matrix.case-key] }}
-          checkout-ref: ${{ needs.build-docker.outputs.checkout-ref }}
           junit-file: /tmp/fastsurfer-quicktest-${{ matrix.subject-id }}.junit.xml
   annotation:
     name: Annotate test results as checks

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -18,10 +18,12 @@ name: quicktest
 #  - QUICKTEST_LICENSE: content of a FreeSurfer license file
 
 concurrency:
-  # the pull request number, or the dispatched branch when there is none. github.event.ref used to
-  # be part of this, but the pull_request payload has no ref, so every run of a pull request shared
-  # one group whether or not that was intended.
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  # one group per pull request and label, or per branch for a dispatch. The label matters because
+  # the group is evaluated when the run is created, before the condition on the job below: with
+  # every label of a pull request in one group, attaching an unrelated label would cancel a
+  # quicktest that is already running. github.event.ref was part of this and does not exist on the
+  # pull_request payload.
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}-${{ github.event.label.name || 'dispatch' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -18,11 +18,9 @@ name: quicktest
 #  - QUICKTEST_LICENSE: content of a FreeSurfer license file
 
 concurrency:
-  # one group per pull request and label, or per branch for a dispatch. The label matters because
-  # the group is evaluated when the run is created, before the condition on the job below: with
-  # every label of a pull request in one group, attaching an unrelated label would cancel a
-  # quicktest that is already running. github.event.ref was part of this and does not exist on the
-  # pull_request payload.
+  # one group per pull request and label, or per branch for a dispatch. The label is part of the key
+  # because the group is evaluated when the run is created, before the condition on the job below,
+  # so without it attaching an unrelated label cancels a quicktest that is already running.
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}-${{ github.event.label.name || 'dispatch' }}
   cancel-in-progress: true
 
@@ -157,14 +155,12 @@ jobs:
         if: steps.parse.outputs.CONTINUE == 'true' && steps.parse.outputs.DOCKER_IMAGE == 'build-cached'
         uses: actions/checkout@v7
         with:
-          # the commit rather than the branch or the merge ref, both of which move: the build job
-          # and the test jobs check out separately, twenty minutes apart, so a push in between would
-          # otherwise leave the tests running a different commit than the image was built from
+          # the commit rather than the branch or the merge ref, both of which move: this job and the
+          # test jobs check out separately, an hour or so apart, and have to agree on what was built
           ref: ${{ github.sha }}
       - name: Setup uv and Python (shipped default)
-        # the same condition as the build steps below: without it this step, and in particular the
-        # cache it saves in its post step, ran even when the workflow had decided to do nothing,
-        # which failed the job for every label dependabot attaches to a pull request
+        # uv is only used by the build below, and its post step saves a cache, which fails when
+        # nothing has used uv, so this carries the same condition as the build steps
         if: steps.parse.outputs.CONTINUE == 'true' && steps.parse.outputs.DOCKER_IMAGE == 'build-cached'
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       docker-image:
-        description: 'Which docker image should be used to run this test (build-cached => build from git, also pr/<#no>)'
+        description: 'Which docker image should be used to run this test (build-cached => build from git, also pr/<#no> for a pull request of this repository, not of a fork)'
         default: build-cached
         type: string
       freesurfer-build-image:
@@ -104,8 +104,9 @@ jobs:
               # the FreeSurfer license would both arrive empty and the run would fail after building
               echo "Pull request ${{ github.event.number }} comes from the fork"
               echo "  '${{ github.event.pull_request.head.repo.full_name }}', which does not receive the"
-              echo "  secrets this workflow needs. Start the workflow by hand instead and pass"
-              echo "  docker-image=pr/${{ github.event.number }} to test this pull request."
+              echo "  secrets this workflow needs, and must not: its code runs in a job that holds the"
+              echo "  FreeSurfer license. Merge the branch into a branch of this repository and label"
+              echo "  a pull request from there instead."
             else
               continue_tests="true"
             fi
@@ -124,12 +125,22 @@ jobs:
               fi
               # the head commit rather than refs/pull/<no>/head, which moves: the build job and the
               # test jobs resolve the ref separately, so a push during the build would leave the
-              # tests running a different commit than the image was built from. WARNING: this builds
-              # and runs the code of that pull request, which for a fork is code from outside this
-              # repository, in a job that has the secrets. Only dispatch it for a diff you have read.
-              if ! checkout_ref="$(gh api "${gh_header[@]}" "/repos/${{ github.repository }}/pulls/$pr_number" --jq ".head.sha")"
+              # tests running a different commit than the image was built from
+              if ! pr_head="$(gh api "${gh_header[@]}" "/repos/${{ github.repository }}/pulls/$pr_number" \
+                              --jq '[.head.sha, (.head.repo.full_name // "")] | @tsv')"
               then
-                echo "Could not resolve the head commit of pull request $pr_number."
+                echo "Could not resolve pull request $pr_number."
+                exit 1
+              fi
+              IFS=$'\t' read -r checkout_ref pr_repo <<< "$pr_head"
+              # the code of the pull request is built and run in a job that holds the FreeSurfer
+              # license, so it has to come from this repository. There is no gate that would make a
+              # fork safe here: whoever approves it, the fork's code still runs with the license.
+              if [[ "$pr_repo" != "${{ github.repository }}" ]]
+              then
+                echo "Pull request $pr_number comes from '$pr_repo' rather than this repository, so"
+                echo "  running it would expose the FreeSurfer license to code we do not control."
+                echo "  Merge the branch into a branch of this repository and test that instead."
                 exit 1
               fi
               docker_image="build-cached"

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -116,10 +116,22 @@ jobs:
             if [[ -n "${{ inputs.docker-image }}" ]] ; then docker_image="${{ inputs.docker-image }}" ; fi
             if [[ "$docker_image" == pr/* ]]
             then
-              # refs/pull/<no>/head exists in this repository even when the pull request comes from
-              # a fork, which is what makes this the way to test one. The image is then built from
-              # that ref here, so what the test job consumes is this build and not a registry tag.
-              checkout_ref="refs/pull/${docker_image#pr/}/head"
+              pr_number="${docker_image#pr/}"
+              if [[ ! "$pr_number" =~ ^[0-9]+$ ]]
+              then
+                echo "docker-image has to be pr/<number>, but is '$docker_image'."
+                exit 1
+              fi
+              # the head commit rather than refs/pull/<no>/head, which moves: the build job and the
+              # test jobs resolve the ref separately, so a push during the build would leave the
+              # tests running a different commit than the image was built from. WARNING: this builds
+              # and runs the code of that pull request, which for a fork is code from outside this
+              # repository, in a job that has the secrets. Only dispatch it for a diff you have read.
+              if ! checkout_ref="$(gh api "${gh_header[@]}" "/repos/${{ github.repository }}/pulls/$pr_number" --jq ".head.sha")"
+              then
+                echo "Could not resolve the head commit of pull request $pr_number."
+                exit 1
+              fi
               docker_image="build-cached"
             fi
           else #  this event has no specific rules (invalid)

--- a/test/image/test_quicktest_header_tolerance.py
+++ b/test/image/test_quicktest_header_tolerance.py
@@ -1,0 +1,88 @@
+"""Tests for the header comparison the quicktest suite uses, `quicktest.helper`.
+
+They live here rather than next to the code they test because `test/quicktest/conftest.py` requires
+`REF_DIR` and `SUBJECTS_DIR` at import, so nothing in that directory can be collected without a
+reference dataset, while `test/image` runs in the unittest workflow on every push.
+
+What is pinned: below 1mm the direction cosines are computed rather than snapped, so `Mdc` carries
+float dust of the order of 1e-18 that no rerun reproduces bit for bit. Comparing headers exactly
+therefore failed every non-1mm file forever. Only float fields are relaxed, so a changed data type
+or image size is still reported.
+"""
+
+import sys
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from quicktest.helper import assert_same_headers, equal_within_tolerance  # noqa: E402
+
+# the largest deviation measured across all 39 shared 0.8mm files of a released v2.5.4 run
+MDC_DUST = 8.842e-18
+
+
+def header_of(shape=(320, 320, 320), vox_size=0.8, dtype=np.uint8):
+    """The header of an empty LIA-ish image, as the suite reads it back from an .mgz."""
+    affine = np.diag([vox_size, vox_size, vox_size, 1.0])
+    affine[:3, 3] = -0.5 * shape[0] * vox_size
+    return nib.MGHImage(np.zeros(shape, dtype=dtype), affine).header
+
+
+def test_mdc_float_dust_passes():
+    """The failure this fixes: an Mdc that differs only in the last bits of a computed cosine."""
+    reference, test = header_of(), header_of()
+    mdc = np.array(reference["Mdc"])
+    mdc[0, 1] += MDC_DUST
+    test["Mdc"] = mdc
+
+    assert not np.array_equal(reference["Mdc"], test["Mdc"]), "the two headers must really differ"
+    assert_same_headers(test, reference)
+
+
+def test_real_orientation_difference_still_fails():
+    """A tolerance that also hid a genuinely different orientation would be worthless."""
+    reference, test = header_of(), header_of()
+    mdc = np.array(reference["Mdc"])
+    mdc[0, 1] += 0.5
+    test["Mdc"] = mdc
+
+    with pytest.raises(BaseException, match="Mdc"):
+        assert_same_headers(test, reference)
+
+
+def test_fov_difference_still_fails():
+    """fov=0 against a real extent is the bug found in the released images, not float noise."""
+    reference, test = header_of(), header_of()
+    reference["fov"] = 256.0
+    test["fov"] = 0.0
+
+    with pytest.raises(BaseException, match="fov"):
+        assert_same_headers(test, reference)
+
+
+def test_data_type_difference_still_fails():
+    """Non-float fields keep the exact comparison; 3 of 37 1.0mm files differ in type alone."""
+    with pytest.raises(BaseException, match="type"):
+        assert_same_headers(header_of(dtype=np.int16), header_of(dtype=np.uint8))
+
+
+@pytest.mark.parametrize(
+    ("reference", "test", "expected"),
+    [
+        # float fields are compared with the tolerance
+        (np.float32([1.0, 0.0]), np.float32([1.0, MDC_DUST]), True),
+        (np.float32([1.0, 0.0]), np.float32([1.0, 0.5]), False),
+        # integers are not, so a size or count is never accepted as noise
+        (np.int32([256, 256]), np.int32([256, 257]), False),
+        # nor is anything of another shape, or not a number at all
+        (np.float32([1.0, 0.0]), np.float32([1.0, 0.0, 0.0]), False),
+        ("MGH", "MGH", False),
+    ],
+)
+def test_equal_within_tolerance(reference, test, expected):
+    """Only float fields of matching shape are eligible for the tolerance."""
+    assert equal_within_tolerance(reference, test, rtol=1e-6, atol=1e-6) is expected

--- a/test/quicktest/README.md
+++ b/test/quicktest/README.md
@@ -45,10 +45,19 @@ turns that drift into test failures, which then hide any real regression.
 
 The inputs and the references are downloaded from urls kept in repository secrets
 (`QUICKTEST_IMAGE_HREF_*` and `QUICKTEST_TARGET_HREF_*`), because the data is too large for the
-repository. To refresh one, process the input with the released version and the flags from the
-matrix in [quicktest.yaml](../../.github/workflows/quicktest.yaml), archive the subject folder, and update
-the url. The archive is unpacked into `REF_DIR`, so the subject folder has to sit at its top level
-under the name the workflow uses for the case.
+repository. To refresh one, process the input with the **released container image** and the flags
+from the matrix in [quicktest.yaml](../../.github/workflows/quicktest.yaml), archive the subject
+folder, and update the url. The archive is unpacked into `REF_DIR`, so the subject folder has to sit
+at its top level under the name the workflow uses for the case.
+
+Use the released image rather than a fresh build of the release tag. The image ships pinned
+dependencies, while a build from source can resolve them again and pick up newer ones, so the two
+do not always produce the same output. The reference has to be what users actually get.
+
+Take the image variant that matches how the workflow runs it, and give the same thread count and
+device. The runner has no GPU, so that is the CPU image rather than `latest`, which is a CUDA build,
+and the thread count is the runner's core count. Both change the output, so a reference produced
+with a GPU or with more threads cannot be reproduced by the workflow.
 
 Tolerances are separate and do live here, one file per output under [data](data). Widen one only for
 a small difference that keeps recurring; a large disagreement means the reference is out of date or

--- a/test/quicktest/README.md
+++ b/test/quicktest/README.md
@@ -1,7 +1,7 @@
 quicktest tests
 ===============
 
-This suite compares two runs of fastsurfer and is used as a online check for function in the [github quicktest workflow](/.github/workflows/quicktest.yaml).
+This suite compares two runs of fastsurfer and is used as a online check for function in the [github quicktest workflow](../../.github/workflows/quicktest.yaml).
 
 The `quicktest` suite requires
 - A python environment as defined by `fastsurfer[quicktest]`
@@ -46,7 +46,7 @@ turns that drift into test failures, which then hide any real regression.
 The inputs and the references are downloaded from urls kept in repository secrets
 (`QUICKTEST_IMAGE_HREF_*` and `QUICKTEST_TARGET_HREF_*`), because the data is too large for the
 repository. To refresh one, process the input with the released version and the flags from the
-matrix in [quicktest.yaml](/.github/workflows/quicktest.yaml), archive the subject folder, and update
+matrix in [quicktest.yaml](../../.github/workflows/quicktest.yaml), archive the subject folder, and update
 the url. The archive is unpacked into `REF_DIR`, so the subject folder has to sit at its top level
 under the name the workflow uses for the case.
 

--- a/test/quicktest/README.md
+++ b/test/quicktest/README.md
@@ -11,9 +11,9 @@ The `quicktest` suite requires
 - A target `subject directory` for an image (processed with a known good version of FastSurfer). This should be placed in the directory defined by the environment variable `REF_DIR`.
 - A to-compare `subject directory` for an image. This should be placed in the directory defined by the environment variable `SUBJECTS_DIR`.
 - A definition of the test setup in the following environment variables:
-  - `REF_DIR`: known-good reference data
+  - `REF_DIR`: known-good reference data. One subject per folder, each compared against the folder of the same name in `SUBJECTS_DIR`; `logs` and `slurm` are ignored.
   - `SUBJECTS_DIR`: to-compare/test data
-  - `SUBJECTS_LIST`: comma separated list of
+  - `MAX_SUBJECTS`: optional, process at most this many subjects (default: all)
 
 Test 1: Search for errors in to-compare log files
 -------------------------------------------------
@@ -35,3 +35,21 @@ Test 4: Check output stats files
 --------------------------------
 
 Contained in test_stats.py
+
+Refreshing the reference data after a release
+---------------------------------------------
+
+The reference data has to be regenerated after every release, so that it stays the output of the most
+recent released version. Outputs drift as the models and the pipeline change, and an old reference
+turns that drift into test failures, which then hide any real regression.
+
+The inputs and the references are downloaded from urls kept in repository secrets
+(`QUICKTEST_IMAGE_HREF_*` and `QUICKTEST_TARGET_HREF_*`), because the data is too large for the
+repository. To refresh one, process the input with the released version and the flags from the
+matrix in [quicktest.yaml](/.github/workflows/quicktest.yaml), archive the subject folder, and update
+the url. The archive is unpacked into `REF_DIR`, so the subject folder has to sit at its top level
+under the name the workflow uses for the case.
+
+Tolerances are separate and do live here, one file per output under [data](data). Widen one only for
+a small difference that keeps recurring; a large disagreement means the reference is out of date or
+something really changed.

--- a/test/quicktest/helper.py
+++ b/test/quicktest/helper.py
@@ -7,7 +7,19 @@ import pytest
 logger = logging.getLogger(__name__)
 
 
-def assert_same_headers(test_header, reference_header):
+def equal_within_tolerance(reference, test, rtol: float, atol: float) -> bool:
+    """Whether two header values are equal as floats, so only their representation differs.
+
+    Anything that is not a float field of the same shape, such as dims or the data type, is left to
+    the exact comparison.
+    """
+    reference, test = np.asanyarray(reference), np.asanyarray(test)
+    if reference.dtype.kind != "f" or test.dtype.kind != "f" or reference.shape != test.shape:
+        return False
+    return bool(np.allclose(reference, test, rtol=rtol, atol=atol, equal_nan=True))
+
+
+def assert_same_headers(test_header, reference_header, rtol: float = 1e-6, atol: float = 1e-6):
     __tracebackhide__ = True
 
     from nibabel.cmdline.diff import get_headers_diff
@@ -15,10 +27,18 @@ def assert_same_headers(test_header, reference_header):
     # the order given here is the order of the two values reported per field, so it is named in the
     # failure message: working it out from the code costs more than saying it
     header_diff = get_headers_diff([reference_header, test_header])
-    if len(header_diff.keys()) != 0:
+    # get_headers_diff compares exactly. Below 1mm the direction cosines are computed rather than
+    # snapped, so every Mdc carries float dust that no rerun reproduces bit for bit.
+    header_diff = {
+        field: values
+        for field, values in header_diff.items()
+        if not equal_within_tolerance(*values, rtol=rtol, atol=atol)
+    }
+    if header_diff:
         differences = "\n".join(f"  '{k}': {v}" for k, v in header_diff.items())
         pytest.fail(
-            f"The headers differ in the following fields, as [reference, test]:\n{differences}"
+            f"The headers differ in the following fields, as [reference, test], with floats "
+            f"compared at rtol={rtol}, atol={atol}:\n{differences}"
         )
 
 

--- a/test/quicktest/helper.py
+++ b/test/quicktest/helper.py
@@ -7,17 +7,20 @@ import pytest
 logger = logging.getLogger(__name__)
 
 
-def assert_same_headers(expected_header, actual_header):
+def assert_same_headers(test_header, reference_header):
     __tracebackhide__ = True
-    # Get the image headers
 
     from nibabel.cmdline.diff import get_headers_diff
 
-    # Check the image headers
-    header_diff = get_headers_diff([actual_header, expected_header])
+    # the order given here is the order of the two values reported per field, so it is named in the
+    # failure message: working it out from the code costs more than saying it
+    header_diff = get_headers_diff([reference_header, test_header])
     if len(header_diff.keys()) != 0:
         differences = "\n".join(f"  '{k}': {v}" for k, v in header_diff.items())
-        pytest.fail(f"The headers differ in the following header fields:\n{differences}")
+        pytest.fail(
+            f"The headers differ in the following fields, as [reference, test]:\n{differences}"
+        )
+
 
 class Approx:
 


### PR DESCRIPTION
Every dependabot PR got a red quicktest check within seconds, a labelled PR from a fork spent 21 minutes building and then died with no usable message, a declined run reported success without testing anything, and the runs that did complete compared headers in a way that could never pass below 1 mm.

### The workflow
- Dependabot red X. The label gate worked, but  Setup uv and Python  had no  if: , so it ran when the workflow had decided to do nothing and its post step failed the job. Across 8 dependabot runs spanning four months that is the only step any of them fails at. The label decision moves to a job-level  if: , so no runner starts.

- A declined run no longer looks green. Both refusals, fork PR and non-collaborator, printed a reason and exited 0, leaving the build job green with every test job skipped. They now exit 1.

- Fork PRs are refused, not enabled.  pull_request  runs from a fork get no secrets, and must not: the PR's code is built and run in the job that mounts the FreeSurfer licence, and no approval gate changes that. Test a fork contribution by merging its branch into a branch of this repository.

- ` docker-image=pr/<no> ` is removed. It never worked ( ref: pr/868  resolves to nothing), and restricted to this repository it only did what dispatching on the branch already does. Its one distinct capability was running a fork's code with the licence.

- Every checkout is pinned to  `github.sha `. The build job and the test jobs resolved the branch or merge ref separately, twenty minutes apart, so a push in between left the tests on a different commit than the image.

- Concurrency group keyed on  `github.event.ref` , absent from the  pull_request  payload, so all four labels dependabot attaches shared one group and cancelled each other: 78 of 113 PR runs are cancelled.

 - `curl`  had no  `--fail` , so a dead URL stored the error page as the T1 or the reference archive. The URLs and the licence are checked for emptiness first, and the licence now reaches the file via the environment rather than being interpolated into the script.

### The subject directory

The tar of the subject folder was written beside the folder while  upload-artifact  was given the folder itself, so the archive was gzipped and then ignored.  load-processed  now takes the processing from the runner instead of fetching its own artifact back, and  run-tests  no longer checks out a second copy of the repository the job already has, which is also why it is renamed to  `Run quicktest `: it never ran FastSurfer.

### The header comparison
Float fields are compared with a tolerance.  assert_same_headers  delegated to nibabel's  `get_headers_diff `, which compares exactly and takes no tolerance. Below 1 mm the direction cosines are computed rather than snapped, so  Mdc  carries float dust that no rerun reproduces, and every non-1 mm file failed the header check permanently, whatever the reference contained. Measured across the shared `mri/*.mgz ` of both quicktest subjects against a released  cpu-v2.5.4  run:

| subject | field | files | max delta | after |
|---------|-------|-------|-----------|-------|
| 1.0mm |  type  | 3/37 | dtype change | still reported |
| 0.8mm |  Mdc  | 39/39 | 8.842e-18 | accepted |
| 0.8mm |  fov  | 9/39 | 256 | still reported |
| 0.8mm |  type  | 4/39 | dtype change | still reported |

The 0.8mm subject goes from 0 of 39 files passing the header check to 29, and the 10 that still fail do so for the two real reasons. Float fields are relaxed at  `rtol=1e-6, atol=1e-6` ; anything that is not a float array of matching shape keeps the exact comparison, which is what keeps  type  and the 256 mm  fov  gap visible while swallowing 1e-18. (The  fov  differences are the separate bug fixed in #873, and clear once that is released and the reference regenerated.)

The failure message says which header is which. The parameters were named  (expected, actual)  but bound to  (test, reference) , and then swapped again internally. The values reported are unchanged; the message now states that the pair is  [reference, test] .

### Documentation
`test/quicktest/README.md` now records that the reference data is regenerated after every release, which had not been written down anywhere, and that it must come from the released container image rather than a build of the tag, since a build of the tag resolves dependencies again and can pick up newer ones than the release shipped. It also names the variant and settings to use, corrects two environment variables, and the workflow links point at this repository instead of github.com.

### Verification
All YAML parses, every  run:  block passes  bash -n  with the expressions stubbed, and the parse script was exercised across the eight trigger scenarios: accepted paths exit 0 with  CONTINUE=true , and all four declined paths exit non-zero.

The header change adds `test/image/test_quicktest_header_tolerance.py`, 9 tests covering the dust that must pass, a real orientation difference, a  `fov`  gap and a `dtype` change that must all still fail, and the eligibility rule itself. They live in `test/image` because `test/quicktest/conftest.py` requires  `REF_DIR`  and ` SUBJECTS_DIR`  at import, so nothing in that directory is collectable without a reference dataset, while test/image is a matrix entry in `unittest.yaml` and runs on every push. 413 image tests pass, ruff clean.

### Caveat
The workflow pins the composite actions  @dev , so the  run-fastsurfer  and  run-tests  changes take effect only once merged.  fail-fast  is deliberately left on.