### PR TITLE
Set the fov header field on the .mgz files we write

### DIFF
--- a/CerebNet/datasets/wm_merge_clean.py
+++ b/CerebNet/datasets/wm_merge_clean.py
@@ -25,6 +25,8 @@ from scipy import ndimage
 from skimage.measure import label, regionprops
 from skimage.morphology import dilation
 
+from FastSurferCNN.data_loader.data_utils import as_mgh_image
+
 NT = TypeVar("NT", bound=Number)
 
 
@@ -287,7 +289,7 @@ def save_mgh_image(img_data, save_path, header, affine):
     """
     Save data as mgh image.
     """
-    mgh_out = nib.MGHImage(img_data, header=header, affine=affine)
+    mgh_out = as_mgh_image(img_data, affine, header)
     print(f"Saving {save_path}")
     nib.save(mgh_out, save_path)
 

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -58,6 +58,7 @@ from CorpusCallosum.utils.mapping_helpers import (
 )
 from CorpusCallosum.utils.types import SliceSelection, SubdivisionMethod
 from FastSurferCNN.data_loader.conform import conform, is_conform
+from FastSurferCNN.data_loader.data_utils import as_mgh_image
 from FastSurferCNN.segstats import HelpFormatter
 from FastSurferCNN.utils import (
     AffineMatrix4x4,
@@ -904,7 +905,7 @@ def main(
                 futures.append(
                     thread_executor().submit(
                         nib.save,
-                        nib.MGHImage(cc_fn_softlabels[..., i], fsaverage_midslab_vox2ras, orig.header),
+                        as_mgh_image(cc_fn_softlabels[..., i], fsaverage_midslab_vox2ras, orig.header),
                         sd.filename_by_attribute(f"cc_softlabels_{attr}"),
                     )
                 )
@@ -916,7 +917,7 @@ def main(
             futures.append(
                 thread_executor().submit(
                     nib.save,
-                    nib.MGHImage(cc_fn_seg_labels, fsaverage_midslab_vox2ras, orig.header),
+                    as_mgh_image(cc_fn_seg_labels, fsaverage_midslab_vox2ras, orig.header),
                     _cc_seg_path,
                 )
             )

--- a/CorpusCallosum/paint_cc_into_pred.py
+++ b/CorpusCallosum/paint_cc_into_pred.py
@@ -20,13 +20,12 @@ import sys
 from functools import partial
 from pathlib import Path
 
-import nibabel as nib
 import numpy as np
 from scipy import ndimage
 
 from CorpusCallosum.data.constants import FORNIX_LABEL, SUBSEGMENT_LABELS
 from FastSurferCNN.data_loader.conform import Reorientation, is_conform
-from FastSurferCNN.data_loader.data_utils import load_image
+from FastSurferCNN.data_loader.data_utils import as_mgh_image, load_image
 from FastSurferCNN.reduce_to_aseg import reduce_to_aseg_and_save
 from FastSurferCNN.utils import Mask2d, Mask3d, Shape3d, logging
 from FastSurferCNN.utils.arg_types import path_or_none
@@ -507,7 +506,7 @@ if __name__ == "__main__":
     )
 
     logger.info(f"Writing segmentation with corpus callosum to: {options.output}")
-    pred_with_cc_fin = nib.MGHImage(pred_corrected, aseg_image.affine, aseg_image.header)
+    pred_with_cc_fin = as_mgh_image(pred_corrected, aseg_image.affine, aseg_image.header)
     io_fut = thread_executor().submit(pred_with_cc_fin.to_filename, options.output)
 
     if options.aseg is not None:

--- a/CorpusCallosum/utils/mapping_helpers.py
+++ b/CorpusCallosum/utils/mapping_helpers.py
@@ -8,6 +8,7 @@ from scipy.ndimage import affine_transform
 
 from CorpusCallosum.data.constants import CC_LABEL, FORNIX_LABEL, SUBSEGMENT_LABELS
 from CorpusCallosum.utils.types import Polygon3dType
+from FastSurferCNN.data_loader.data_utils import as_mgh_image
 from FastSurferCNN.utils import (
     AffineMatrix3x3,
     AffineMatrix4x4,
@@ -267,7 +268,7 @@ def apply_transform_to_volume(
         logger.info(f"Saving transformed volume to {output_path}")
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         resampled_typecast = resampled.astype((header if header else orig_image).get_data_dtype())
-        nib.save(nib.MGHImage(resampled_typecast, save_vox2ras, header), output_path)
+        nib.save(as_mgh_image(resampled_typecast, save_vox2ras, header), output_path)
     return resampled
 
 
@@ -392,7 +393,7 @@ def map_softlabels_to_orig(
     if orig_space_segmentation_path is not None:
         logger.info(f"Saving segmentation in original space to {orig_space_segmentation_path}")
         nib.save(
-            nib.MGHImage(seg_orig_space, orig.affine, orig.header),
+            as_mgh_image(seg_orig_space, orig.affine, orig.header),
             orig_space_segmentation_path,
         )
     return seg_orig_space
@@ -456,7 +457,7 @@ def map_hard_segmentation_to_orig(
     output_path.parent.mkdir(exist_ok=True, parents=True)
     logger.info(f"Saving edited segmentation in original space to {output_path}")
     nib.save(
-        nib.MGHImage(output, reference_image.affine, reference_image.header),
+        as_mgh_image(output, reference_image.affine, reference_image.header),
         output_path,
     )
     return output

--- a/FastSurferCNN/data_loader/conform.py
+++ b/FastSurferCNN/data_loader/conform.py
@@ -1103,6 +1103,11 @@ def conform(
     target_header.set_zooms(np.concatenate([target_vox_size, img.header.get_zooms()[3:]], axis=0))
     target_header.set_data_shape(np.concatenate([reorient.target_shape, img.shape[3:]], axis=0))
 
+    if isinstance(target_header, nib.freesurfer.mghformat.MGHHeader):
+        # FreeSurfer keeps the largest of the three extents in fov. MGHHeader defaults it to 0, and
+        # a header converted from a NIfTI, which has no fov, would keep that 0.
+        target_header["fov"] = np.max(np.asarray(reorient.target_shape) * target_vox_size)
+
     if LOGGER.getEffectiveLevel() <= logging.DEBUG:
         with np.printoptions(precision=2, suppress=True):
             from re import sub

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -232,8 +232,41 @@ def load_maybe_conform(
 
         # after conforming, save the conformed file
         save_image(header, affine, data, dst_file)
-        img = nib.MGHImage(data, affine, header)
+        img = as_mgh_image(data, affine, header)
     return dst_file, img, data
+
+
+def as_mgh_image(
+        data: np.ndarray,
+        affine: AffineMatrix4x4,
+        header: _Header | None = None,
+) -> nib.MGHImage:
+    """
+    Build an MGHImage from data, affine and header, and fill in its field of view.
+
+    `MGHHeader` defaults `fov` to 0 and a NIfTI header has no `fov` at all, so writing an .mgz whose
+    header came from a .nii input leaves the field empty. FreeSurfer keeps the largest of the three
+    extents there, which deriving it from `data` also gets right when the header is inherited from a
+    volume of a different shape.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        An array containing image data.
+    affine : AffineMatrix4x4
+        Image affine information.
+    header : _Header, optional
+        Image header information; a non-MGH header is converted.
+
+    Returns
+    -------
+    nib.MGHImage
+        The image, with `fov` set from the data shape and the voxel sizes.
+    """
+    img = nib.MGHImage(data, affine, header)
+    zooms = img.header.get_zooms()
+    img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
+    return img
 
 
 # Save image routine
@@ -267,7 +300,7 @@ def save_image(
     assert valid_ext, f"Output filename does not contain a supported file format {SUPPORTED_OUTPUT_FILE_FORMATS}!"
 
     if save_as.suffix == ".mgz":
-        mgh_img = nib.MGHImage(img_array, affine_info, header_info)
+        mgh_img = as_mgh_image(img_array, affine_info, header_info)
     elif save_as.suffix == ".nii" or save_as.suffixes[-2:] == [".nii", ".gz"]:
         mgh_img = nib.nifti1.Nifti1Pair(img_array, affine_info, header_info)
     else:

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -25,6 +25,7 @@ import scipy.ndimage
 from skimage.filters import gaussian
 from skimage.measure import label
 
+from FastSurferCNN.data_loader.data_utils import as_mgh_image
 from FastSurferCNN.utils import AffineMatrix4x4, ShapeType, logging, nibabelHeader, nibabelImage
 from FastSurferCNN.utils.brainvolstats import mask_in_array
 from FastSurferCNN.utils.logging import setup_logging
@@ -237,7 +238,7 @@ def create_mask_and_save(
     mask_data = create_mask(seg, 5, 4)
     if filename is not None:
         LOGGER.info(f"Outputting mask: {filename}")
-        mask = nib.MGHImage(mask_data, seg_affine, seg_header)
+        mask = as_mgh_image(mask_data, seg_affine, seg_header)
         mask.to_filename(filename)
     return mask_data
 
@@ -253,7 +254,7 @@ def reduce_to_aseg_and_save(
 
     if filename is not None:
         LOGGER.info(f"Outputting aseg: {filename}")
-        mask = nib.MGHImage(_data, seg_affine, seg_header)
+        mask = as_mgh_image(_data, seg_affine, seg_header)
         mask.to_filename(filename)
     return _data
 
@@ -298,7 +299,7 @@ if __name__ == "__main__":
         aseg = flip_wm_islands(aseg)
 
     LOGGER.info(f"Outputting aseg: {options.output_seg}")
-    aseg_fin = nib.MGHImage(aseg, inseg_affine, inseg_header)
+    aseg_fin = as_mgh_image(aseg, inseg_affine, inseg_header)
     aseg_fin.to_filename(options.output_seg)
 
     sys.exit(0)

--- a/recon_surf/image_io.py
+++ b/recon_surf/image_io.py
@@ -69,6 +69,9 @@ def mgh_from_sitk(
         dims = np.hstack((dims, [1]))
     h1["dims"] = dims
     h1["Pxyz_c"] = affine.dot(np.hstack((dims[:3] / 2.0, [1])))[:3]
+    # FreeSurfer keeps the largest of the three extents in fov; MGHHeader defaults it to 0 and a
+    # header converted from a NIfTI has none to inherit
+    h1["fov"] = float(np.max(dims[:3] * h1["delta"]))
     # swap axes as data is stored differently between sITK and Nibabel
     data = np.swapaxes(sitk.GetArrayFromImage(sitk_img), 0, 2)
     # assemble MGHImage from header, image data and affine

--- a/test/image/test_mgh_fov.py
+++ b/test/image/test_mgh_fov.py
@@ -1,0 +1,85 @@
+"""Regression tests for the field-of-view header field of the .mgz files FastSurfer writes.
+
+``MGHHeader`` defaults ``fov`` to 0 and a NIfTI header has no ``fov`` at all, so every .mgz written
+from a NIfTI input carried ``fov=0``, while the files FreeSurfer writes carry the real extent. The
+value pinned here is the one FreeSurfer computes for an MGZ, the largest of the three extents, which
+``mri_info`` reports regardless of what the file stores. These tests cover both the header ``conform``
+builds and one inherited from a volume of a different shape.
+"""
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from FastSurferCNN.data_loader.conform import conform
+from FastSurferCNN.data_loader.data_utils import as_mgh_image, save_image
+
+CUBE_1MM = ((256, 256, 256), (1.0, 1.0, 1.0))
+CUBE_08MM = ((320, 320, 320), (0.8, 0.8, 0.8))
+
+
+def make_image(shape, vox_size, file_type=nib.MGHImage):
+    """An empty image of `shape` at `vox_size`, centred on the origin."""
+    affine = np.diag([*vox_size, 1.0])
+    affine[:3, 3] = [-0.5 * n * v for n, v in zip(shape, vox_size, strict=True)]
+    return file_type(np.zeros(shape, dtype=np.uint8), affine)
+
+
+def max_extent(shape, vox_size):
+    """The largest of the three extents, which is what FreeSurfer stores in fov."""
+    return max(n * v for n, v in zip(shape, vox_size, strict=True))
+
+
+@pytest.mark.parametrize("file_type", [nib.MGHImage, nib.Nifti1Image], ids=["from mgz", "from nifti"])
+@pytest.mark.parametrize(("shape", "vox_size"), [CUBE_1MM, CUBE_08MM], ids=["1.0mm", "0.8mm"])
+def test_conform_sets_fov(file_type, shape, vox_size):
+    """conform fills in fov for an .mgz target, whichever container the source arrived in."""
+    conformed = conform(
+        make_image(shape, vox_size, file_type),
+        vox_size=vox_size[0],
+        img_size="auto",
+        rescale=None,
+        file_type=nib.MGHImage,
+    )
+    assert float(conformed.header["fov"]) == pytest.approx(max_extent(shape, vox_size))
+
+
+def test_conform_to_nifti_has_no_fov():
+    """A NIfTI target has no fov field at all, so conform must leave it alone."""
+    conformed = conform(
+        make_image(*CUBE_1MM),
+        vox_size=1.0,
+        img_size="auto",
+        rescale=None,
+        file_type=nib.Nifti1Image,
+    )
+    assert isinstance(conformed, nib.Nifti1Image)
+    with pytest.raises(ValueError):
+        _ = conformed.header["fov"]
+
+
+def test_save_image_writes_fov(tmp_path):
+    """The 0.8mm path: a NIfTI input conformed in its own container, then written as .mgz."""
+    conformed = conform(make_image(*CUBE_08MM, nib.Nifti1Image), vox_size=0.8, img_size="auto", rescale=None)
+    assert isinstance(conformed, nib.Nifti1Image), "conform keeps the container of its input"
+
+    out_file = tmp_path / "conformed.mgz"
+    save_image(conformed.header, conformed.affine, np.asarray(conformed.dataobj), out_file)
+    assert float(nib.load(out_file).header["fov"]) == pytest.approx(256.0)
+
+
+def test_as_mgh_image_replaces_a_stale_fov():
+    """An inherited header must not keep the parent's fov when the data has another shape.
+
+    This is the corpus callosum slab, written with the header of the full conformed volume.
+    """
+    parent = make_image(*CUBE_08MM)
+    parent.header["fov"] = 256.0
+    slab = as_mgh_image(np.zeros((7, 100, 100), dtype=np.uint8), parent.affine, parent.header)
+    assert float(slab.header["fov"]) == pytest.approx(max_extent((7, 100, 100), (0.8, 0.8, 0.8)))
+
+
+def test_fov_is_the_largest_extent_not_the_first():
+    """The two candidate rules disagree here, and FreeSurfer's mri_info reports 120 for this .mgz."""
+    img = as_mgh_image(np.zeros((40, 200, 80), dtype=np.uint8), np.diag([2.0, 0.5, 1.5, 1.0]))
+    assert float(img.header["fov"]) == pytest.approx(120.0)


### PR DESCRIPTION
Every  .mgz  FastSurfer writes from a NIfTI input carried  fov=0 , where the files FreeSurfer writes carry the real extent.  MGHHeader  defaults the field to 0, and a NIfTI header has no  fov  at all, so there was nothing to inherit when the header was converted.
conform  returns an image in the container the input arrived in, so the trigger is the input format, not the voxel size:
| input | target | conform returns | saved  .mgz  fov |
|-------|--------|-----------------|------------------|
| MGH | 1.0 |  MGHImage  | 256.0 |
| MGH | 0.8 |  MGHImage  | 256.0 |
| NIfTI | 1.0 |  Nifti1Image  | 0.0 |
| NIfTI | 0.8 |  Nifti1Image  | 0.0 |

On a released  cpu-v2.5.4  run, 11 of the 41  mri/*.mgz  of the 0.8mm subject have  fov=0 , against 0 of 39 in the v2.3.3 reference.

The value. FreeSurfer stores the largest of the three extents in an MGZ. Probed on FreeSurfer 7.4.1 with volumes whose extents all differ:
| extents x/y/z |  mri_info  fov | largest | first axis |
|---------------|----------------|---------|------------|
| 100 / 50 / 180 | 180 | yes | no |
| 30 / 30 / 30 | 30 | yes | yes |
| 80 / 100 / 120 | 120 | yes | no |
Note this is per container: the same geometry reports the largest extent as  .mgz  and the first-axis extent as  .nii.gz , so  mri_info  on a NIfTI is not the rule to copy for the files we write.

Where it is set. Two places, rather than at each of the eleven files:
 conform  sets it on the target header, immediately after the target zooms and shape are known. That is the root, since  MGHHeader.from_header(nifti_header)  is where the 0 entered, and it covers the  conform.py  CLI and every conformed output.

A new  as_mgh_image()  in  data_utils  derives it from the data being written, so it is also right when a header is inherited from a volume of a different shape. That case is real:  callosum.CC.upright.mgz  was carrying the parent volume's 256 for a 5 mm wide slab, which is wrong on the 1 mm path too, where nothing was zero.

All MGH write sites now route through one of the two. recon_surf/image_io.py applies the same rule inline, because nothing in recon_surf imports FastSurferCNN and this did not seem the place to start.  sample_parc.py  is untouched, since it builds an image to sample from and never writes it, and HypVINN and  apply_warp  write NIfTI, which has no such field.

Impact. No measurement changes, and no FastSurfer or FreeSurfer result changes: FreeSurfer recomputes fov on read and ignores what is stored, which the probes confirm (a file written with a deliberately wrong  fov=42.0  is still reported as 256). What this fixes is the metadata other tools read, including nibabel-based downstream code and our own header comparison in quicktest.

Header bytes do change in those eleven files per subject, so the quicktest reference will differ and should be regenerated after this is released.

Verification. Checked against FreeSurfer rather than against expectation: a slab written with a stale inherited fov of 256 now writes 80.0, and  mri_info  independently computes 80.000 for that same file. test/image/test_mgh_fov.py adds 8 tests covering conform from both containers at both resolutions, the NIfTI target that must gain no fov, the  save_image  round trip that reproduces the 0.8mm path, the stale-slab recompute, and one that separates the two candidate rules. 412 image tests and 77 shell tests pass, ruff clean.