### PR TITLE
Remove author tags and dead RCS keywords from the source and ask contributors not to add new ones 

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -5,7 +5,6 @@
 # This action requires an existing uv installation!
 
 name: 'Build a FastSurfer docker image'
-author: 'David Kuegler'
 description: 'Build a FastSurfer image'
 
 inputs:

--- a/.github/actions/load-docker/action.yml
+++ b/.github/actions/load-docker/action.yml
@@ -1,5 +1,4 @@
 name: 'Load a docker image'
-author: 'David Kuegler'
 description: 'Load a docker image from an artifact'
 
 inputs:

--- a/.github/actions/load-processed/action.yml
+++ b/.github/actions/load-processed/action.yml
@@ -1,5 +1,4 @@
 name: 'Load processed data'
-author: 'David Kuegler'
 description: 'Load a docker image from an artifact'
 
 inputs:

--- a/.github/actions/run-fastsurfer/action.yml
+++ b/.github/actions/run-fastsurfer/action.yml
@@ -4,7 +4,6 @@
 # The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
 
 name: 'Run Fastsurfer'
-author: 'David Kuegler'
 description: 'Runs FastSurfer'
 
 inputs:

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -4,7 +4,6 @@
 # The build artifact includes the image in docker-image.tar and the name of the image in image_name.env
 
 name: 'Run Fastsurfer'
-author: 'David Kuegler'
 description: 'Runs FastSurfer'
 
 inputs:

--- a/.github/workflows/quicktest.yaml
+++ b/.github/workflows/quicktest.yaml
@@ -1,9 +1,6 @@
 name: quicktest
 
 # File: quicktest.yaml
-# Author: David Kügler
-# Reworked on: 2024-12-01
-# Created on: 2023-07-10 by Taha Abdullah
 # Functionality: This workflow runs FastSurfer on MRI data and runs pytest to check if the results are acceptable. It
 #  also checks if the FastSurfer environment and output already exist, and if not, it creates them.
 # Usage: This workflow is triggered on a pull request to the dev and main branch. It can also be triggered manually

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,8 +1,6 @@
 name: test
 
 # File: test.yaml
-# Author: David Kügler
-# Created on: 2025-09-08
 # Functionality: This workflow runs unit tests defined in tests/image.
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,15 +109,18 @@ Contributing Code
    uv run --no-project --with ruff ruff check .
    uv run --no-project --with pytest pytest test/shell/test_bash4_lint.py test/shell/test_fs_time.py
    uv run --no-project --with codespell codespell --ignore-words .codespellignore \
-     --check-filenames --check-hidden .
+     --check-filenames --check-hidden \
+     --skip './build,./doc/images,./Tutorial,./.git,./.mypy_cache,./.pytest_cache,./.venv' .
    ```
 
    Ruff is the lint and style check. The shell tests scan the shipped scripts for constructs the
    bash 3.2 that macOS provides does not have, which is easy to break from Linux; the test that
    actually runs them under bash 3.2 needs a macOS machine and runs in CI. Codespell finds typos;
-   it reads untracked files too, so run it on a clean tree or expect noise from your own scratch
-   directories. CI installs these from the `style` extra of `pyproject.toml`, which you can use
-   instead with `uv run --extra style <tool>` if you prefer the pinned versions.
+   the skip list is the one CI uses, and it reads untracked files too, so add any local virtualenv
+   or scratch directory of your own or expect noise from it. Ruff and codespell are also declared
+   in the `style` extra of `pyproject.toml`, so `uv run --extra style <tool>` works as well. CI
+   takes Ruff from that extra, installs pytest on its own, and runs codespell through its own
+   GitHub action.
 
 9. Commit your changes: `git commit -am 'Add some feature'`
 10. Push to the branch to your GitHub: `git push origin my-new-feature`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,32 @@ Contributing Code
    ```
 
 8. Edit the code and implement your changes/features 
