### PR TITLE
Write the CC aseg stats as .stats, and drop a skimage call removed in 0.28

### DIFF
--- a/CerebNet/datasets/wm_merge_clean.py
+++ b/CerebNet/datasets/wm_merge_clean.py
@@ -23,7 +23,7 @@ import numpy as np
 from numpy import typing as npt
 from scipy import ndimage
 from skimage.measure import label, regionprops
-from skimage.morphology import binary_dilation
+from skimage.morphology import dilation
 
 NT = TypeVar("NT", bound=Number)
 
@@ -35,9 +35,8 @@ def locating_unknowns(gm_binary, wm_mask):
     selem = ndimage.generate_binary_structure(3, 3)
     wm_binary = np.array(wm_mask, dtype=np.bool)
     # gm_binary = (segmap != 0) ^ wm_binary
-    wm_boundary = binary_dilation(wm_binary, selem) ^ wm_binary
-    # wm_boundary = (binary_dilation(wm_boundary, selem))
-    gm_boundary = binary_dilation(gm_binary, selem) ^ gm_binary
+    wm_boundary = dilation(wm_binary, selem) ^ wm_binary
+    gm_boundary = dilation(gm_binary, selem) ^ gm_binary
     boundary_holes = np.logical_and(wm_boundary, gm_boundary)
     return boundary_holes
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1329,7 +1329,7 @@ then
     # generate file names of for the analysis
     asegdkt_withcc_segfile="$(add_file_suffix "$asegdkt_segfile" "withCC")"
     asegdkt_withcc_vinn_statsfile="$(add_file_suffix "$asegdkt_vinn_statsfile" "withCC")"
-    aseg_auto_statsfile="$(dirname "$aseg_vinn_statsfile")/aseg.auto.mgz"
+    aseg_auto_statsfile="$(add_file_suffix "$aseg_vinn_statsfile" "withCC")"
     callosum_upright_seg="$subject_dir/mri/callosum.CC.upright.mgz"
     callosum_upright_seg_manedit="$(add_file_suffix "$callosum_upright_seg" "manedit")"
     callosum_seg_manedit="$(add_file_suffix "$callosum_seg" "manedit")"


### PR DESCRIPTION
Two unrelated fixes, both turned up by comparing a released  cpu-v2.5.4  run against the quicktest reference data.
 stats/aseg.auto.mgz  was a text file wearing a volume's name. The CC module built the path for its segstats output from the basename of its input segmentation, so a segstats summary landed in  stats/aseg.auto.mgz : 7.8 KB of ASCII beginning  # Title Segmentation Statistics . It now uses  add_file_suffix  like the line directly above it, giving  stats/aseg.VINN.withCC.stats , the withCC counterpart of  aseg.VINN.stats  exactly as  aseg+DKT.VINN.withCC.stats  is of  aseg+DKT.VINN.stats .

Both of those are segmentation module stats, computed from the network output before any surface exists, which is what the  .VINN.  infix marks. The surface corrected  stats/aseg.stats  that  recon-surf.sh  writes is a separate file and is untouched.
The old line had a second defect:  dirname  kept a user's  --aseg_statsfile  directory but overwrote their basename, so this file could not be redirected. It now follows that flag.

Nothing referenced the old name, in expected-files.yaml or anywhere else, and the variable is used only as the  --segstatsfile  argument of that single call.

CerebNet used a skimage call that disappears in 0.28.  skimage.morphology.binary_dilation  is deprecated as of 0.26. It is the same call already fixed in  quick_qc.py , which is why a v2.5.4 run logs the FutureWarning from there. The footprint is  generate_binary_structure(3, 3) , fully symmetric, so the mirroring caveat in the deprecation note does not apply, and  locating_unknowns  was checked to return identical arrays and dtype over five random volumes.
Output impact: one file in  stats/  is renamed, for runs with the CC module and  --biasfield  enabled. No measurement changes. Ruff clean, 77 shell tests pass.