+
+   Two things to observe while you do:
+
+   **Do not add inline author tags.** Leave out `@author`, `Author:`, `Created by`, `Created on`,
+   `Modified by` and the like, in new files as well as in files you change. Most files end up with
+   several authors, and git records who wrote each line, so `git log`, `git blame` and the GitHub
+   interface report it accurately; a tag in the file says nothing about the parts somebody else has
+   since rewritten, and nobody remembers to update it.
+
+   **Run the checks before you commit**, so a pull request does not fail on something you can fix in
+   a second. These are the checks CI runs:
+
+   ```bash
+   uv run --no-project --with ruff ruff check .
+   uv run --no-project --with pytest pytest test/shell/test_bash4_lint.py test/shell/test_fs_time.py
+   uv run --no-project --with codespell codespell --ignore-words .codespellignore \
+     --check-filenames --check-hidden .
+   ```
+
+   Ruff is the lint and style check. The shell tests scan the shipped scripts for constructs the
+   bash 3.2 that macOS provides does not have, which is easy to break from Linux; the test that
+   actually runs them under bash 3.2 needs a macOS machine and runs in CI. Codespell finds typos;
+   it reads untracked files too, so run it on a clean tree or expect noise from your own scratch
+   directories. CI installs these from the `style` extra of `pyproject.toml`, which you can use
+   instead with `uv run --extra style <tool>` if you prefer the pinned versions.
+
 9. Commit your changes: `git commit -am 'Add some feature'`
 10. Push to the branch to your GitHub: `git push origin my-new-feature`
 

--- a/CorpusCallosum/paint_cc_into_pred.py
+++ b/CorpusCallosum/paint_cc_into_pred.py
@@ -49,11 +49,6 @@ Dependencies:
 
     Nibabel to read and write FreeSurfer data
     http://nipy.org/nibabel/
-
-Original Author: Leonie Henschel
-Date: Jul-10-2020
-Modified by: Clemens Pollak, David Kügler
-Date: Dec-2025
 """
 
 

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -68,9 +68,6 @@ Dependencies:
     https://www.numpy.org
     Nibabel to read and write FreeSurfer data
     https://nipy.org/nibabel/
-Original Author: Martin Reuter
-Modified by: David Kügler
-Date: May-12-2025
 """
 
 LOGGER = logging.getLogger(__name__)

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -130,7 +130,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version="$Id: conform.py,v 1.0 2025/05/12 15:30:12 mreuter, kueglerd Exp $",
+        version="%(prog)s, part of FastSurfer, see 'run_fastsurfer.sh --version'",
     )
     parser.add_argument(
         "--input", "-i",

--- a/FastSurferCNN/mri_brainvol_stats.py
+++ b/FastSurferCNN/mri_brainvol_stats.py
@@ -58,8 +58,6 @@ Dependencies:
     Pandas to read/write stats files etc.
     https://pandas.pydata.org/
 
-Original Author: David Kügler
-Date: Jan-23-2024
 
 Revision: {VERSION}
 """

--- a/FastSurferCNN/mri_brainvol_stats.py
+++ b/FastSurferCNN/mri_brainvol_stats.py
@@ -21,7 +21,7 @@ from os import environ as env
 from pathlib import Path
 
 from FastSurferCNN.mri_segstats import print_and_exit
-from FastSurferCNN.segstats import VERSION, HelpFormatter, main
+from FastSurferCNN.segstats import HelpFormatter, main
 
 DEFAULT_MEASURES_STRINGS = [
    (False, "BrainSeg"),
@@ -44,7 +44,7 @@ DEFAULT_MEASURES_STRINGS = [
 DEFAULT_MEASURES = list((False, m) for m in DEFAULT_MEASURES_STRINGS)
 
 USAGE = "python mri_brainvol_stats.py -s <subject>"
-HELPTEXT = f"""
+HELPTEXT = """
 Dependencies:
 
     Python 3.10
@@ -58,8 +58,6 @@ Dependencies:
     Pandas to read/write stats files etc.
     https://pandas.pydata.org/
 
-
-Revision: {VERSION}
 """
 DESCRIPTION = """
 Translates mri_brainvol_stats options for segstats.py. Options not listed here have no 

--- a/FastSurferCNN/mri_segstats.py
+++ b/FastSurferCNN/mri_segstats.py
@@ -48,8 +48,6 @@ Dependencies:
     Pandas to read/write stats files etc.
     https://pandas.pydata.org/
 
-Original Author: David Kügler
-Date: Jan-04-2024
 
 Revision: {VERSION}
 """

--- a/FastSurferCNN/mri_segstats.py
+++ b/FastSurferCNN/mri_segstats.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from FastSurferCNN.segstats import (
-    VERSION,
     HelpFormatter,
     add_two_help_messages,
     empty,
@@ -34,7 +33,7 @@ _T = TypeVar("_T")
 
 
 USAGE = "python mri_segstats.py --seg segvol [optional arguments]"
-HELPTEXT = f"""
+HELPTEXT = """
 Dependencies:
 
     Python 3.10
@@ -49,7 +48,6 @@ Dependencies:
     https://pandas.pydata.org/
 
 
-Revision: {VERSION}
 """
 DESCRIPTION = """
 Translates mri_segstats options for segstats.py. Options not listed here have no 
@@ -188,7 +186,7 @@ def make_arguments() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"%(prog)s {VERSION}",
+        version="%(prog)s, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         help="Print the version of the mri_segstats.py script",
     )
     parser.add_argument(

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -64,10 +64,6 @@ Dependencies:
     
     skimage for erosion, dilation, connected component
     https://scikit-image.org/
-
-Original Author: Martin Reuter
-Date: Jul-24-2018
-
 """
 
 h_input = "path to input segmentation"

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -82,7 +82,7 @@ def options_parse():
         Object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id: reduce_to_aseg.py,v 1.0 2018/06/24 11:34:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--input", "-i", dest="input_seg", help=h_input)

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -42,8 +42,7 @@ from FastSurferCNN.utils.parser_defaults import add_arguments
 USAGE = ("python segstats.py (-norm|-pv) <input_norm> -i <input_seg> -o <output_seg_stats> [optional arguments] "
          "[{measures,mri_segstats} ...]")
 DESCRIPTION = "Script to calculate partial volumes and other segmentation statistics of a segmentation file."
-VERSION = "1.1"
-HELPTEXT = f"""
+HELPTEXT = """
 Dependencies:
 
     Python 3.10
@@ -58,7 +57,6 @@ Dependencies:
     https://pandas.pydata.org/
 
 
-Revision: {VERSION}
 """
 FILTER_SIZES = (3, 15)
 COLUMNS = ["Index", "SegId", "NVoxels", "Volume_mm3", "StructName", "Mean", "StdDev", "Min", "Max", "Range"]

--- a/FastSurferCNN/segstats.py
+++ b/FastSurferCNN/segstats.py
@@ -57,9 +57,6 @@ Dependencies:
     Pandas to read/write stats files etc.
     https://pandas.pydata.org/
 
-Original Author: David Kügler
-Date: Dec-30-2022
-Modified: Dec-07-2023
 
 Revision: {VERSION}
 """
@@ -1602,7 +1599,6 @@ def pad_slicer(
         Tuple of slice-objects to go from image to padded patch.
     SlicingTuple
         Tuple of slice-objects to go from padded patch to patch.
-
     """
     # patch start/stop
     _patch = np.asarray([(s.start, s.stop) for s in slicer])
@@ -1646,7 +1642,6 @@ def uniform_filter(
     -------
     _ArrayType
         The filtered data.
-
     """
     _patch = (slice(None),) if slicer_patch is None else slicer_patch
     data = data.astype(float)
@@ -2050,7 +2045,6 @@ def global_stats(
         A tuple of number_of_voxels, number_of_within_robustness_thresholds,
         minimum_intensity, maximum_intensity, sum_of_intensities,
         sum_of_intensity_squares, and border with respect to the label.
-
     """
     def __compute_borders(out: np.ndarray | None) -> np.ndarray:
         # compute/update the border
@@ -2252,7 +2246,6 @@ def pv_calc_patch(
     -------
     dict[int, float]
         Dictionary of per-label PV-corrected volume of affected voxels in the patch.
-
     """
 
     # Variable conventions:

--- a/FastSurferCNN/utils/mapper.py
+++ b/FastSurferCNN/utils/mapper.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Original Author: David Kuegler.
-
-Date: Aug-19-2022
-"""
 
 import json
 import os.path

--- a/brun_fastsurfer.sh
+++ b/brun_fastsurfer.sh
@@ -48,9 +48,6 @@ brun_fastsurfer.sh [...] [--batch "<i>/<n>"] [--parallel <N>|max] [--parallel_se
     [--run_fastsurfer <script to run fastsurfer>] [--statusfile <filename>] [--debug] [--help]
     [<additional run_fastsurfer.sh options>]
 
-Author:   David Kügler, david.kuegler@dzne.de
-Date:     Nov 6, 2023
-Version:  1.0
 License:  Apache License, Version 2.0
 
 Documentation of Options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = 'A fast and accurate deep-learning based neuroimaging pipeline'
 readme = 'README.md'
 license = { file = 'LICENSE' }
 requires-python = '>=3.10'
-authors = [{ name = 'Martin Reuter et al.' }]
+authors = [{ name = 'FastSurfer Developers' }]
 maintainers = [{ name = 'FastSurfer Developers' }]
 keywords = [
     'python',

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -80,12 +80,6 @@ If a brain mask (--mask) is passed, the center is placed at the centroid of the
 brainmask. 
 
 One of --mask, --tal, --aseg must be passed to achieve rescaling.
-
-Original Author: Martin Reuter
-Date: Mar-18-2022
-
-Modified: David Kügler
-Date: Feb-27-2024
 """
 
 HELP_VERBOSITY = "Logging verbosity: 0 (none), 1 (normal), 2 (debug)"

--- a/recon_surf/N4_bias_correct.py
+++ b/recon_surf/N4_bias_correct.py
@@ -222,7 +222,7 @@ def options_parse():
     parser.add_argument(
         "--version",
         action="version",
-        version="$Id: N4_bias_correct.py,v 2.1 2024/02/27 20:02:08 mreuter,dkuegler Exp $"
+        version="%(prog)s, part of FastSurfer, see 'run_fastsurfer.sh --version'"
     )
     return parser.parse_args()
 

--- a/recon_surf/create_annotation.py
+++ b/recon_surf/create_annotation.py
@@ -94,7 +94,7 @@ def options_parse():
         Object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id:create_annotation.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--hemi", dest="hemi", help=h_hemi)

--- a/recon_surf/create_annotation.py
+++ b/recon_surf/create_annotation.py
@@ -64,10 +64,6 @@ will prevail).
 
 Also note, all filenames require full (or relative) path including hemi and filename, e.g.
 --outannot $SUBJECTS_DIR/subjectid/surf/lh.BA_exvivo.annot
-
-
-Original Author: Martin Reuter
-Date: Aug-24-2022
 """
 
 h_hemi = '"lh" or "rh" for reading labels'
@@ -145,7 +141,6 @@ def options_parse():
         )
 
     return options
-
 
 
 def map_multiple_labels(
@@ -271,7 +266,6 @@ def read_multiple_labels(
         all_labels.append(ll)
         all_values.append(vv)
     return all_labels, all_values
-
 
 
 def build_annot(all_labels: npt.ArrayLike, all_values: npt.ArrayLike,

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -79,7 +79,7 @@ def options_parse():
         Namespace object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id:fs_balabels.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--sid", dest="sid", help=h_sid)

--- a/recon_surf/fs_balabels.py
+++ b/recon_surf/fs_balabels.py
@@ -59,9 +59,6 @@ hemisphere it will:
    FreeSurfer's mris_anatomical_stats via command line execution)
 Note, this script needs to be updated if FreeSurfer introduces changes into the -balabel 
 block of recon-all. Currently this is based on FreeSurfer 7.3.2.
-
-Original Author: Martin Reuter
-Date: Aug-31-2022
 """
 
 h_sid = "subject id (name of directory within the subject directory)"
@@ -171,7 +168,6 @@ def parse_version(fs_version_str):
         return tuple(map(int, version_parts))
     except ValueError:
         return fs_version
-
 
 
 if __name__ == "__main__":

--- a/recon_surf/fs_time
+++ b/recon_surf/fs_time
@@ -34,7 +34,7 @@ import sys
 import time
 from datetime import datetime
 
-VERSION = "$Id: fs_time, v2.0 2026/09/02 python Exp $"
+VERSION = "fs_time, part of FastSurfer, see 'run_fastsurfer.sh --version'"
 
 # Fields the kernel does not populate on this platform, reported as "." rather than a misleading 0.
 # macOS never counts block IO or swaps for a child; Linux does count block IO. ru_nswap is

--- a/recon_surf/long_compat_segmentHA.py
+++ b/recon_surf/long_compat_segmentHA.py
@@ -23,7 +23,7 @@ from subprocess import CompletedProcess
 
 import nibabel as nib
 
-VERSION = "1.0 2025-08-18 by kueglerd @ DZNE"
+VERSION = "part of FastSurfer, see 'run_fastsurfer.sh --version'"
 
 
 class FastSurferCompatError(Exception):
@@ -177,7 +177,8 @@ def make_parser() -> argparse.ArgumentParser:
                         help="Set openMP and ITK threads to <int>.")
     parser.add_argument("--fs_license", dest="fs_license", type=validate_existing_file, default=Path("."),
                         help="Path to FreeSurfer license key file.")
-    parser.add_argument("--version", action="version", version=f"long_compat_segmentHA: {VERSION}")
+    parser.add_argument("--version", action="version",
+                        version="%(prog)s, part of FastSurfer, see 'run_fastsurfer.sh --version'")
 
     # Dev flags
     parser.add_argument("--ignore_fs_version", action="store_true",

--- a/recon_surf/map_surf_label.py
+++ b/recon_surf/map_surf_label.py
@@ -43,9 +43,6 @@ Description:
 Computes correspondence between source and target spheres and maps src-label to target.
 Target surf (usually the white) coordinates at label vertices and SID is only written
 to output label and not used for any computations. 
-
-Original Author: Martin Reuter
-Date: Aug-24-2022
 """
 
 

--- a/recon_surf/map_surf_label.py
+++ b/recon_surf/map_surf_label.py
@@ -64,7 +64,7 @@ def options_parse():
         Namespace object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id:map_surf_label.py,v 1.0 2022/08/24 21:22:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--srclabel", dest="srclabel", help=h_srclabel)

--- a/recon_surf/rewrite_mc_surface.py
+++ b/recon_surf/rewrite_mc_surface.py
@@ -31,7 +31,7 @@ def options_parse():
         Namespace object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id: rewrite_mc_surface,v 1.1 2020/06/23 15:42:08 henschell $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage="Function to load and resafe surface under a given name",
     )
     parser.add_option("--input", "-i", dest="input_surf", help="path to input surface")

--- a/recon_surf/rewrite_oriented_surface.py
+++ b/recon_surf/rewrite_oriented_surface.py
@@ -11,16 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# IMPORTS
 import argparse
 import shutil
-
-# IMPORTS
 import sys
 from pathlib import Path
 
 import lapy
-
-__version__ = "1.0"
 
 
 def make_parser() -> argparse.ArgumentParser:
@@ -54,7 +51,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"{__version__} 2024/08/08 12:20:10 kueglerd",
+        version="%(prog)s, part of FastSurfer, see 'run_fastsurfer.sh --version'",
     )
     return parser
 

--- a/recon_surf/rotate_sphere.py
+++ b/recon_surf/rotate_sphere.py
@@ -56,10 +56,6 @@ computed (and mapped back to the sphere of radius 100, FS format). The point pai
 are then aligned by finding the rotation that minimizes their SSD. The output file
 will contain the angles (alpha,beta,gama) as expected by mris_register for rotation
 initialization.
-
-
-Original Author: Martin Reuter
-Date: Jun-8-2022
 """
 
 # In the future, maybe add a way to specify what labels to align as a list or

--- a/recon_surf/rotate_sphere.py
+++ b/recon_surf/rotate_sphere.py
@@ -79,7 +79,7 @@ def options_parse():
         Namespace object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id: rotate_sphere.py,v 1.0 2022/03/18 21:22:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--srcsphere", dest="srcsphere", help=h_srcsphere)

--- a/recon_surf/sample_parc.py
+++ b/recon_surf/sample_parc.py
@@ -45,11 +45,6 @@ Dependencies:
 
     Nibabel to read and write FreeSurfer surface meshes
     http://nipy.org/nibabel/
-
-
-Original Author: Martin Reuter
-Date: Dec-18-2023
-
 """
 
 h_inseg = "path to input segmentation image"

--- a/recon_surf/sample_parc.py
+++ b/recon_surf/sample_parc.py
@@ -67,7 +67,7 @@ def options_parse():
         Namespace object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id: smooth_aparc,v 1.0 2018/06/24 11:34:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--inseg", dest="inseg", help=h_inseg)

--- a/recon_surf/smooth_aparc.py
+++ b/recon_surf/smooth_aparc.py
@@ -40,11 +40,6 @@ Dependencies:
 
     Nibabel to read and write FreeSurfer surface meshes
     http://nipy.org/nibabel/
-
-
-Original Author: Martin Reuter
-Date: Jul-24-2018
-
 """
 
 h_inaparc = "path to input aparc"

--- a/recon_surf/smooth_aparc.py
+++ b/recon_surf/smooth_aparc.py
@@ -58,7 +58,7 @@ def options_parse():
         Namespace object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id: smooth_aparc,v 1.0 2018/06/24 11:34:08 mreuter Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--insurf", dest="insurf", help=h_insurf)

--- a/recon_surf/spherically_project.py
+++ b/recon_surf/spherically_project.py
@@ -75,7 +75,7 @@ def options_parse():
         Object holding options.
     """
     parser = optparse.OptionParser(
-        version="$Id: spherically_project,v 1.1 2017/01/30 20:42:08 ltirrell Exp $",
+        version="%prog, part of FastSurfer, see 'run_fastsurfer.sh --version'",
         usage=HELPTEXT,
     )
     parser.add_option("--input", "-i", dest="input_surf", help=h_input)

--- a/recon_surf/spherically_project.py
+++ b/recon_surf/spherically_project.py
@@ -60,12 +60,6 @@ Dependencies:
 
     Nibabel to read and write FreeSurfer surface meshes
     http://nipy.org/nibabel/
-
-
-Original Author: Martin Reuter
-Date: Jan-18-2016
-
-
 """
 
 h_input = "path to input surface"
@@ -125,7 +119,6 @@ def tria_spherical_project(
     -------
     triamesh
         Triangle Mesh spherically projected.
-
     """
     if not tria.is_closed():
         raise ValueError("Error: Can only project closed meshes!")
@@ -316,7 +309,6 @@ def spherically_project_surface(
         Path to output surface file.
     use_cholmod : bool, default=True
         Try to use the Cholesky decomposition from the cholmod.
-
     """
     surf = fs.read_geometry(insurf, read_metadata=True)
     projected = tria_spherical_project(TriaMesh(surf[0], surf[1]), flow_iter=3, use_cholmod=use_cholmod)

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION='$Id$'
-
 # Set default values for arguments
 if [[ -z "${BASH_SOURCE[0]}" ]]; then THIS_SCRIPT="$0"
 else THIS_SCRIPT="${BASH_SOURCE[0]}"

--- a/srun_fastsurfer.sh
+++ b/srun_fastsurfer.sh
@@ -73,9 +73,6 @@ srun_fastsurfer.sh [--data <directory to search images>]
     [--slurm_jobarray <jobarray specification>] [--skip_cleanup] [--email <email address>] [--debug] [--dry] [--help]
     [<additional fastsurfer options>]
 
-Author:   David Kügler, david.kuegler@dzne.de
-Date:     Nov 3, 2023
-Version:  1.0
 License:  Apache License, Version 2.0
 
 Documentation of Options:

--- a/tools/Docker/Dockerfile
+++ b/tools/Docker/Dockerfile
@@ -64,7 +64,7 @@
 #   - default: "Image Analysis Lab, DZNE https://deep-mi.org/"
 # - AUTHOR:
 #   The author string to include in image labels.
-#   - default: "David Kügler <david.kuegler@dzne.de>"
+#   - default: "FastSurfer Developers <https://github.com/Deep-MI/FastSurfer>"
 # - DEVICE:
 #   The device type to build the python environment for, this affects the installed torch packages.
 #   Supported values are what is supported by uv, e.g.: cu128, xpu, rocm6.2.4, etc.
@@ -100,7 +100,7 @@ ARG GIT_HASH=""
 ARG REPOSITORY_URL="<no repository set>"
 ARG DOC_URL="https://fastsurfer.org/fastsurfer/dev"
 ARG VENDOR="Image Analysis Lab, DZNE https://deep-mi.org/"
-ARG AUTHOR="David Kügler <david.kuegler@dzne.de>"
+ARG AUTHOR="FastSurfer Developers <https://github.com/Deep-MI/FastSurfer>"
 ARG BUILDKIT_SBOM_SCAN_CONTEXT="true"
 ARG DEVICE="cu128"
 ARG DEBUG="false"

--- a/tools/Docker/build.py
+++ b/tools/Docker/build.py
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: David Kuegler
-# June 27th 2023
-# Modified February 2026
 
 import argparse
 import logging

--- a/tools/export_pip-r.sh
+++ b/tools/export_pip-r.sh
@@ -30,8 +30,6 @@ examples:
 export_pip-r.sh $FASTSURFER_HOME/requirements.txt fastsurfer:dev
 export_pip-r.sh $FASTSURFER_HOME/requirements.txt fastsurfer.sif
 
-Created 26-11-2023, David Kügler, Image Analysis Lab,
-German Center for Neurodegenerative Diseases (DZNE), Bonn
 EOF
 }
 


### PR DESCRIPTION
- Takes personal attribution out of the source, and replaces the RCS keywords that were standing in for version strings.
- Author tags  ` @author` ,  Created by ,  Created on  and the like. Git records who wrote each line, so  `git log`  and  `git blame`  report it accurately, while a tag says nothing about the parts somebody else has since rewritten.
 - `$Id:`  keywords git never expanded them, so each one froze at whenever it was typed and several carried a username.
 - Every  `--version ` now names the program and points at  `run_fastsurfer.sh --version` , which reports the real version. 
- Names in metadata,  the Docker maintainer label and the `pyproject.toml` authors field both read "FastSurfer Developers".
- `CONTRIBUTING.md`  asks contributors to leave author tags out, and lists the checks CI runs.
- No behaviour change apart from what ` --version` prints.