### PR TITLE
Write .mgz files with the right data type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,47 +6,49 @@ Reporting Bugs
 --------------
 
 ### Before Submitting a Bug Report
+
 Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
 - Determine if you your setup is supported, in particular, check if you are using the correct versions of python
   packages, FreeSurfer, the operating system and drivers. You may use `$FASTSURFER_HOME/run_fastsurfer.sh --version all`
   to get a list of versions of the python packages used by FastSurfer.
-- Search the [Issue Tracker](https://github.com/Deep-MI/FastSurfer/issues?q=is%3Aissue) to see if other users have 
+- Search the [Issue Tracker](https://github.com/Deep-MI/FastSurfer/issues?q=is%3Aissue) to see if other users have
   previously experienced the same issue or similar issues to yours. You may find a solution in a response to an issue
   reported by another user.
 - Collect information about your issue:
-  - Error messages and stack traces (Traceback)
-  - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
-  - FastSurfer installation type: native, Docker, Singularity
-  - Versions of relevant libraries, in particular those reported by `$FASTSURFER_HOME/run_fastsurfer.sh --version all`
-  - How did you run FastSurfer (command and arguments)? 
-  - Your input and output files
-  - Can you reliably reproduce the issue (e.g. on other computers)? And can you also reproduce it with older versions?
+    - Error messages and stack traces (Traceback)
+    - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+    - FastSurfer installation type: native, Docker, Singularity
+    - Versions of relevant libraries, in particular those reported by `$FASTSURFER_HOME/run_fastsurfer.sh --version all`
+    - How did you run FastSurfer (command and arguments)?
+    - Your input and output files
+    - Can you reliably reproduce the issue (e.g. on other computers)? And can you also reproduce it with older versions?
 
 ### How Do I Submit a Good Bug Report?
+
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue in GitHub](https://github.com/Deep-MI/FastSurfer/issues/new). 
-- Select the Issue type that best describes the Issue type you are reporting. "Bugs" describe situations, where the 
-  observed and the intended behavior are different. If you are about the intended behavior, it is best to report the 
+- Open an [Issue in GitHub](https://github.com/Deep-MI/FastSurfer/issues/new).
+- Select the Issue type that best describes the Issue type you are reporting. "Bugs" describe situations, where the
+  observed and the intended behavior are different. If you are about the intended behavior, it is best to report the
   Issue as "Question/Help/Support" and ask about the intended behavior or "Documentation".
-- Closely follow the template format presented to you and answer the questions asked.  
+- Closely follow the template format presented to you and answer the questions asked.
 - In particular, please explain the behavior you would expect and the observed behavior.
-- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to 
-  recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem 
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to
+  recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem
   and create a reduced test case.
 - Provide the information you collected in the previous section.
-- Also provide log files and screenshots as indicated in the template, e.g. `<subject_dir>/scripts/deep-seg.log`, 
+- Also provide log files and screenshots as indicated in the template, e.g. `<subject_dir>/scripts/deep-seg.log`,
   `<subject_dir>/scripts/recon-surf.log`, and `<subject_dir>/scripts/[l/r]h.processing.cmdf.log` (if these exist).
 
 Once it's filed:
 
 - The project team will label the issue accordingly.
-- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no 
-  obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs 
+- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no
+  obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs
   with the `needs-repro` tag will not be addressed until they are reproduced.
-- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as 
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as
   `critical`).
 
 Suggesting Enhancements
@@ -54,17 +56,19 @@ Suggesting Enhancements
 Please follow these guidelines to help maintainers and the community to understand your suggestion for enhancements.
 
 ### Before Submitting an Enhancement
+
 - Make sure that you are using the latest version.
-- Read the documentation carefully and find out if the functionality is already covered, maybe by an individual 
+- Read the documentation carefully and find out if the functionality is already covered, maybe by an individual
   configuration.
 - Perform a [search](https://github.com/Deep-MI/FastSurfer/issues?q=is%3Aissue) to see if the enhancement has already  
   been suggested. If it has, add a comment to the existing issue instead of opening a new one.
-- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to 
-  convince the project's developers of the merits of this feature. Keep in mind that we want features that will be 
-  useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, 
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to
+  convince the project's developers of the merits of this feature. Keep in mind that we want features that will be
+  useful to the majority of our users and not just a small subset. If you're just targeting a minority of users,
   consider writing an add-on/plugin library.
 
 ### How Do I Submit a Good Enhancement Suggestion?
+
 Enhancement suggestions are tracked as [GitHub issues](https://github.com/Deep-MI/FastSurfer/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
@@ -74,7 +78,8 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/Deep-M
 
 Contributing Code
 -----------------
-1. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the 
+
+1. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the
    [official FastSurfer](https://github.com/Deep-MI/FastSurfer) repository to your GitHub account.
 2. Clone your fork to your computer: `git clone https://github.com/<username>/FastSurfer.git`
 3. Change into the project directory: `cd FastSurfer`
@@ -92,18 +97,28 @@ Contributing Code
    git checkout -b my-new-feature
    ```
 
-8. Edit the code and implement your changes/features 
+8. Edit the code and implement your changes/features
 
-   Two things to observe while you do:
+   Four things to observe while you do:
 
    **Do not add inline author tags.** Leave out `@author`, `Author:`, `Created by`, `Created on`,
-   `Modified by` and the like, in new files as well as in files you change. Most files end up with
-   several authors, and git records who wrote each line, so `git log`, `git blame` and the GitHub
-   interface report it accurately; a tag in the file says nothing about the parts somebody else has
-   since rewritten, and nobody remembers to update it.
+   `Modified by` and the like, in new files as well as in files you change. Most files end up with several authors, and
+   git records who wrote each line, so `git log`, `git blame` and the GitHub interface report it accurately; a tag in
+   the file says nothing about the parts somebody else has since rewritten, and nobody remembers to update it.
 
-   **Run the checks before you commit**, so a pull request does not fail on something you can fix in
-   a second. These are the checks CI runs:
+   **Comments describe what the code does now.** Do not write how something used to behave or which bug a line fixes, as
+   in "this used to be stored as float32" or "without this the int16 carries over". State the rule the code follows
+   instead: "probabilities are float, so ask for float". A present fact about a dependency is worth keeping, for example
+   that `MGHHeader.from_header` drops the data type, because it explains why the code exists; the before-and-after is
+   not, because it says nothing about today and grows stale once the bug is out of living memory. That belongs in the
+   commit message, the pull request and the release notes, where it is dated. This applies to docstrings and test
+   docstrings as much as to inline comments.
+
+   **No double hyphens or em dashes in prose.** Not in comments, docstrings, documentation, commit messages or pull
+   request descriptions. Use a comma, a colon or a second sentence.
+
+   **Run the checks before you commit**, so a pull request does not fail on something you can fix in a second. These are
+   the checks CI runs:
 
    ```bash
    uv run --no-project --with ruff ruff check .
@@ -113,31 +128,30 @@ Contributing Code
      --skip './build,./doc/images,./Tutorial,./.git,./.mypy_cache,./.pytest_cache,./.venv' .
    ```
 
-   Ruff is the lint and style check. The shell tests scan the shipped scripts for constructs the
-   bash 3.2 that macOS provides does not have, which is easy to break from Linux; the test that
-   actually runs them under bash 3.2 needs a macOS machine and runs in CI. Codespell finds typos;
-   the skip list is the one CI uses, and it reads untracked files too, so add any local virtualenv
-   or scratch directory of your own or expect noise from it. Ruff and codespell are also declared
-   in the `style` extra of `pyproject.toml`, so `uv run --extra style <tool>` works as well. CI
-   takes Ruff from that extra, installs pytest on its own, and runs codespell through its own
-   GitHub action.
+   Ruff is the lint and style check. The shell tests scan the shipped scripts for constructs the bash 3.2 that macOS
+   provides does not have, which is easy to break from Linux; the test that actually runs them under bash 3.2 needs a
+   macOS machine and runs in CI. Codespell finds typos; the skip list is the one CI uses, and it reads untracked files
+   too, so add any local virtualenv or scratch directory of your own or expect noise from it. Ruff and codespell are
+   also declared in the `style` extra of `pyproject.toml`, so `uv run --extra style <tool>` works as well. CI takes Ruff
+   from that extra, installs pytest on its own, and runs codespell through its own GitHub action.
 
 9. Commit your changes: `git commit -am 'Add some feature'`
 10. Push to the branch to your GitHub: `git push origin my-new-feature`
 
-   ```bash
-   git commit -am 'Add some feature'
-   git push origin my-new-feature
-   ```
+```bash
+git commit -am 'Add some feature'
+git push origin my-new-feature
+```
 
-11. [Create a new pull request on the GitHub web interface](https://github.com/Deep-MI/FastSurfer/compare) from your 
+11. [Create a new pull request on the GitHub web interface](https://github.com/Deep-MI/FastSurfer/compare) from your
     branch into Deep-NI **dev branch** (not into stable): Select "Compare across forks" and then your fork on the right,
     finally, select your `my-new-feature` branch to compare to.
 
 If lots of things changed on the official FastSurfer repository in the meantime or the pull request is showing
 conflicts, these need to be resolved by either rebasing (preferred) or merging.
-    
+
 ### Option 1: Rebasing
+
 Rebasing is preferred, because it leaves a cleaner history of changes. However, rebasing is only possible if you are the
 sole developer collaborating on your branch. To rebase, do the following:
 
@@ -156,8 +170,9 @@ sole developer collaborating on your branch. To rebase, do the following:
     ```
 
 ### Option 2: Merging
-If other people co-develop in the `my-new-feature` branch, rewriting history with a rebase is not possible.
-Instead, you need to merge `upstream/dev` into your branch:
+
+If other people co-develop in the `my-new-feature` branch, rewriting history with a rebase is not possible. Instead, you
+need to merge `upstream/dev` into your branch:
 
 12. Switch into dev branch: `git checkout dev`
 13. Update your dev branch: `git pull upstream dev`
@@ -173,25 +188,26 @@ Instead, you need to merge `upstream/dev` into your branch:
     git push origin my-new-feature
     ```
 
-Either method updates the pull request and resolves conflicts, so that we can merge it once it is complete.
-Once the pull request is merged by us you can delete the feature branch locally and on your fork:
+Either method updates the pull request and resolves conflicts, so that we can merge it once it is complete. Once the
+pull request is merged by us you can delete the feature branch locally and on your fork:
 
 17. Switch into dev branch: `git checkout dev`
 18. Delete feature branch: `git branch -D my-new-feature`
 19. Delete the branch on your GitHub fork either via GUI, or via command line: `git push origin --delete my-new-feature`
 
 This procedure will ensure that your local `dev` branch always follows our `dev` branch and will never diverge. You can,
-once in a while, push the `dev` branch, or similarly update `stable` and push it to your fork (`origin`), but that is 
-not really necessary. 
+once in a while, push the `dev` branch, or similarly update `stable` and push it to your fork (`origin`), but that is
+not really necessary.
 
 Next time you contribute a feature, steps 1-6 above are simpler as you already have a local FastSurfer copy. Simply:
+
 - Switch to dev branch: `git checkout dev`
 - Make sure it is identical to upstream: `git pull upstream dev`
-- Check out a new feature branch and continue from 7. above. 
+- Check out a new feature branch and continue from 7. above.
 
-Another good command, if -- for any reason -- your `dev` branch diverged, which should never happen as you never 
-commit to it, you can reset it by `git reset --hard upstream/dev`. Make absolutely sure you are in your `dev` branch 
-(not the feature branch) and be aware that this will delete any local changes!
+Another good command, if -- for any reason -- your `dev` branch diverged, which should never happen as you never commit
+to it, you can reset it by `git reset --hard upstream/dev`. Make absolutely sure you are in your `dev` branch (not the
+feature branch) and be aware that this will delete any local changes!
 
 Attribution
 -----------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,10 +138,10 @@ Contributing Code
 9. Commit your changes: `git commit -am 'Add some feature'`
 10. Push to the branch to your GitHub: `git push origin my-new-feature`
 
-```bash
-git commit -am 'Add some feature'
-git push origin my-new-feature
-```
+    ```bash
+    git commit -am 'Add some feature'
+    git push origin my-new-feature
+    ```
 
 11. [Create a new pull request on the GitHub web interface](https://github.com/Deep-MI/FastSurfer/compare) from your
     branch into Deep-NI **dev branch** (not into stable): Select "Compare across forks" and then your fork on the right,
@@ -205,7 +205,7 @@ Next time you contribute a feature, steps 1-6 above are simpler as you already h
 - Make sure it is identical to upstream: `git pull upstream dev`
 - Check out a new feature branch and continue from 7. above.
 
-Another good command, if -- for any reason -- your `dev` branch diverged, which should never happen as you never commit
+Another good command, if your `dev` branch diverged for any reason, which should never happen as you never commit
 to it, you can reset it by `git reset --hard upstream/dev`. Make absolutely sure you are in your `dev` branch (not the
 feature branch) and be aware that this will delete any local changes!
 

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -905,7 +905,14 @@ def main(
                 futures.append(
                     thread_executor().submit(
                         nib.save,
-                        as_mgh_image(cc_fn_softlabels[..., i], fsaverage_midslab_vox2ras, orig.header),
+                        # probabilities, written with the header of the conformed image, which is
+                        # uchar and would round them all to 0 or 1
+                        as_mgh_image(
+                            cc_fn_softlabels[..., i],
+                            fsaverage_midslab_vox2ras,
+                            orig.header,
+                            dtype=np.float32,
+                        ),
                         sd.filename_by_attribute(f"cc_softlabels_{attr}"),
                     )
                 )

--- a/CorpusCallosum/fastsurfer_cc.py
+++ b/CorpusCallosum/fastsurfer_cc.py
@@ -905,8 +905,8 @@ def main(
                 futures.append(
                     thread_executor().submit(
                         nib.save,
-                        # probabilities, written with the header of the conformed image, which is
-                        # uchar and would round them all to 0 or 1
+                        # these are probabilities, so ask for float; the header is the conformed
+                        # image's and carries uchar
                         as_mgh_image(
                             cc_fn_softlabels[..., i],
                             fsaverage_midslab_vox2ras,

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -237,6 +237,36 @@ def load_maybe_conform(
     return dst_file, img, data
 
 
+def fits_dtype(array: np.ndarray, dtype: npt.DTypeLike) -> bool:
+    """
+    Whether every value of `array` survives being stored as `dtype`.
+
+    Only integer targets can lose data here: rounding a float into an integer always loses the
+    fraction, and a floating-point target holds any integer we write.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        The data to store.
+    dtype : npt.DTypeLike
+        The type to store it as.
+
+    Returns
+    -------
+    bool
+        False if storing `array` as `dtype` would round or clip a value.
+    """
+    dtype = np.dtype(dtype)
+    if not np.issubdtype(dtype, np.integer):
+        return True
+    if not np.issubdtype(array.dtype, np.integer):
+        return False
+    if np.can_cast(array.dtype, dtype):
+        return True
+    limits = np.iinfo(dtype)
+    return array.size == 0 or bool(limits.min <= array.min() and array.max() <= limits.max)
+
+
 def as_mgh_image(
         data: np.ndarray,
         affine: AffineMatrix4x4,
@@ -252,8 +282,10 @@ def as_mgh_image(
     which is what FreeSurfer keeps, and deriving it from `data` also gets it right when the header
     is inherited from a volume of a different shape.
 
-    Floating-point data is never stored as an integer type, whatever the header says, since that
-    would round it away. Pass `dtype` to `save_image` where a narrower type really is wanted.
+    The type is only ever widened, never narrowed past what the data holds: floating-point data is
+    not stored as an integer type, and neither is a value the header's type cannot represent, since
+    both lose data silently. Callers that really want a narrower type, because they know the data
+    fits it, set it on the returned image, as `reduce_to_aseg` does for the uchar aseg files.
 
     Parameters
     ----------
@@ -276,11 +308,17 @@ def as_mgh_image(
     zooms = img.header.get_zooms()
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
 
-    data_dtype = array.dtype if header is None else header.get_data_dtype()
-    # an integer type would round floating-point data away, as it did to the CC soft labels, which
-    # are probabilities written with the header of the conformed image
+    data_dtype = np.dtype(array.dtype if header is None else header.get_data_dtype())
     if np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer):
+        # an integer type would round floating-point data away, as it did to the CC soft labels,
+        # which are probabilities written with the header of the conformed image
         data_dtype = np.dtype(np.float32)
+    elif not fits_dtype(array, data_dtype):
+        # a header narrower than its data would clip it, silently
+        LOGGER.warning(
+            f"The data does not fit {data_dtype}, writing {array.dtype} instead to avoid clipping."
+        )
+        data_dtype = array.dtype
     try:
         img.set_data_dtype(data_dtype)
     except MGHError:
@@ -329,7 +367,15 @@ def save_image(
         raise ValueError(f"Invalid file extension of {save_as}, must be .mgz, .nii or .nii.gz!")
 
     if dtype is not None:
-        mgh_img.set_data_dtype(dtype)
+        # an explicit dtype is the caller's decision, so it is applied as given, but it falls back
+        # like the inferred one rather than aborting the run
+        try:
+            mgh_img.set_data_dtype(dtype)
+        except MGHError:
+            LOGGER.warning(
+                f"An MGH file cannot store {np.dtype(dtype)}, writing {mgh_img.get_data_dtype()} "
+                f"instead."
+            )
 
     if save_as.suffix in (".mgz", ".nii"):
         nib.save(mgh_img, save_as)

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -252,6 +252,9 @@ def as_mgh_image(
     which is what FreeSurfer keeps, and deriving it from `data` also gets it right when the header
     is inherited from a volume of a different shape.
 
+    Floating-point data is never stored as an integer type, whatever the header says, since that
+    would round it away. Pass `dtype` to `save_image` where a narrower type really is wanted.
+
     Parameters
     ----------
     data : np.ndarray
@@ -274,17 +277,17 @@ def as_mgh_image(
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
 
     data_dtype = array.dtype if header is None else header.get_data_dtype()
-    # an integer header would truncate floating-point data, such as the soft labels the CC module
-    # writes with the header of the conformed image, so leave those to nibabel
-    truncates = np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer)
-    if not truncates:
-        try:
-            img.set_data_dtype(data_dtype)
-        except MGHError:
-            # MGH stores uint8, uint16, int16, int32 and float32 only
-            LOGGER.warning(
-                f"An MGH file cannot store {data_dtype}, writing {img.get_data_dtype()} instead."
-            )
+    # an integer type would round floating-point data away, as it did to the CC soft labels, which
+    # are probabilities written with the header of the conformed image
+    if np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer):
+        data_dtype = np.dtype(np.float32)
+    try:
+        img.set_data_dtype(data_dtype)
+    except MGHError:
+        # MGH stores uint8, uint16, int16, int32 and float32 only
+        LOGGER.warning(
+            f"An MGH file cannot store {data_dtype}, writing {img.get_data_dtype()} instead."
+        )
     return img
 
 

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -43,6 +43,8 @@ from FastSurferCNN.utils import AffineMatrix4x4, Shape1d, logging, nibabelImage
 # Global Vars
 ##
 SUPPORTED_OUTPUT_FILE_FORMATS = ("mgz", "nii", "nii.gz")
+# the integer types an MGH file can store, narrowest first, so the first that fits is the choice
+MGH_INT_DTYPES = (np.uint8, np.uint16, np.int16, np.int32)
 LOGGER = logging.getLogger(__name__)
 
 ##
@@ -241,8 +243,10 @@ def fits_dtype(array: np.ndarray, dtype: npt.DTypeLike) -> bool:
     """
     Whether every value of `array` survives being stored as `dtype`.
 
-    Only integer targets can lose data here: rounding a float into an integer always loses the
-    fraction, and a floating-point target holds any integer we write.
+    Only integer targets are checked, since that is where this pipeline loses data: a float rounded
+    into an integer loses its fraction, and a label outside the range is clipped. A floating-point
+    target is reported as fitting, which ignores the precision a very large integer or a float64
+    would lose, because MGH offers nothing wider than float32 to move it to.
 
     Parameters
     ----------
@@ -271,6 +275,7 @@ def as_mgh_image(
         data: np.ndarray,
         affine: AffineMatrix4x4,
         header: _Header | None = None,
+        prefer_dtype: npt.DTypeLike | None = None,
 ) -> nib.MGHImage:
     """
     Build an MGHImage from data, affine and header, keeping what the conversion would drop.
@@ -282,10 +287,9 @@ def as_mgh_image(
     which is what FreeSurfer keeps, and deriving it from `data` also gets it right when the header
     is inherited from a volume of a different shape.
 
-    The type is only ever widened, never narrowed past what the data holds: floating-point data is
-    not stored as an integer type, and neither is a value the header's type cannot represent, since
-    both lose data silently. Callers that really want a narrower type, because they know the data
-    fits it, set it on the returned image, as `reduce_to_aseg` does for the uchar aseg files.
+    The type is never narrowed past what the data holds: floating-point data is not stored as an
+    integer type, and neither is a value the header's type cannot represent, since both lose data
+    silently. Where the header does not fit, the narrowest type MGH can store that does is used.
 
     Parameters
     ----------
@@ -295,6 +299,10 @@ def as_mgh_image(
         Image affine information.
     header : _Header, optional
         Image header information; a non-MGH header is converted.
+    prefer_dtype : npt.DTypeLike, optional
+        A narrower type to use if the data fits it, for callers who know what their output should
+        be, such as the uchar aseg files. Ignored when it would round or clip a value, so it cannot
+        be used to force a lossy type; `save_image` takes a `dtype` for that.
 
     Returns
     -------
@@ -309,16 +317,20 @@ def as_mgh_image(
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
 
     data_dtype = np.dtype(array.dtype if header is None else header.get_data_dtype())
-    if np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer):
+    if prefer_dtype is not None and fits_dtype(array, prefer_dtype):
+        data_dtype = np.dtype(prefer_dtype)
+    elif np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer):
         # an integer type would round floating-point data away, as it did to the CC soft labels,
         # which are probabilities written with the header of the conformed image
         data_dtype = np.dtype(np.float32)
     elif not fits_dtype(array, data_dtype):
-        # a header narrower than its data would clip it, silently
-        LOGGER.warning(
-            f"The data does not fit {data_dtype}, writing {array.dtype} instead to avoid clipping."
+        # a header narrower than its data would clip it, silently. Widening to the array's own type
+        # is not enough: MGH cannot store int64, and falling back would clip after all.
+        wider = next(
+            (np.dtype(t) for t in MGH_INT_DTYPES if fits_dtype(array, t)), np.dtype(np.float32)
         )
-        data_dtype = array.dtype
+        LOGGER.warning(f"The data does not fit {data_dtype}, writing {wider} instead to avoid clipping.")
+        data_dtype = wider
     try:
         img.set_data_dtype(data_dtype)
     except MGHError:
@@ -367,8 +379,10 @@ def save_image(
         raise ValueError(f"Invalid file extension of {save_as}, must be .mgz, .nii or .nii.gz!")
 
     if dtype is not None:
-        # an explicit dtype is the caller's decision, so it is applied as given, but it falls back
-        # like the inferred one rather than aborting the run
+        # an explicit dtype is the caller's decision, so it is applied as given even where it loses
+        # data, but it says so, and it falls back like the inferred one rather than aborting the run
+        if not fits_dtype(np.asanyarray(img_array), dtype):
+            LOGGER.warning(f"The data does not fit the requested {np.dtype(dtype)}, values will clip.")
         try:
             mgh_img.set_data_dtype(dtype)
         except MGHError:

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -25,7 +25,7 @@ import pandas as pd
 import scipy.ndimage.morphology as morphology
 import torch
 from nibabel.filebasedimages import FileBasedHeader as _Header
-from nibabel.freesurfer.mghformat import MGHError
+from nibabel.freesurfer.mghformat import MGHError, MGHHeader
 from numpy import typing as npt
 from scipy.ndimage import (
     binary_closing,
@@ -266,12 +266,18 @@ def as_mgh_image(
     nib.MGHImage
         The image, with `fov` and the data type set.
     """
-    img = nib.MGHImage(data, affine, header)
+    array = np.asanyarray(data)
+    # without a header, nibabel raises while constructing an image whose type MGH cannot store, so
+    # give it a default one and settle the type below, where the fallback is
+    img = nib.MGHImage(array, affine, MGHHeader() if header is None else header)
     zooms = img.header.get_zooms()
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
 
-    if header is not None:
-        data_dtype = header.get_data_dtype()
+    data_dtype = array.dtype if header is None else header.get_data_dtype()
+    # an integer header would truncate floating-point data, such as the soft labels the CC module
+    # writes with the header of the conformed image, so leave those to nibabel
+    truncates = np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer)
+    if not truncates:
         try:
             img.set_data_dtype(data_dtype)
         except MGHError:

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -25,6 +25,7 @@ import pandas as pd
 import scipy.ndimage.morphology as morphology
 import torch
 from nibabel.filebasedimages import FileBasedHeader as _Header
+from nibabel.freesurfer.mghformat import MGHError
 from numpy import typing as npt
 from scipy.ndimage import (
     binary_closing,
@@ -242,12 +243,14 @@ def as_mgh_image(
         header: _Header | None = None,
 ) -> nib.MGHImage:
     """
-    Build an MGHImage from data, affine and header, and fill in its field of view.
+    Build an MGHImage from data, affine and header, keeping what the conversion would drop.
 
-    `MGHHeader` defaults `fov` to 0 and a NIfTI header has no `fov` at all, so writing an .mgz whose
-    header came from a .nii input leaves the field empty. FreeSurfer keeps the largest of the three
-    extents there, which deriving it from `data` also gets right when the header is inherited from a
-    volume of a different shape.
+    `MGHHeader.from_header` carries neither the field of view nor the data type over from a non-MGH
+    header, so an .mgz written with a header that came from a .nii ended up with `fov=0` and stored
+    as float32, whatever the data or the caller asked for. Both are restored here, so the file does
+    not depend on the container its header came from. The fov is the largest of the three extents,
+    which is what FreeSurfer keeps, and deriving it from `data` also gets it right when the header
+    is inherited from a volume of a different shape.
 
     Parameters
     ----------
@@ -261,11 +264,21 @@ def as_mgh_image(
     Returns
     -------
     nib.MGHImage
-        The image, with `fov` set from the data shape and the voxel sizes.
+        The image, with `fov` and the data type set.
     """
     img = nib.MGHImage(data, affine, header)
     zooms = img.header.get_zooms()
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
+
+    if header is not None:
+        data_dtype = header.get_data_dtype()
+        try:
+            img.set_data_dtype(data_dtype)
+        except MGHError:
+            # MGH stores uint8, uint16, int16, int32 and float32 only
+            LOGGER.warning(
+                f"An MGH file cannot store {data_dtype}, writing {img.get_data_dtype()} instead."
+            )
     return img
 
 

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -25,6 +25,8 @@ import pandas as pd
 import scipy.ndimage.morphology as morphology
 import torch
 from nibabel.filebasedimages import FileBasedHeader as _Header
+from nibabel.freesurfer.mghformat import MGHError
+from nibabel.spatialimages import HeaderDataError
 from numpy import typing as npt
 from scipy.ndimage import (
     binary_closing,
@@ -287,18 +289,17 @@ def choose_dtype(
         array: np.ndarray,
         header: _Header,
         dtype: npt.DTypeLike | None = None,
-        candidates: tuple[npt.DTypeLike, ...] = MGH_DTYPES,
 ) -> np.dtype:
     """
     The type to store `array` as: `dtype` if the caller gave one, else the header's.
 
-    That type is used or nothing is: it may not lose data, and the output format has to be able to
-    store it. Narrowing that would round or clip is the caller's to do, deliberately and outside,
-    because only the caller knows whether to cast, to rescale or to refuse. `storable_dtype` is how
-    a caller with no type of its own asks for the closest the format offers.
+    That type is used or nothing is. It may not lose data: narrowing that would round or clip is the
+    caller's to do, deliberately and outside, because only the caller knows whether to cast, to
+    rescale or to refuse.
 
-    The byte order is dropped, because the output format decides it: an MGH file is always
-    big-endian, whatever type it stores.
+    Whether the type can be stored at all is the output format's answer, not this function's, so it
+    is asked when the type is applied. The byte order is dropped here for the same reason: an MGH
+    file is always big-endian, whatever type it stores.
 
     Parameters
     ----------
@@ -308,8 +309,6 @@ def choose_dtype(
         The header, whose type is used when `dtype` is None.
     dtype : npt.DTypeLike, optional
         The type to store, overriding the header's.
-    candidates : tuple of npt.DTypeLike, default=MGH_DTYPES
-        Every type the output format can store.
 
     Returns
     -------
@@ -319,8 +318,7 @@ def choose_dtype(
     Raises
     ------
     ValueError
-        If storing `array` as that type would round or clip a value, or if the output format cannot
-        store it at all.
+        If storing `array` as that type would round or clip a value.
     """
     wanted = np.dtype(header.get_data_dtype() if dtype is None else dtype).newbyteorder("=")
     if not fits_dtype(array, wanted):
@@ -331,13 +329,24 @@ def choose_dtype(
             f"be {'clipped' if both_integer else 'rounded'}. Convert the data before saving if that "
             f"is what you want."
         )
-    if wanted not in tuple(np.dtype(c) for c in candidates):
-        offered = ", ".join(np.dtype(c).name for c in candidates)
-        raise ValueError(
-            f"The output format cannot store {wanted}, only {offered}. Name a type it can store, "
-            f"write the image in a format that can, or call storable_dtype to pick the closest one."
-        )
     return wanted
+
+
+def _set_dtype(img: nibabelImage, wanted: np.dtype, offered: tuple[npt.DTypeLike, ...]) -> None:
+    """
+    Store `wanted` in the image header, or say what the format can hold instead.
+
+    The format is the authority on what it accepts, so it is asked rather than checked against a
+    list; `offered` only names the alternatives in the message.
+    """
+    try:
+        img.set_data_dtype(wanted)
+    except (MGHError, HeaderDataError) as error:
+        raise ValueError(
+            f"The output format cannot store {wanted}, only "
+            f"{', '.join(np.dtype(c).name for c in offered)}. Name a type it can store, write the "
+            f"image in a format that can, or call storable_dtype to pick the closest one."
+        ) from error
 
 
 def storable_dtype(
@@ -410,9 +419,9 @@ def as_mgh_image(
     affine : AffineMatrix4x4
         Image affine information.
     header : _Header
-        Image header information; a non-MGH header is converted. Required: the affine covers the
-        geometry, but the header is the only carrier of the acquisition parameters and of the type
-        to store, so a caller with no source image has to say so by passing an `MGHHeader()`.
+        Image header information; a non-MGH header is converted. Required, because every image we
+        write is derived from one we read, and the header is the only carrier of the acquisition
+        parameters and of the type to store.
     dtype : npt.DTypeLike, optional
         The type to store, overriding the one the header carries. Neither may lose data nor be one
         MGH cannot store, see `choose_dtype`.
@@ -423,12 +432,12 @@ def as_mgh_image(
         The image, with `fov` and the data type set.
     """
     array = np.asanyarray(data)
-    # before building anything, so a request that cannot be honoured fails where it was made
-    wanted = choose_dtype(array, header, dtype, MGH_DTYPES)
+    # before building anything, so a request that loses data fails where it was made
+    wanted = choose_dtype(array, header, dtype)
     img = nib.MGHImage(array, affine, header)
     zooms = img.header.get_zooms()
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
-    img.set_data_dtype(wanted)
+    _set_dtype(img, wanted, MGH_DTYPES)
     return img
 
 
@@ -471,22 +480,22 @@ def save_image(
     available at all: MGH has no float64 and no int64, NIfTI has both.
     """
     save_as = Path(save_as)
-    valid_ext = save_as.suffix[1:] in SUPPORTED_OUTPUT_FILE_FORMATS or save_as.suffixes[-2:] == [".nii", ".gz"]
-    assert valid_ext, f"Output filename does not contain a supported file format {SUPPORTED_OUTPUT_FILE_FORMATS}!"
-
     array = np.asanyarray(img_array)
     if save_as.suffix == ".mgz":
         img = as_mgh_image(array, affine_info, header_info, dtype)
     elif save_as.suffix == ".nii" or save_as.suffixes[-2:] == [".nii", ".gz"]:
-        wanted = choose_dtype(array, header_info, dtype, NIFTI_DTYPES)
+        wanted = choose_dtype(array, header_info, dtype)
         img = nib.nifti1.Nifti1Pair(array, affine_info, header_info)
-        img.set_data_dtype(wanted)
+        _set_dtype(img, wanted, NIFTI_DTYPES)
         if np.issubdtype(wanted, np.integer):
             # left free, nibabel is entitled to add a scale factor of its own, and a label read back
             # through one is no longer the integer it was written as
             img.header.set_slope_inter(1, 0)
     else:
-        raise ValueError(f"Invalid file extension of {save_as}, must be .mgz, .nii or .nii.gz!")
+        raise ValueError(
+            f"Invalid file extension of {save_as}, must be one of "
+            f"{SUPPORTED_OUTPUT_FILE_FORMATS}!"
+        )
 
     if save_as.suffix in (".mgz", ".nii"):
         nib.save(img, save_as)

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -25,7 +25,6 @@ import pandas as pd
 import scipy.ndimage.morphology as morphology
 import torch
 from nibabel.filebasedimages import FileBasedHeader as _Header
-from nibabel.freesurfer.mghformat import MGHError, MGHHeader
 from numpy import typing as npt
 from scipy.ndimage import (
     binary_closing,
@@ -43,10 +42,13 @@ from FastSurferCNN.utils import AffineMatrix4x4, Shape1d, logging, nibabelImage
 # Global Vars
 ##
 SUPPORTED_OUTPUT_FILE_FORMATS = ("mgz", "nii", "nii.gz")
-# the integer types to fall back on, narrowest first, so the first that fits is the choice. MGH can
-# also store uint16, but FreeSurfer writes none itself, so int32 is preferred over an odd-looking
-# file; a header that asks for uint16 is still honoured.
-MGH_INT_DTYPES = (np.uint8, np.int16, np.int32)
+# Every type each output format can store. Asking for one outside its own list is refused rather
+# than answered with a substitute, so these have to be complete and not a preference.
+MGH_DTYPES = (np.uint8, np.uint16, np.int16, np.int32, np.float32)
+NIFTI_DTYPES = (
+    np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32, np.uint64, np.int64,
+    np.float32, np.float64,
+)
 LOGGER = logging.getLogger(__name__)
 
 ##
@@ -245,10 +247,11 @@ def fits_dtype(array: np.ndarray, dtype: npt.DTypeLike) -> bool:
     """
     Whether every value of `array` survives being stored as `dtype`.
 
-    Only integer targets are checked, since that is where this pipeline loses data: a float rounded
-    into an integer loses its fraction, and a label outside the range is clipped. A floating-point
-    target is reported as fitting, which ignores the precision a very large integer or a float64
-    would lose, because MGH offers nothing wider than float32 to move it to.
+    An integer loses its identity as surely by being rounded into a float as by being clipped, so a
+    float target holds integers only as far as it counts exactly: 2**24 for float32, 2**53 for
+    float64. Narrowing a value that was already floating-point is not counted, because that is a
+    measurement losing digits rather than a label becoming a different label, and it only arises
+    where the output format has left nothing wider to move to.
 
     Parameters
     ----------
@@ -263,67 +266,142 @@ def fits_dtype(array: np.ndarray, dtype: npt.DTypeLike) -> bool:
         False if storing `array` as `dtype` would round or clip a value.
     """
     dtype = np.dtype(dtype)
+    # a bool counts as an integer here: it is 0 or 1, which every numeric type stores exactly
+    array_is_integer = np.issubdtype(array.dtype, np.integer) or array.dtype == np.bool_
+    if np.issubdtype(dtype, np.floating):
+        if not array_is_integer:
+            return True
+        # the mantissa plus its implied leading bit, so every integer up to here is exact
+        exact = 2 ** (np.finfo(dtype).nmant + 1)
+        return array.size == 0 or bool(-exact <= int(array.min()) and int(array.max()) <= exact)
     if not np.issubdtype(dtype, np.integer):
         return True
-    if not np.issubdtype(array.dtype, np.integer):
+    if not array_is_integer:
         return False
     if np.can_cast(array.dtype, dtype):
         return True
     limits = np.iinfo(dtype)
-    return array.size == 0 or bool(limits.min <= array.min() and array.max() <= limits.max)
+    return array.size == 0 or bool(limits.min <= int(array.min()) and int(array.max()) <= limits.max)
 
 
 def choose_dtype(
         array: np.ndarray,
-        header_dtype: npt.DTypeLike,
-        prefer_dtype: npt.DTypeLike | None = None,
+        header: _Header,
+        dtype: npt.DTypeLike | None = None,
+        candidates: tuple[npt.DTypeLike, ...] = MGH_DTYPES,
 ) -> np.dtype:
     """
-    The type to store `array` as, never one that would round or clip a value.
+    The type to store `array` as: `dtype` if the caller gave one, else the header's.
 
-    `header_dtype` is what the header asks for, and is used where it holds the data. Where it does
-    not, the narrowest type MGH can store that does is used instead: widening to the array's own
-    type is not enough, since MGH has no int64 and the write would fall back and clip after all.
+    That type is used or nothing is: it may not lose data, and the output format has to be able to
+    store it. Neither is guessed around. Narrowing that would round or clip is the caller's to do,
+    deliberately and outside, because only the caller knows whether the right answer is to cast, to
+    rescale or to refuse. Substituting a type the format does happen to offer would be a guess of
+    the same kind, and a float answered with an integer is not a smaller version of the request but
+    a different file; `storable_dtype` is how a caller asks for that on purpose.
+
+    The byte order is dropped, because the output format decides it: an MGH file is always
+    big-endian, whatever type it stores.
 
     Parameters
     ----------
     array : np.ndarray
         The data to store.
-    header_dtype : npt.DTypeLike
-        The type the header asks for.
-    prefer_dtype : npt.DTypeLike, optional
-        A narrower type to use if the data fits it, ignored otherwise.
+    header : _Header
+        The header, whose type is used when `dtype` is None.
+    dtype : npt.DTypeLike, optional
+        The type to store, overriding the header's.
+    candidates : tuple of npt.DTypeLike, default=MGH_DTYPES
+        Every type the output format can store.
 
     Returns
     -------
     np.dtype
-        The type to write.
-    """
-    header_dtype = np.dtype(header_dtype)
-    if prefer_dtype is not None and fits_dtype(array, prefer_dtype):
-        return np.dtype(prefer_dtype)
-    if np.issubdtype(array.dtype, np.floating) and np.issubdtype(header_dtype, np.integer):
-        # an integer type would round floating-point data away, as it did to the CC soft labels,
-        # which are probabilities written with the header of the conformed image
-        return np.dtype(np.float32)
-    if fits_dtype(array, header_dtype):
-        return header_dtype
+        The type to write, in native byte order.
 
-    # integer data the header cannot hold; the range is read once, not once per candidate
-    low, high = (int(array.min()), int(array.max())) if array.size else (0, 0)
-    wider = next(
-        (np.dtype(t) for t in MGH_INT_DTYPES if np.iinfo(t).min <= low and high <= np.iinfo(t).max),
-        np.dtype(np.float32),
+    Raises
+    ------
+    ValueError
+        If storing `array` as that type would round or clip a value, or if the output format cannot
+        store it at all.
+    """
+    wanted = np.dtype(header.get_data_dtype() if dtype is None else dtype).newbyteorder("=")
+    if not fits_dtype(array, wanted):
+        source = "requested" if dtype is not None else "carried by the header"
+        raise ValueError(
+            f"Refusing to store {array.dtype} data as the {wanted} {source}, because values would "
+            f"be {_damage(array, wanted)}. Convert the data before saving if that is what you want."
+        )
+    if wanted not in tuple(np.dtype(c) for c in candidates):
+        offered = ", ".join(np.dtype(c).name for c in candidates)
+        raise ValueError(
+            f"The output format cannot store {wanted}, only {offered}. Name a type it can store, "
+            f"write the image in a format that can, or call storable_dtype to pick the closest one."
+        )
+    return wanted
+
+
+def _damage(array: np.ndarray, dtype: np.dtype) -> str:
+    """What storing `array` as `dtype` would do to it, for the message that refuses to."""
+    both_integer = np.issubdtype(array.dtype, np.integer) and np.issubdtype(dtype, np.integer)
+    return "clipped" if both_integer else "rounded"
+
+
+def storable_dtype(
+        array: np.ndarray,
+        candidates: tuple[npt.DTypeLike, ...] = MGH_DTYPES,
+) -> np.dtype:
+    """
+    The array's own type if the output format can store it, else the closest one that holds it.
+
+    For an output whose type is not ours to choose. That is `mri/orig/001.mgz`, the archival copy of
+    whatever the scanner or the conversion tool produced, and nothing else: every other output has a
+    type that belongs to the output rather than to the input, so its caller names it and
+    `choose_dtype` refuses anything that does not fit.
+
+    Closest means the same kind first, so a float is never answered with an integer and signed data
+    stays signed, and within the kind the narrowest that holds every value. An MGH file has no
+    float64, so a float64 input is archived as float32; that loss is the reason a copy of the input
+    is better kept in the format it arrived in, which is a decision above this function.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        The data to store.
+    candidates : tuple of npt.DTypeLike, default=MGH_DTYPES
+        Every type the output format can store.
+
+    Returns
+    -------
+    np.dtype
+        The type to write, in native byte order.
+
+    Raises
+    ------
+    ValueError
+        If nothing the format can store holds `array`.
+    """
+    own = np.dtype(array.dtype).newbyteorder("=")
+    offered = tuple(np.dtype(c) for c in candidates)
+    if own in offered:
+        return own
+    by_width = sorted(offered, key=lambda c: (c.itemsize, c.kind))
+    same_kind = [c for c in by_width if c.kind == own.kind]
+    for group in (same_kind, by_width):
+        for candidate in group:
+            if fits_dtype(array, candidate):
+                return candidate
+    raise ValueError(
+        f"The output format cannot store {own}, and none of the types it does store "
+        f"({', '.join(c.name for c in offered)}) holds this data. Write it in a format that can."
     )
-    LOGGER.warning(f"The data does not fit {header_dtype}, writing {wider} instead to avoid clipping.")
-    return wider
 
 
 def as_mgh_image(
         data: np.ndarray,
         affine: AffineMatrix4x4,
-        header: _Header | None = None,
-        prefer_dtype: npt.DTypeLike | None = None,
+        header: _Header,
+        dtype: npt.DTypeLike | None = None,
 ) -> nib.MGHImage:
     """
     Build an MGHImage from data, affine and header, keeping what the conversion would drop.
@@ -335,22 +413,19 @@ def as_mgh_image(
     which is what FreeSurfer keeps, and deriving it from `data` also gets it right when the header
     is inherited from a volume of a different shape.
 
-    The type is never narrowed past what the data holds: floating-point data is not stored as an
-    integer type, and neither is a value the header's type cannot represent, since both lose data
-    silently. Where the header does not fit, the narrowest type MGH can store that does is used.
-
     Parameters
     ----------
     data : np.ndarray
         An array containing image data.
     affine : AffineMatrix4x4
         Image affine information.
-    header : _Header, optional
-        Image header information; a non-MGH header is converted.
-    prefer_dtype : npt.DTypeLike, optional
-        A narrower type to use if the data fits it, for callers who know what their output should
-        be, such as the uchar aseg files. Ignored when it would round or clip a value, so it cannot
-        be used to force a lossy type; `save_image` takes a `dtype` for that.
+    header : _Header
+        Image header information; a non-MGH header is converted. Required: the affine covers the
+        geometry, but the header is the only carrier of the acquisition parameters and of the type
+        to store, so a caller with no source image has to say so by passing an `MGHHeader()`.
+    dtype : npt.DTypeLike, optional
+        The type to store, overriding the one the header carries. Neither may lose data nor be one
+        MGH cannot store, see `choose_dtype`.
 
     Returns
     -------
@@ -358,21 +433,12 @@ def as_mgh_image(
         The image, with `fov` and the data type set.
     """
     array = np.asanyarray(data)
-    # without a header, nibabel raises while constructing an image whose type MGH cannot store, so
-    # give it a default one and settle the type below, where the fallback is
-    img = nib.MGHImage(array, affine, MGHHeader() if header is None else header)
+    # before building anything, so a request that cannot be honoured fails where it was made
+    wanted = choose_dtype(array, header, dtype, MGH_DTYPES)
+    img = nib.MGHImage(array, affine, header)
     zooms = img.header.get_zooms()
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
-
-    header_dtype = array.dtype if header is None else header.get_data_dtype()
-    data_dtype = choose_dtype(array, header_dtype, prefer_dtype)
-    try:
-        img.set_data_dtype(data_dtype)
-    except MGHError:
-        # MGH stores uint8, uint16, int16, int32 and float32 only
-        LOGGER.warning(
-            f"An MGH file cannot store {data_dtype}, writing {img.get_data_dtype()} instead."
-        )
+    img.set_data_dtype(wanted)
     return img
 
 
@@ -400,38 +466,38 @@ def save_image(
     save_as : Path, str
         Name under which to save prediction; this determines output file format.
     dtype : npt.DTypeLike, optional
-        Image array type; if provided, the image object is explicitly set to match this type.
+        The type to store, overriding the one the header carries. Neither may lose data nor be one
+        the format cannot store, see `choose_dtype`.
+
+    Notes
+    -----
+    The type is decided the same way for every format. The file name only decides which types are
+    available at all: MGH has no float64 and no int64, NIfTI has both.
     """
     save_as = Path(save_as)
     valid_ext = save_as.suffix[1:] in SUPPORTED_OUTPUT_FILE_FORMATS or save_as.suffixes[-2:] == [".nii", ".gz"]
     assert valid_ext, f"Output filename does not contain a supported file format {SUPPORTED_OUTPUT_FILE_FORMATS}!"
 
+    array = np.asanyarray(img_array)
     if save_as.suffix == ".mgz":
-        mgh_img = as_mgh_image(img_array, affine_info, header_info)
+        img = as_mgh_image(array, affine_info, header_info, dtype)
     elif save_as.suffix == ".nii" or save_as.suffixes[-2:] == [".nii", ".gz"]:
-        mgh_img = nib.nifti1.Nifti1Pair(img_array, affine_info, header_info)
+        wanted = choose_dtype(array, header_info, dtype, NIFTI_DTYPES)
+        img = nib.nifti1.Nifti1Pair(array, affine_info, header_info)
+        img.set_data_dtype(wanted)
+        if np.issubdtype(wanted, np.integer):
+            # left free, nibabel is entitled to add a scale factor of its own, and a label read back
+            # through one is no longer the integer it was written as
+            img.header.set_slope_inter(1, 0)
     else:
         raise ValueError(f"Invalid file extension of {save_as}, must be .mgz, .nii or .nii.gz!")
 
-    if dtype is not None:
-        # an explicit dtype is the caller's decision, so it is applied as given even where it loses
-        # data, but it says so, and it falls back like the inferred one rather than aborting the run
-        if not fits_dtype(np.asanyarray(img_array), dtype):
-            LOGGER.warning(f"The data does not fit the requested {np.dtype(dtype)}, values will clip.")
-        try:
-            mgh_img.set_data_dtype(dtype)
-        except MGHError:
-            LOGGER.warning(
-                f"An MGH file cannot store {np.dtype(dtype)}, writing {mgh_img.get_data_dtype()} "
-                f"instead."
-            )
-
     if save_as.suffix in (".mgz", ".nii"):
-        nib.save(mgh_img, save_as)
+        nib.save(img, save_as)
     elif save_as.suffixes[-2:] == [".nii", ".gz"]:
         # For correct outputs, nii.gz files should be saved using the nifti1
         # sub-module's save():
-        nib.nifti1.save(mgh_img, str(save_as))
+        nib.nifti1.save(img, str(save_as))
 
 
 # Transformation for mapping

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -43,8 +43,10 @@ from FastSurferCNN.utils import AffineMatrix4x4, Shape1d, logging, nibabelImage
 # Global Vars
 ##
 SUPPORTED_OUTPUT_FILE_FORMATS = ("mgz", "nii", "nii.gz")
-# the integer types an MGH file can store, narrowest first, so the first that fits is the choice
-MGH_INT_DTYPES = (np.uint8, np.uint16, np.int16, np.int32)
+# the integer types to fall back on, narrowest first, so the first that fits is the choice. MGH can
+# also store uint16, but FreeSurfer writes none itself, so int32 is preferred over an odd-looking
+# file; a header that asks for uint16 is still honoured.
+MGH_INT_DTYPES = (np.uint8, np.int16, np.int32)
 LOGGER = logging.getLogger(__name__)
 
 ##
@@ -271,6 +273,52 @@ def fits_dtype(array: np.ndarray, dtype: npt.DTypeLike) -> bool:
     return array.size == 0 or bool(limits.min <= array.min() and array.max() <= limits.max)
 
 
+def choose_dtype(
+        array: np.ndarray,
+        header_dtype: npt.DTypeLike,
+        prefer_dtype: npt.DTypeLike | None = None,
+) -> np.dtype:
+    """
+    The type to store `array` as, never one that would round or clip a value.
+
+    `header_dtype` is what the header asks for, and is used where it holds the data. Where it does
+    not, the narrowest type MGH can store that does is used instead: widening to the array's own
+    type is not enough, since MGH has no int64 and the write would fall back and clip after all.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        The data to store.
+    header_dtype : npt.DTypeLike
+        The type the header asks for.
+    prefer_dtype : npt.DTypeLike, optional
+        A narrower type to use if the data fits it, ignored otherwise.
+
+    Returns
+    -------
+    np.dtype
+        The type to write.
+    """
+    header_dtype = np.dtype(header_dtype)
+    if prefer_dtype is not None and fits_dtype(array, prefer_dtype):
+        return np.dtype(prefer_dtype)
+    if np.issubdtype(array.dtype, np.floating) and np.issubdtype(header_dtype, np.integer):
+        # an integer type would round floating-point data away, as it did to the CC soft labels,
+        # which are probabilities written with the header of the conformed image
+        return np.dtype(np.float32)
+    if fits_dtype(array, header_dtype):
+        return header_dtype
+
+    # integer data the header cannot hold; the range is read once, not once per candidate
+    low, high = (int(array.min()), int(array.max())) if array.size else (0, 0)
+    wider = next(
+        (np.dtype(t) for t in MGH_INT_DTYPES if np.iinfo(t).min <= low and high <= np.iinfo(t).max),
+        np.dtype(np.float32),
+    )
+    LOGGER.warning(f"The data does not fit {header_dtype}, writing {wider} instead to avoid clipping.")
+    return wider
+
+
 def as_mgh_image(
         data: np.ndarray,
         affine: AffineMatrix4x4,
@@ -316,21 +364,8 @@ def as_mgh_image(
     zooms = img.header.get_zooms()
     img.header["fov"] = max(d * z for d, z in zip(img.shape[:3], zooms[:3], strict=True))
 
-    data_dtype = np.dtype(array.dtype if header is None else header.get_data_dtype())
-    if prefer_dtype is not None and fits_dtype(array, prefer_dtype):
-        data_dtype = np.dtype(prefer_dtype)
-    elif np.issubdtype(array.dtype, np.floating) and np.issubdtype(data_dtype, np.integer):
-        # an integer type would round floating-point data away, as it did to the CC soft labels,
-        # which are probabilities written with the header of the conformed image
-        data_dtype = np.dtype(np.float32)
-    elif not fits_dtype(array, data_dtype):
-        # a header narrower than its data would clip it, silently. Widening to the array's own type
-        # is not enough: MGH cannot store int64, and falling back would clip after all.
-        wider = next(
-            (np.dtype(t) for t in MGH_INT_DTYPES if fits_dtype(array, t)), np.dtype(np.float32)
-        )
-        LOGGER.warning(f"The data does not fit {data_dtype}, writing {wider} instead to avoid clipping.")
-        data_dtype = wider
+    header_dtype = array.dtype if header is None else header.get_data_dtype()
+    data_dtype = choose_dtype(array, header_dtype, prefer_dtype)
     try:
         img.set_data_dtype(data_dtype)
     except MGHError:

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -237,8 +237,8 @@ def load_maybe_conform(
             src_file, logger=logging.getLogger(__name__ + ".conform"), **conform_kwargs,
         )
 
-        # after conforming, save the conformed file; the image returned is the one written, so a
-        # .nii conf_name is not handed back as an MGHImage and the type is decided only once
+        # save the conformed file and hand back the image that was written, so the container
+        # matches the file and the type is decided once
         img = save_image(header, affine, data, dst_file)
     return dst_file, img, data
 
@@ -249,9 +249,8 @@ def fits_dtype(array: np.ndarray, dtype: npt.DTypeLike) -> bool:
 
     An integer loses its identity as surely by being rounded into a float as by being clipped, so a
     float target holds integers only as far as it counts exactly: 2**24 for float32, 2**53 for
-    float64. Narrowing a value that was already floating-point is not counted, because that is a
-    measurement losing digits rather than a label becoming a different label, and it only arises
-    where the output format has left nothing wider to move to.
+    float64. Narrowing a value that was already floating-point counts as fitting, since a
+    measurement losing digits is not a label becoming a different label.
 
     Parameters
     ----------
@@ -294,11 +293,9 @@ def choose_dtype(
     The type to store `array` as: `dtype` if the caller gave one, else the header's.
 
     That type is used or nothing is: it may not lose data, and the output format has to be able to
-    store it. Neither is guessed around. Narrowing that would round or clip is the caller's to do,
-    deliberately and outside, because only the caller knows whether the right answer is to cast, to
-    rescale or to refuse. Substituting a type the format does happen to offer would be a guess of
-    the same kind, and a float answered with an integer is not a smaller version of the request but
-    a different file; `storable_dtype` is how a caller asks for that on purpose.
+    store it. Narrowing that would round or clip is the caller's to do, deliberately and outside,
+    because only the caller knows whether to cast, to rescale or to refuse. `storable_dtype` is how
+    a caller with no type of its own asks for the closest the format offers.
 
     The byte order is dropped, because the output format decides it: an MGH file is always
     big-endian, whatever type it stores.
@@ -350,15 +347,14 @@ def storable_dtype(
     """
     The array's own type if the output format can store it, else the closest one that holds it.
 
-    For an output whose type is not ours to choose. That is `mri/orig/001.mgz`, the archival copy of
-    whatever the scanner or the conversion tool produced, and nothing else: every other output has a
-    type that belongs to the output rather than to the input, so its caller names it and
-    `choose_dtype` refuses anything that does not fit.
+    For an output whose type is not ours to choose: `mri/orig/001.mgz`, the archival copy of
+    whatever the scanner or the conversion tool produced. Every other output has a type that belongs
+    to the output rather than to the input, so its caller names it and `choose_dtype` refuses
+    anything that does not fit.
 
     Closest means the same kind first, so a float is never answered with an integer and signed data
     stays signed, and within the kind the narrowest that holds every value. An MGH file has no
-    float64, so a float64 input is archived as float32; that loss is the reason a copy of the input
-    is better kept in the format it arrived in, which is a decision above this function.
+    float64, so a float64 input is archived as float32.
 
     Parameters
     ----------
@@ -400,14 +396,12 @@ def as_mgh_image(
         dtype: npt.DTypeLike | None = None,
 ) -> nib.MGHImage:
     """
-    Build an MGHImage from data, affine and header, keeping what the conversion would drop.
+    Build an MGHImage from data, affine and header, and set the two fields the conversion drops.
 
     `MGHHeader.from_header` carries neither the field of view nor the data type over from a non-MGH
-    header, so an .mgz written with a header that came from a .nii ended up with `fov=0` and stored
-    as float32, whatever the data or the caller asked for. Both are restored here, so the file does
-    not depend on the container its header came from. The fov is the largest of the three extents,
-    which is what FreeSurfer keeps, and deriving it from `data` also gets it right when the header
-    is inherited from a volume of a different shape.
+    header, so both are set here and the file does not depend on the container its header came from.
+    The fov is the largest of the three extents, as FreeSurfer keeps it, taken from `data` so that
+    it is right even where the header is inherited from a volume of a different shape.
 
     Parameters
     ----------

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -237,9 +237,9 @@ def load_maybe_conform(
             src_file, logger=logging.getLogger(__name__ + ".conform"), **conform_kwargs,
         )
 
-        # after conforming, save the conformed file
-        save_image(header, affine, data, dst_file)
-        img = as_mgh_image(data, affine, header)
+        # after conforming, save the conformed file; the image returned is the one written, so a
+        # .nii conf_name is not handed back as an MGHImage and the type is decided only once
+        img = save_image(header, affine, data, dst_file)
     return dst_file, img, data
 
 
@@ -328,9 +328,11 @@ def choose_dtype(
     wanted = np.dtype(header.get_data_dtype() if dtype is None else dtype).newbyteorder("=")
     if not fits_dtype(array, wanted):
         source = "requested" if dtype is not None else "carried by the header"
+        both_integer = np.issubdtype(array.dtype, np.integer) and np.issubdtype(wanted, np.integer)
         raise ValueError(
             f"Refusing to store {array.dtype} data as the {wanted} {source}, because values would "
-            f"be {_damage(array, wanted)}. Convert the data before saving if that is what you want."
+            f"be {'clipped' if both_integer else 'rounded'}. Convert the data before saving if that "
+            f"is what you want."
         )
     if wanted not in tuple(np.dtype(c) for c in candidates):
         offered = ", ".join(np.dtype(c).name for c in candidates)
@@ -339,12 +341,6 @@ def choose_dtype(
             f"write the image in a format that can, or call storable_dtype to pick the closest one."
         )
     return wanted
-
-
-def _damage(array: np.ndarray, dtype: np.dtype) -> str:
-    """What storing `array` as `dtype` would do to it, for the message that refuses to."""
-    both_integer = np.issubdtype(array.dtype, np.integer) and np.issubdtype(dtype, np.integer)
-    return "clipped" if both_integer else "rounded"
 
 
 def storable_dtype(
@@ -449,7 +445,7 @@ def save_image(
         img_array: np.ndarray,
         save_as: str | Path,
         dtype: npt.DTypeLike | None = None
-) -> None:
+) -> nibabelImage:
     """
     Save an image (nibabel MGHImage), according to the desired output file format.
 
@@ -468,6 +464,12 @@ def save_image(
     dtype : npt.DTypeLike, optional
         The type to store, overriding the one the header carries. Neither may lose data nor be one
         the format cannot store, see `choose_dtype`.
+
+    Returns
+    -------
+    nibabelImage
+        The image as it was written, so a caller that also needs it in memory does not have to build
+        it a second time, and gets the container the file actually uses.
 
     Notes
     -----
@@ -498,6 +500,7 @@ def save_image(
         # For correct outputs, nii.gz files should be saved using the nifti1
         # sub-module's save():
         nib.nifti1.save(img, str(save_as))
+    return img
 
 
 # Transformation for mapping

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -25,7 +25,7 @@ import scipy.ndimage
 from skimage.filters import gaussian
 from skimage.measure import label
 
-from FastSurferCNN.data_loader.data_utils import as_mgh_image, fits_dtype
+from FastSurferCNN.data_loader.data_utils import as_mgh_image
 from FastSurferCNN.utils import AffineMatrix4x4, ShapeType, logging, nibabelHeader, nibabelImage
 from FastSurferCNN.utils.brainvolstats import mask_in_array
 from FastSurferCNN.utils.logging import setup_logging
@@ -238,10 +238,8 @@ def create_mask_and_save(
     mask_data = create_mask(seg, 5, 4)
     if filename is not None:
         LOGGER.info(f"Outputting mask: {filename}")
-        mask = as_mgh_image(mask_data, seg_affine, seg_header)
         # a mask is uchar, like the aseg, and not the type of the segmentation it was derived from
-        if fits_dtype(mask_data, np.uint8):
-            mask.set_data_dtype(np.uint8)
+        mask = as_mgh_image(mask_data, seg_affine, seg_header, prefer_dtype=np.uint8)
         mask.to_filename(filename)
     return mask_data
 
@@ -257,11 +255,9 @@ def reduce_to_aseg_and_save(
 
     if filename is not None:
         LOGGER.info(f"Outputting aseg: {filename}")
-        image = as_mgh_image(_data, seg_affine, seg_header)
         # FreeSurfer writes the aseg files as uchar, and an aseg has no label above 255. Without
         # this, the int16 of the segmentation it is reduced from carries over.
-        if fits_dtype(_data, np.uint8):
-            image.set_data_dtype(np.uint8)
+        image = as_mgh_image(_data, seg_affine, seg_header, prefer_dtype=np.uint8)
         image.to_filename(filename)
     return _data
 
@@ -275,7 +271,8 @@ if __name__ == "__main__":
     LOGGER.info(f"Reading in aparc+aseg: {options.input_seg} ...")
     inseg = cast(nibabelImage, nib.load(options.input_seg))
     inseg_data = np.asanyarray(inseg.dataobj)
-    inseg_header = inseg.header
+    # a copy, since it outlives the load and is handed to a thread below
+    inseg_header = inseg.header.copy()
     inseg_affine = inseg.affine
 
     # get mask
@@ -303,9 +300,7 @@ if __name__ == "__main__":
         aseg = flip_wm_islands(aseg)
 
     LOGGER.info(f"Outputting aseg: {options.output_seg}")
-    aseg_fin = as_mgh_image(aseg, inseg_affine, inseg_header)
-    if fits_dtype(aseg, np.uint8):
-        aseg_fin.set_data_dtype(np.uint8)
+    aseg_fin = as_mgh_image(aseg, inseg_affine, inseg_header, prefer_dtype=np.uint8)
     aseg_fin.to_filename(options.output_seg)
 
     sys.exit(0)

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -254,8 +254,15 @@ def reduce_to_aseg_and_save(
 
     if filename is not None:
         LOGGER.info(f"Outputting aseg: {filename}")
-        mask = as_mgh_image(_data, seg_affine, seg_header)
-        mask.to_filename(filename)
+        image = as_mgh_image(_data, seg_affine, seg_header)
+        # FreeSurfer writes the aseg files as uchar, and an aseg has no label above 255. Without
+        # this, the int16 of the segmentation it is reduced from carries over. Only narrow labels
+        # that survive it: a float would be rounded and a negative value clipped, both silently.
+        uchar = np.iinfo(np.uint8)
+        fits = np.issubdtype(_data.dtype, np.integer) and uchar.min <= _data.min() <= _data.max() <= uchar.max
+        if fits:
+            image.set_data_dtype(np.uint8)
+        image.to_filename(filename)
     return _data
 
 

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -25,7 +25,7 @@ import scipy.ndimage
 from skimage.filters import gaussian
 from skimage.measure import label
 
-from FastSurferCNN.data_loader.data_utils import as_mgh_image
+from FastSurferCNN.data_loader.data_utils import as_mgh_image, fits_dtype
 from FastSurferCNN.utils import AffineMatrix4x4, ShapeType, logging, nibabelHeader, nibabelImage
 from FastSurferCNN.utils.brainvolstats import mask_in_array
 from FastSurferCNN.utils.logging import setup_logging
@@ -239,6 +239,9 @@ def create_mask_and_save(
     if filename is not None:
         LOGGER.info(f"Outputting mask: {filename}")
         mask = as_mgh_image(mask_data, seg_affine, seg_header)
+        # a mask is uchar, like the aseg, and not the type of the segmentation it was derived from
+        if fits_dtype(mask_data, np.uint8):
+            mask.set_data_dtype(np.uint8)
         mask.to_filename(filename)
     return mask_data
 
@@ -256,11 +259,8 @@ def reduce_to_aseg_and_save(
         LOGGER.info(f"Outputting aseg: {filename}")
         image = as_mgh_image(_data, seg_affine, seg_header)
         # FreeSurfer writes the aseg files as uchar, and an aseg has no label above 255. Without
-        # this, the int16 of the segmentation it is reduced from carries over. Only narrow labels
-        # that survive it: a float would be rounded and a negative value clipped, both silently.
-        uchar = np.iinfo(np.uint8)
-        fits = np.issubdtype(_data.dtype, np.integer) and uchar.min <= _data.min() <= _data.max() <= uchar.max
-        if fits:
+        # this, the int16 of the segmentation it is reduced from carries over.
+        if fits_dtype(_data, np.uint8):
             image.set_data_dtype(np.uint8)
         image.to_filename(filename)
     return _data
@@ -277,9 +277,6 @@ if __name__ == "__main__":
     inseg_data = np.asanyarray(inseg.dataobj)
     inseg_header = inseg.header
     inseg_affine = inseg.affine
-
-    # Change datatype to np.uint8
-    inseg_header.set_data_dtype(np.uint8)
 
     # get mask
     if options.output_mask:
@@ -307,6 +304,8 @@ if __name__ == "__main__":
 
     LOGGER.info(f"Outputting aseg: {options.output_seg}")
     aseg_fin = as_mgh_image(aseg, inseg_affine, inseg_header)
+    if fits_dtype(aseg, np.uint8):
+        aseg_fin.set_data_dtype(np.uint8)
     aseg_fin.to_filename(options.output_seg)
 
     sys.exit(0)

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -271,8 +271,7 @@ if __name__ == "__main__":
     LOGGER.info(f"Reading in aparc+aseg: {options.input_seg} ...")
     inseg = cast(nibabelImage, nib.load(options.input_seg))
     inseg_data = np.asanyarray(inseg.dataobj)
-    # a copy, since it outlives the load and is handed to a thread below
-    inseg_header = inseg.header.copy()
+    inseg_header = inseg.header
     inseg_affine = inseg.affine
 
     # get mask

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -239,7 +239,7 @@ def create_mask_and_save(
     if filename is not None:
         LOGGER.info(f"Outputting mask: {filename}")
         # a mask is uchar, like the aseg, and not the type of the segmentation it was derived from
-        mask = as_mgh_image(mask_data, seg_affine, seg_header, prefer_dtype=np.uint8)
+        mask = as_mgh_image(mask_data, seg_affine, seg_header, dtype=np.uint8)
         mask.to_filename(filename)
     return mask_data
 
@@ -257,7 +257,7 @@ def reduce_to_aseg_and_save(
         LOGGER.info(f"Outputting aseg: {filename}")
         # FreeSurfer writes the aseg files as uchar, and an aseg has no label above 255. Without
         # this, the int16 of the segmentation it is reduced from carries over.
-        image = as_mgh_image(_data, seg_affine, seg_header, prefer_dtype=np.uint8)
+        image = as_mgh_image(_data, seg_affine, seg_header, dtype=np.uint8)
         image.to_filename(filename)
     return _data
 
@@ -300,7 +300,7 @@ if __name__ == "__main__":
         aseg = flip_wm_islands(aseg)
 
     LOGGER.info(f"Outputting aseg: {options.output_seg}")
-    aseg_fin = as_mgh_image(aseg, inseg_affine, inseg_header, prefer_dtype=np.uint8)
+    aseg_fin = as_mgh_image(aseg, inseg_affine, inseg_header, dtype=np.uint8)
     aseg_fin.to_filename(options.output_seg)
 
     sys.exit(0)

--- a/FastSurferCNN/reduce_to_aseg.py
+++ b/FastSurferCNN/reduce_to_aseg.py
@@ -255,8 +255,8 @@ def reduce_to_aseg_and_save(
 
     if filename is not None:
         LOGGER.info(f"Outputting aseg: {filename}")
-        # FreeSurfer writes the aseg files as uchar, and an aseg has no label above 255. Without
-        # this, the int16 of the segmentation it is reduced from carries over.
+        # an aseg has no label above 255 and FreeSurfer writes these files as uchar, so ask for it
+        # rather than inheriting the type of the segmentation this was reduced from
         image = as_mgh_image(_data, seg_affine, seg_header, dtype=np.uint8)
         image.to_filename(filename)
     return _data

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -34,6 +34,7 @@ from typing import Any, Literal, cast
 
 import numpy as np
 import torch
+from numpy import typing as npt
 from yacs.config import CfgNode
 
 import FastSurferCNN.reduce_to_aseg as rta
@@ -315,7 +316,11 @@ class RunModelOnData:
 
         # Save input image to standard location, but only
         if subject.has_attribute("copy_orig_name") and subject.can_resolve_attribute("copy_orig_name"):
-            self.async_save_img(subject.copy_orig_name, orig_data, orig, orig_data.dtype)
+            # the archival copy of the input, so its type is the input's and not ours to name; a
+            # scaled or float64 NIfTI carries one no .mgz can hold, hence the closest that fits
+            self.async_save_img(
+                subject.copy_orig_name, orig_data, orig, du.storable_dtype(orig_data),
+            )
 
         if not is_conform(orig, **self.__conform_kwargs(verbose=True)):
             if (self.orientation is None or self.orientation == "native") and \
@@ -404,7 +409,7 @@ class RunModelOnData:
         save_as: str | Path,
         data: np.ndarray | torch.Tensor,
         orig: nibabelImage,
-        dtype: type | None = None,
+        dtype: npt.DTypeLike | None = None,
     ) -> None:
         """
         Save image as a file.
@@ -427,12 +432,7 @@ class RunModelOnData:
             save_as.parent.mkdir(parents=True)
 
         np_data = data if isinstance(data, np.ndarray) else data.cpu().numpy()
-        if dtype is not None:
-            _header = orig.header.copy()
-            _header.set_data_dtype(dtype)
-        else:
-            _header = orig.header
-        du.save_image(_header, orig.affine, np_data, save_as, dtype=dtype)
+        du.save_image(orig.header, orig.affine, np_data, save_as, dtype=dtype)
         LOGGER.info(f"Successfully saved image {'asynchronously ' if self._async_io else ''}as {save_as}.")
 
     def async_save_img(
@@ -440,7 +440,7 @@ class RunModelOnData:
         save_as: str | Path,
         data: np.ndarray | torch.Tensor,
         orig: nibabelImage,
-        dtype: type | None = None,
+        dtype: npt.DTypeLike | None = None,
     ) -> Future[None]:
         """
         Save the image asynchronously and return a concurrent.futures.Future to track,

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -316,8 +316,8 @@ class RunModelOnData:
 
         # Save input image to standard location, but only
         if subject.has_attribute("copy_orig_name") and subject.can_resolve_attribute("copy_orig_name"):
-            # the archival copy of the input, so its type is the input's and not ours to name; a
-            # scaled or float64 NIfTI carries one no .mgz can hold, hence the closest that fits
+            # an archival copy, so the type is the input's rather than one we name; a scaled or
+            # float64 NIfTI carries one no .mgz can hold, hence the closest the format offers
             self.async_save_img(
                 subject.copy_orig_name, orig_data, orig, du.storable_dtype(orig_data),
             )

--- a/HypVINN/utils/img_processing_utils.py
+++ b/HypVINN/utils/img_processing_utils.py
@@ -16,14 +16,14 @@ from typing import cast
 
 import nibabel as nib
 import numpy as np
-from nibabel import Nifti1Image
 from nibabel.orientations import aff2axcodes
 from scipy import ndimage
 from skimage.measure import label
 
 import FastSurferCNN.utils.logging as logging
 from FastSurferCNN.data_loader.conform import Reorientation, does_vox2vox_rot_require_interpolation
-from FastSurferCNN.utils import AffineMatrix4x4, Image4d, nibabelHeader, nibabelImage
+from FastSurferCNN.data_loader.data_utils import save_image
+from FastSurferCNN.utils import AffineMatrix4x4, Image4d, nibabelImage
 from HypVINN.data_loader.data_utils import hypo_map_subseg_2_fsseg
 
 LOGGER = logging.get_logger(__name__)
@@ -94,26 +94,25 @@ def save_segmentation(
         LOGGER.warning("Hypothalamus mask and segmentation reorientation requires lossy interpolation.")
 
     if save_mask:
-        mask_header: nibabelHeader = Nifti1Image.header_class.from_header(orig_img.header)
-        mask_header.set_data_dtype(np.uint8)
-        mask_img = nib.Nifti1Image(
+        # a mask is uchar
+        save_image(
+            orig_img.header,
+            orig_img.affine,
             reorient(labels_cc.astype(np.uint8), order=0),
-            affine=orig_img.affine,
-            header=mask_header,
+            subject_dir / "mri" / mask_file,
+            dtype=np.uint8,
         )
-        LOGGER.info(f"HypVINN Mask after re-orientation: {aff2axcodes(mask_img.affine)}")
-        nib.save(mask_img, subject_dir / "mri" / mask_file)
+        LOGGER.info(f"HypVINN Mask after re-orientation: {aff2axcodes(orig_img.affine)}")
 
-    pred_header: nibabelHeader = Nifti1Image.header_class.from_header(orig_img.header)
-    pred_header.set_data_dtype(np.uint8)
-    pred_img = nib.Nifti1Image(
+    # the hypothalamus labels reach 984, so int16
+    save_image(
+        orig_img.header,
+        orig_img.affine,
         reorient(pred_arr.astype(np.int16), order=0),
-        affine=orig_img.affine,
-        header=pred_header,
+        subject_dir / "mri" / seg_file,
+        dtype=np.int16,
     )
-    LOGGER.info(f"HypVINN Prediction after re-orientation: {aff2axcodes(pred_img.affine)}")
-    pred_img.set_data_dtype(np.int16)  # Maximum value 984
-    nib.save(pred_img, subject_dir / "mri" / seg_file)
+    LOGGER.info(f"HypVINN Prediction after re-orientation: {aff2axcodes(orig_img.affine)}")
     return time() - starttime
 
 
@@ -154,23 +153,22 @@ def save_logits(
     """
     orig_img = cast(nibabelImage, nib.load(orig_path))
     LOGGER.info(f"Orig data orientation: {aff2axcodes(orig_img.affine)}")
-    header: nibabelHeader = Nifti1Image.header_class.from_header(orig_img.header)
-    header.set_data_dtype(np.float32)
     reorient = Reorientation.from_target_affine(
         ras_affine,
         orig_img.affine,
         logits.shape,
         voxel_center=False,
     )
-    nifti_img = nib.Nifti1Image(
-        reorient(logits.astype(np.float32)),
-        affine=orig_img.affine,
-        header=header,
-    )
-    LOGGER.info(f"HypVINN logits after re-orientation: {aff2axcodes(nifti_img.affine)}")
-    nifti_img.set_data_dtype(np.float32)
     save_as = save_dir / f"HypVINN_logits_{mode}.nii.gz"
-    nib.save(nifti_img, save_as)
+    # logits are continuous, so float
+    save_image(
+        orig_img.header,
+        orig_img.affine,
+        reorient(logits.astype(np.float32)),
+        save_as,
+        dtype=np.float32,
+    )
+    LOGGER.info(f"HypVINN logits after re-orientation: {aff2axcodes(orig_img.affine)}")
     return save_as
 
 

--- a/HypVINN/utils/img_processing_utils.py
+++ b/HypVINN/utils/img_processing_utils.py
@@ -101,7 +101,6 @@ def save_segmentation(
             affine=orig_img.affine,
             header=mask_header,
         )
-        mask_img.set_data_dtype(np.float32)
         LOGGER.info(f"HypVINN Mask after re-orientation: {aff2axcodes(mask_img.affine)}")
         nib.save(mask_img, subject_dir / "mri" / mask_file)
 
@@ -156,7 +155,7 @@ def save_logits(
     orig_img = cast(nibabelImage, nib.load(orig_path))
     LOGGER.info(f"Orig data orientation: {aff2axcodes(orig_img.affine)}")
     header: nibabelHeader = Nifti1Image.header_class.from_header(orig_img.header)
-    header.set_data_type(np.float32)
+    header.set_data_dtype(np.float32)
     reorient = Reorientation.from_target_affine(
         ras_affine,
         orig_img.affine,

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -88,7 +88,8 @@ def test_float_data_is_never_stored_as_an_integer(container, header_dtype, tmp_p
 def test_only_the_type_changes_not_the_rest_of_the_header(tmp_path):
     """Widening the type must not cost the header. Only the type is ours to override."""
     source = nib.MGHImage(np.zeros(SHAPE, dtype=np.uint8), AFFINE)
-    acquisition = {"tr": 2300.0, "te": 2.98, "ti": 900.0, "flip_angle": 0.15708}
+    # the keys are MGH header field names, hence the ignore for the echo time one
+    acquisition = {"tr": 2300.0, "te": 2.98, "ti": 900.0, "flip_angle": 0.15708}  # codespell:ignore te
     for field, value in acquisition.items():
         source.header[field] = value
 

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -1,0 +1,80 @@
+"""Regression tests for the data type of the .mgz files FastSurfer writes.
+
+`MGHHeader.from_header` does not carry the data type over from a non-MGH header: it returns float32
+whatever the source says. Every .mgz written with a header that came from a .nii was therefore stored
+as float32, which is how the 1mm copy CerebNet conforms for a high-res subject became a float32 file
+four times the size of the uint8 one it asked for, holding nothing but integers.
+
+The rule pinned here is that the written type must not depend on the container the header came from.
+"""
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from FastSurferCNN.data_loader.data_utils import as_mgh_image, load_maybe_conform, save_image
+
+AFFINE = np.eye(4)
+SHAPE = (8, 8, 8)
+
+
+def headers_of(dtype):
+    """The same image as a NIfTI and as an MGH header, plus no header at all."""
+    data = np.zeros(SHAPE, dtype=dtype)
+    return {
+        "nifti": nib.Nifti1Image(data, AFFINE).header,
+        "mgh": nib.MGHImage(data, AFFINE).header,
+        "none": None,
+    }
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.int32, np.float32], ids=str)
+@pytest.mark.parametrize("source", ["nifti", "mgh", "none"])
+def test_dtype_does_not_depend_on_the_source_container(dtype, source):
+    """The bug: a NIfTI header silently produced float32, an MGH header did not."""
+    data = np.zeros(SHAPE, dtype=dtype)
+    img = as_mgh_image(data, AFFINE, headers_of(dtype)[source])
+    # MGH stores big-endian, so compare in native byte order
+    assert img.get_data_dtype().newbyteorder("=") == np.dtype(dtype)
+
+
+def test_unstorable_dtype_falls_back_instead_of_raising(caplog):
+    """MGH has no float64. That must degrade to float32 with a warning, not abort a run."""
+    data = np.zeros(SHAPE, dtype=np.float64)
+    header = nib.Nifti1Image(data, AFFINE).header
+
+    img = as_mgh_image(data, AFFINE, header)
+
+    assert img.get_data_dtype() == np.dtype(">f4")
+    assert "cannot store" in caplog.text
+
+
+def test_explicit_dtype_still_wins(tmp_path):
+    """save_image(dtype=...) overrides whatever the header carried."""
+    data = np.zeros(SHAPE, dtype=np.float32)
+    header = nib.Nifti1Image(data, AFFINE).header
+
+    out_file = tmp_path / "explicit.mgz"
+    save_image(header, AFFINE, data, out_file, dtype=np.uint8)
+
+    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)
+
+
+def test_conformed_copy_of_a_float_input_is_not_float(tmp_path):
+    """The path that produced orig.10mm.mgz: a float NIfTI input, uint8 asked for, uint8 expected."""
+    affine = np.diag([0.8, 0.8, 0.8, 1.0])
+    affine[:3, 3] = -128.0
+    voxels = np.rint(np.random.default_rng(0).random((64, 64, 64)) * 255).astype(np.float32)
+    nib.save(nib.Nifti1Image(voxels, affine), tmp_path / "T1.nii.gz")
+
+    out_file, _, _ = load_maybe_conform(
+        tmp_path / "orig.mgz",
+        tmp_path / "T1.nii.gz",
+        vox_size=1.0,
+        img_size="auto",
+        orientation="lia",
+        order=1,
+        dtype=np.uint8,
+    )
+
+    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -59,25 +59,49 @@ def test_unstorable_dtype_falls_back_instead_of_raising(with_header, caplog):
     assert "cannot store" in caplog.text
 
 
-@pytest.mark.parametrize(
-    "header_dtype", [np.uint8, np.int16], ids=["uint8 header", "int16 header"],
-)
-def test_an_integer_header_does_not_truncate_float_data(header_dtype, tmp_path):
-    """Carrying the type across must never round data away.
+@pytest.mark.parametrize("header_dtype", [np.uint8, np.int16], ids=["uint8", "int16"])
+@pytest.mark.parametrize("container", ["nifti", "mgh", "none"])
+def test_float_data_is_never_stored_as_an_integer(container, header_dtype, tmp_path):
+    """Probabilities must survive, whatever integer type the header carries.
 
-    The CC module writes its soft labels, which are probabilities, with the header of the conformed
-    image. Where that header is an integer type, taking it would store 0.37 as 0.
+    The CC module writes its soft labels with the header of the conformed image, which is uchar, so
+    0.37 was stored as 0 and the probability map came back as a binary mask. An MGH header is the
+    case that matters: nibabel applies its type while constructing the image, not only afterwards.
     """
     soft_labels = np.zeros(SHAPE, dtype=np.float32)
     soft_labels[0, 0, 0] = 0.37
-    header = nib.Nifti1Image(np.zeros(SHAPE, dtype=header_dtype), AFFINE).header
+    integers = np.zeros(SHAPE, dtype=header_dtype)
+    headers = {
+        "nifti": nib.Nifti1Image(integers, AFFINE).header,
+        "mgh": nib.MGHImage(integers, AFFINE).header,
+        "none": None,
+    }
 
     out_file = tmp_path / "soft.mgz"
-    nib.save(as_mgh_image(soft_labels, AFFINE, header), out_file)
+    nib.save(as_mgh_image(soft_labels, AFFINE, headers[container]), out_file)
 
     written = nib.load(out_file)
     assert written.get_data_dtype() == np.dtype(">f4")
     assert np.asarray(written.dataobj)[0, 0, 0] == pytest.approx(0.37)
+
+
+def test_only_the_type_changes_not_the_rest_of_the_header(tmp_path):
+    """Widening the type must not cost the header. Only the type is ours to override."""
+    source = nib.MGHImage(np.zeros(SHAPE, dtype=np.uint8), AFFINE)
+    acquisition = {"tr": 2300.0, "te": 2.98, "ti": 900.0, "flip_angle": 0.15708}
+    for field, value in acquisition.items():
+        source.header[field] = value
+
+    soft_labels = np.zeros(SHAPE, dtype=np.float32)
+    soft_labels[0, 0, 0] = 0.37
+    out_file = tmp_path / "soft.mgz"
+    nib.save(as_mgh_image(soft_labels, AFFINE, source.header), out_file)
+
+    written = nib.load(out_file)
+    assert written.get_data_dtype() == np.dtype(">f4"), "the type is widened"
+    for field, value in acquisition.items():
+        assert float(written.header[field]) == pytest.approx(value), f"{field} survives"
+    assert np.allclose(written.affine, AFFINE)
 
 
 def test_explicit_dtype_still_wins(tmp_path):

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -42,15 +42,42 @@ def test_dtype_does_not_depend_on_the_source_container(dtype, source):
     assert img.get_data_dtype().newbyteorder("=") == np.dtype(dtype)
 
 
-def test_unstorable_dtype_falls_back_instead_of_raising(caplog):
-    """MGH has no float64. That must degrade to float32 with a warning, not abort a run."""
+@pytest.mark.parametrize("with_header", [True, False], ids=["from a header", "headerless"])
+def test_unstorable_dtype_falls_back_instead_of_raising(with_header, caplog):
+    """MGH has no float64. That must degrade to float32 with a warning, not abort a run.
+
+    The headerless case is the one that bites: nibabel raises while constructing the image, before
+    any fallback of ours could run.
+    """
     data = np.zeros(SHAPE, dtype=np.float64)
-    header = nib.Nifti1Image(data, AFFINE).header
+    data[0, 0, 0] = 0.37
+    header = nib.Nifti1Image(data, AFFINE).header if with_header else None
 
     img = as_mgh_image(data, AFFINE, header)
 
     assert img.get_data_dtype() == np.dtype(">f4")
     assert "cannot store" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "header_dtype", [np.uint8, np.int16], ids=["uint8 header", "int16 header"],
+)
+def test_an_integer_header_does_not_truncate_float_data(header_dtype, tmp_path):
+    """Carrying the type across must never round data away.
+
+    The CC module writes its soft labels, which are probabilities, with the header of the conformed
+    image. Where that header is an integer type, taking it would store 0.37 as 0.
+    """
+    soft_labels = np.zeros(SHAPE, dtype=np.float32)
+    soft_labels[0, 0, 0] = 0.37
+    header = nib.Nifti1Image(np.zeros(SHAPE, dtype=header_dtype), AFFINE).header
+
+    out_file = tmp_path / "soft.mgz"
+    nib.save(as_mgh_image(soft_labels, AFFINE, header), out_file)
+
+    written = nib.load(out_file)
+    assert written.get_data_dtype() == np.dtype(">f4")
+    assert np.asarray(written.dataobj)[0, 0, 0] == pytest.approx(0.37)
 
 
 def test_explicit_dtype_still_wins(tmp_path):

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -15,8 +15,13 @@ import nibabel as nib
 import numpy as np
 import pytest
 
-from FastSurferCNN.data_loader.data_utils import as_mgh_image, load_maybe_conform, save_image
-from FastSurferCNN.reduce_to_aseg import reduce_to_aseg_and_save
+from FastSurferCNN.data_loader.data_utils import (
+    as_mgh_image,
+    fits_dtype,
+    load_maybe_conform,
+    save_image,
+)
+from FastSurferCNN.reduce_to_aseg import create_mask_and_save, reduce_to_aseg_and_save
 
 AFFINE = np.eye(4)
 SHAPE = (8, 8, 8)
@@ -85,6 +90,40 @@ def test_float_data_is_never_stored_as_an_integer(container, header_dtype, tmp_p
     assert np.asarray(written.dataobj)[0, 0, 0] == pytest.approx(0.37)
 
 
+@pytest.mark.parametrize("container", ["nifti", "mgh"])
+def test_integer_data_wider_than_the_header_is_not_clipped(container, tmp_path):
+    """The mirror of the float case: a header narrower than its data must not silently clip it.
+
+    A uchar header with int16 data holding 500 wrote 255, losing the label. The NIfTI path used to
+    escape it only because the type was dropped entirely and everything became float32.
+    """
+    labels = np.zeros(SHAPE, dtype=np.int16)
+    labels[0, 0, 0] = 500
+    narrow = np.zeros(SHAPE, dtype=np.uint8)
+    header = {
+        "nifti": nib.Nifti1Image(narrow, AFFINE).header,
+        "mgh": nib.MGHImage(narrow, AFFINE).header,
+    }[container]
+
+    out_file = tmp_path / "labels.mgz"
+    nib.save(as_mgh_image(labels, AFFINE, header), out_file)
+
+    written = nib.load(out_file)
+    assert written.get_data_dtype() != np.dtype(np.uint8)
+    assert np.asarray(written.dataobj).max() == 500
+
+
+def test_fits_dtype():
+    """The shared rule the writers narrow by."""
+    assert fits_dtype(np.zeros(SHAPE, np.int16), np.uint8), "in range"
+    assert not fits_dtype(np.full(SHAPE, 500, np.int16), np.uint8), "above the range"
+    assert not fits_dtype(np.full(SHAPE, -1, np.int16), np.uint8), "below the range"
+    assert not fits_dtype(np.zeros(SHAPE, np.float32), np.uint8), "a float would be rounded"
+    assert fits_dtype(np.zeros(SHAPE, np.uint8), np.int16), "widening always fits"
+    assert fits_dtype(np.zeros(SHAPE, np.int16), np.float32), "a float target holds any integer"
+    assert fits_dtype(np.zeros((0,), np.int16), np.uint8), "an empty array has nothing to clip"
+
+
 def test_only_the_type_changes_not_the_rest_of_the_header(tmp_path):
     """Widening the type must not cost the header. Only the type is ours to override."""
     source = nib.MGHImage(np.zeros(SHAPE, dtype=np.uint8), AFFINE)
@@ -138,6 +177,18 @@ def test_aseg_is_written_as_uchar(tmp_path):
     assert set(np.unique(np.asarray(written.dataobj))) == {0, 3, 17, 42, 251}
 
 
+def test_mask_is_written_as_uchar(tmp_path):
+    """The mask carries the same uchar guarantee as the aseg, not the type it was derived from."""
+    seg = np.zeros((16, 16, 16), dtype=np.int16)
+    seg[4:12, 4:12, 4:12] = 17
+    header = nib.MGHImage(seg, AFFINE).header
+
+    out_file = tmp_path / "mask.mgz"
+    create_mask_and_save(seg, AFFINE, header, out_file)
+
+    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)
+
+
 def label_above_255():
     seg = dkt_segmentation()
     seg[4] = 500
@@ -151,9 +202,10 @@ def negative_label():
 
 
 def fractional_float():
+    # 17.5 is exact in float32, so the assertion tests the narrowing and not float promotion
     seg = dkt_segmentation().astype(np.float32)
-    seg[4] = 17.6
-    return seg, 17.6
+    seg[4] = 17.5
+    return seg, 17.5
 
 
 @pytest.mark.parametrize(

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -6,6 +6,9 @@ as float32, which is how the 1mm copy CerebNet conforms for a high-res subject b
 four times the size of the uint8 one it asked for, holding nothing but integers.
 
 The rule pinned here is that the written type must not depend on the container the header came from.
+
+The aseg files are the second half of the same problem: they inherit the header of the int16
+segmentation they are reduced from, where FreeSurfer, and FastSurfer up to v2.3.3, write uchar.
 """
 
 import nibabel as nib
@@ -13,6 +16,7 @@ import numpy as np
 import pytest
 
 from FastSurferCNN.data_loader.data_utils import as_mgh_image, load_maybe_conform, save_image
+from FastSurferCNN.reduce_to_aseg import reduce_to_aseg_and_save
 
 AFFINE = np.eye(4)
 SHAPE = (8, 8, 8)
@@ -58,6 +62,66 @@ def test_explicit_dtype_still_wins(tmp_path):
     save_image(header, AFFINE, data, out_file, dtype=np.uint8)
 
     assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)
+
+
+def dkt_segmentation():
+    """A DKT segmentation as FastSurfer writes it: int16, with cortical labels in the 1000s."""
+    seg = np.zeros((16, 16, 16), dtype=np.int16)
+    seg[0], seg[1], seg[2], seg[3] = 1035, 2035, 251, 17
+    return seg
+
+
+def test_aseg_is_written_as_uchar(tmp_path):
+    """FreeSurfer writes aseg.auto.mgz as uchar, and so did FastSurfer before the int16 carried over."""
+    seg = dkt_segmentation()
+    header = nib.MGHImage(seg, AFFINE).header
+    assert header.get_data_dtype() == np.dtype(">i2"), "the input really is int16"
+
+    out_file = tmp_path / "aseg.auto.mgz"
+    reduce_to_aseg_and_save(seg, AFFINE, header, out_file)
+
+    written = nib.load(out_file)
+    assert written.get_data_dtype() == np.dtype(np.uint8)
+    # the labels survive the narrowing: cortex became 3 and 42, the rest is unchanged
+    assert set(np.unique(np.asarray(written.dataobj))) == {0, 3, 17, 42, 251}
+
+
+def label_above_255():
+    seg = dkt_segmentation()
+    seg[4] = 500
+    return seg, 500.0
+
+
+def negative_label():
+    seg = dkt_segmentation()
+    seg[4] = -1
+    return seg, -1.0
+
+
+def fractional_float():
+    seg = dkt_segmentation().astype(np.float32)
+    seg[4] = 17.6
+    return seg, 17.6
+
+
+@pytest.mark.parametrize(
+    "case", [label_above_255, negative_label, fractional_float],
+    ids=["above 255", "negative", "fractional float"],
+)
+def test_data_that_uchar_would_damage_is_not_narrowed(case, tmp_path):
+    """Narrowing must never round or clip. Only integer labels within 0 to 255 are eligible.
+
+    Without the range and dtype check, uchar turned 17.6 into 18 and -1 into 0, silently.
+    """
+    seg, sentinel = case()
+    header = nib.MGHImage(seg, AFFINE).header
+
+    out_file = tmp_path / "wide.mgz"
+    reduce_to_aseg_and_save(seg, AFFINE, header, out_file)
+
+    written = nib.load(out_file)
+    assert written.get_data_dtype() != np.dtype(np.uint8)
+    assert sentinel in np.asarray(written.dataobj)
 
 
 def test_conformed_copy_of_a_float_input_is_not_float(tmp_path):

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -113,6 +113,63 @@ def test_integer_data_wider_than_the_header_is_not_clipped(container, tmp_path):
     assert np.asarray(written.dataobj).max() == 500
 
 
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([0, 500], np.dtype(">u2")),
+        ([-1, 500], np.dtype(">i2")),
+        ([0, 2 ** 20], np.dtype(">i4")),
+    ],
+    ids=["fits uint16", "needs a sign", "needs int32"],
+)
+def test_widening_picks_a_type_mgh_can_store(values, expected, tmp_path):
+    """int64 is the default integer width here, and MGH cannot store it.
+
+    Widening to the array's own type therefore hit the MGHError fallback, which handed the type back
+    to the narrow header and clipped after all: 500 was written as 255, with two log lines saying
+    first that clipping had been avoided and then that it had not.
+    """
+    labels = np.zeros(SHAPE, dtype=np.int64)
+    labels[0, 0, 0], labels[0, 0, 1] = values
+    header = nib.MGHImage(np.zeros(SHAPE, dtype=np.uint8), AFFINE).header
+
+    out_file = tmp_path / "labels.mgz"
+    nib.save(as_mgh_image(labels, AFFINE, header), out_file)
+
+    written = nib.load(out_file)
+    assert written.get_data_dtype() == expected
+    assert set(np.asarray(written.dataobj).flatten().tolist()) == {0, *values}
+
+
+def test_prefer_dtype_is_ignored_when_it_would_lose_data(tmp_path):
+    """The narrowing knob is a preference, not a force, so it cannot be used to clip."""
+    labels = np.zeros(SHAPE, dtype=np.int16)
+    labels[0, 0, 0] = 500
+    header = nib.MGHImage(labels, AFFINE).header
+
+    fitting = as_mgh_image(np.zeros(SHAPE, dtype=np.int16), AFFINE, header, prefer_dtype=np.uint8)
+    assert fitting.get_data_dtype() == np.dtype(np.uint8), "honoured where the data fits"
+
+    out_file = tmp_path / "labels.mgz"
+    nib.save(as_mgh_image(labels, AFFINE, header, prefer_dtype=np.uint8), out_file)
+    written = nib.load(out_file)
+    assert written.get_data_dtype() != np.dtype(np.uint8)
+    assert np.asarray(written.dataobj).max() == 500
+
+
+def test_explicit_dtype_says_when_it_clips(tmp_path, caplog):
+    """save_image still forces the type, since run_prediction narrows with it, but no longer silently."""
+    labels = np.zeros(SHAPE, dtype=np.int16)
+    labels[0, 0, 0] = 500
+    header = nib.MGHImage(labels, AFFINE).header
+
+    out_file = tmp_path / "forced.mgz"
+    save_image(header, AFFINE, labels, out_file, dtype=np.uint8)
+
+    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8), "the caller's decision stands"
+    assert "does not fit" in caplog.text
+
+
 def test_fits_dtype():
     """The shared rule the writers narrow by."""
     assert fits_dtype(np.zeros(SHAPE, np.int16), np.uint8), "in range"

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -8,11 +8,11 @@ four times the size of the uint8 one it asked for, holding nothing but integers.
 Three rules are pinned here.
 
 - The written type does not depend on the container the header came from, nor on the container it is
-  written to. Only where a format cannot store the answer, as MGH cannot store float64, does the
-  file name change what is written.
-- A type that would round or clip the data is refused, not quietly replaced. Narrowing is the
-  caller's to do, deliberately and outside, because only the caller knows whether to cast, to
-  rescale or to refuse.
+  written to. The output format only decides which types are available at all.
+- A type that cannot be honoured is refused, not quietly replaced: neither one that would round or
+  clip the data, nor one the format cannot store. Narrowing is the caller's to do, deliberately and
+  outside, because only the caller knows whether to cast, to rescale or to refuse. The single output
+  whose type is not ours to choose asks for `storable_dtype` on purpose.
 - The aseg files are written as uchar, as FreeSurfer writes them, rather than inheriting the int16
   of the segmentation they are reduced from.
 """
@@ -69,56 +69,56 @@ def test_dtype_depends_on_neither_container(dtype, source, suffix, tmp_path):
     assert written(out_file).get_data_dtype().newbyteorder("=") == np.dtype(dtype)
 
 
-def test_float64_survives_where_the_format_allows_it(tmp_path):
-    """NIfTI can store float64, so nothing is degraded there."""
-    data = np.zeros(SHAPE, dtype=np.float64)
-    data[0, 0, 0] = 0.1 + 0.2  # not representable in float32
+@pytest.mark.parametrize("dtype", [np.int64, np.float64], ids=["int64", "float64"])
+def test_a_wide_type_survives_where_the_format_allows_it(dtype, tmp_path):
+    """NIfTI stores int64 and float64, so neither is narrowed there. The .mgz mirror is below."""
+    data = np.full(SHAPE, 2 ** 40 if dtype is np.int64 else 0.1 + 0.2, dtype=dtype)
 
     out_file = tmp_path / "x.nii.gz"
-    save_image(header_of(np.float64, "nifti"), AFFINE, data, out_file)
+    save_image(header_of(dtype, "nifti"), AFFINE, data, out_file)
 
-    assert written(out_file).get_data_dtype() == np.dtype(np.float64)
-    assert np.asarray(written(out_file).dataobj)[0, 0, 0] == 0.1 + 0.2
+    assert written(out_file).get_data_dtype() == np.dtype(dtype)
+    assert np.asarray(written(out_file).dataobj)[0, 0, 0] == data[0, 0, 0]
 
 
-@pytest.mark.parametrize("container", ["mgh", "nifti"])
+def probabilities():
+    """The CC soft labels: written with the header of the conformed image, which is uchar."""
+    data = np.zeros(SHAPE, dtype=np.float32)
+    data[0, 0, 0] = 0.37
+    return data
+
+
+def label_over_uchar():
+    """A label a uchar cannot hold, which used to be written as 255."""
+    data = np.zeros(SHAPE, dtype=np.int16)
+    data[0, 0, 0] = 500
+    return data
+
+
+@pytest.mark.parametrize(
+    ("data", "header_dtype", "explicit", "damage"),
+    [
+        (probabilities, np.uint8, None, "rounded"),
+        (probabilities, np.int16, np.uint8, "rounded"),
+        (label_over_uchar, np.uint8, None, "clipped"),
+        (label_over_uchar, np.int16, np.uint8, "clipped"),
+    ],
+    ids=["float via header", "float via dtype", "wide via header", "wide via dtype"],
+)
 @BOTH_FORMATS
-def test_float_data_with_an_integer_header_is_refused(container, suffix, tmp_path):
-    """Probabilities must never be rounded into a label type, in either direction.
+def test_a_type_that_would_lose_data_is_refused(data, header_dtype, explicit, damage, suffix, tmp_path):
+    """Both axes, both kinds of loss, both formats.
 
-    The CC module writes its soft labels with the header of the conformed image, which is uchar, so
-    0.37 was stored as 0 and the probability map came back as a binary mask. The module now says
-    float32 at the call site; anything that does not is a bug, and says so.
+    The header axis is how the bugs arrived: 0.37 stored as 0 turned the CC probability map into a
+    binary mask, and a uchar header with a 500 in it wrote 255. The dtype axis is the same rule
+    applied to what a caller asks for, so the knob cannot be used to clip either. `data.astype(...)`
+    at the call site is how you ask for that on purpose.
+
+    The header's own container is not varied, because `test_dtype_depends_on_neither_container`
+    already establishes that it makes no difference.
     """
-    soft_labels = np.zeros(SHAPE, dtype=np.float32)
-    soft_labels[0, 0, 0] = 0.37
-
-    with pytest.raises(ValueError, match="would be rounded"):
-        save_image(header_of(np.uint8, container), AFFINE, soft_labels, tmp_path / f"soft{suffix}")
-
-
-@pytest.mark.parametrize("container", ["mgh", "nifti"])
-@BOTH_FORMATS
-def test_integer_data_wider_than_the_header_is_refused(container, suffix, tmp_path):
-    """The mirror of the float case: a header narrower than its data must not silently clip it.
-
-    A uchar header with int16 data holding 500 wrote 255, losing the label. The NIfTI path escaped
-    the clipping only by rescaling instead, which turns the label into 500.00000059604645.
-    """
-    labels = np.zeros(SHAPE, dtype=np.int16)
-    labels[0, 0, 0] = 500
-
-    with pytest.raises(ValueError, match="would be clipped"):
-        save_image(header_of(np.uint8, container), AFFINE, labels, tmp_path / f"labels{suffix}")
-
-
-def test_explicit_dtype_that_would_lose_data_is_refused(tmp_path):
-    """The knob cannot be used to clip. `data.astype(...)` at the call site is how you ask for that."""
-    labels = np.zeros(SHAPE, dtype=np.int16)
-    labels[0, 0, 0] = 500
-
-    with pytest.raises(ValueError, match="would be clipped"):
-        save_image(header_of(np.int16), AFFINE, labels, tmp_path / "forced.mgz", dtype=np.uint8)
+    with pytest.raises(ValueError, match=f"would be {damage}"):
+        save_image(header_of(header_dtype), AFFINE, data(), tmp_path / f"x{suffix}", dtype=explicit)
 
 
 def test_explicit_dtype_overrides_the_header(tmp_path):
@@ -133,27 +133,41 @@ def test_explicit_dtype_overrides_the_header(tmp_path):
     assert np.asarray(written(out_file).dataobj).max() == 42
 
 
+def int64_of(*values):
+    data = np.zeros(SHAPE, dtype=np.int64)
+    for i, value in enumerate(values):
+        data.flat[i] = value
+    return data
+
+
 @pytest.mark.parametrize(
-    ("values", "expected"),
-    [([0, 250], np.int16), ([-1, 500], np.int16), ([0, 2 ** 20], np.int32)],
-    ids=["small", "signed", "large"],
+    ("data", "expected"),
+    [
+        (lambda: int64_of(0, 250), np.int16),
+        (lambda: int64_of(-1, 500), np.int16),
+        (lambda: int64_of(0, 2 ** 20), np.int32),
+        (lambda: np.full(SHAPE, 0.1 + 0.2, np.float64), np.float32),
+    ],
+    ids=["small", "signed", "large", "float64"],
 )
-def test_storable_dtype_moves_up_one_step_at_a_time(values, expected, tmp_path):
-    """int64 is the default integer width in numpy, and MGH cannot store it.
+def test_storable_dtype_writes_the_archival_copy(data, expected, tmp_path):
+    """mri/orig/001.mgz, whose type belongs to whoever produced the input file.
 
-    An archival copy of such data has to land on a type the format has: the narrowest that holds
-    every value, and signed, because the source was. Values in 0 to 250 would fit uchar, but
-    changing the signedness of someone else's data is a bigger liberty than a wider file.
+    int64 is the default integer width in numpy and float64 is what a scaled NIfTI reads back as,
+    and MGH stores neither. Such data has to land on a type the format has: the narrowest that holds
+    every value, and of the same kind, so a float stays a float and signed stays signed. Values in 0
+    to 250 would fit uchar, but changing the signedness of someone else's data is a bigger liberty
+    than a wider file.
     """
-    labels = np.zeros(SHAPE, dtype=np.int64)
-    labels[0, 0, 0], labels[0, 0, 1] = values
-    out_file = tmp_path / "labels.mgz"
+    array = data()
+    out_file = tmp_path / "001.mgz"
 
-    save_image(header_of(np.int64, "nifti"), AFFINE, labels, out_file,
-               dtype=storable_dtype(labels))
+    save_image(header_of(array.dtype, "nifti"), AFFINE, array, out_file,
+               dtype=storable_dtype(array))
 
-    assert set(np.asarray(written(out_file).dataobj).flatten().tolist()) == {0, *values}
     assert written(out_file).get_data_dtype().newbyteorder("=") == np.dtype(expected)
+    if np.issubdtype(array.dtype, np.integer):
+        assert set(np.asarray(written(out_file).dataobj).flatten().tolist()) == set(array.flatten().tolist())
 
 
 @pytest.mark.parametrize("wanted", [np.int64, np.float64], ids=["int64", "float64"])
@@ -170,14 +184,6 @@ def test_a_type_mgh_cannot_store_is_refused(wanted, tmp_path):
         save_image(header_of(wanted, "nifti"), AFFINE, data, tmp_path / "x.mgz", dtype=wanted)
 
 
-def test_the_exactness_boundary_is_where_the_float_stops_counting():
-    """An integer rounded into a float loses its identity, so a float target has a range too."""
-    fits = np.full(SHAPE, 2 ** 24, dtype=np.int64)
-    assert fits_dtype(fits, np.float32), "float32 counts every integer up to 2**24"
-    assert not fits_dtype(fits + 1, np.float32), "and not the one after it"
-    assert fits_dtype(fits + 1, np.float64), "float64 counts far past it"
-
-
 def test_storable_dtype_keeps_the_kind_and_the_values():
     """The archival copy of the input, whose type was chosen by whoever produced the file."""
     for dtype in (np.uint8, np.int16, np.int32, np.float32):
@@ -192,30 +198,6 @@ def test_storable_dtype_keeps_the_kind_and_the_values():
 
     with pytest.raises(ValueError, match="cannot store"):
         storable_dtype(np.full(SHAPE, 2 ** 40, np.int64))
-
-
-def test_storable_dtype_lets_the_archival_copy_be_written(tmp_path):
-    """The one caller: a float64 or scaled NIfTI input copied to mri/orig/001.mgz."""
-    data = np.zeros(SHAPE, dtype=np.float64)
-    data[0, 0, 0] = 0.1 + 0.2
-
-    out_file = tmp_path / "001.mgz"
-    save_image(header_of(np.float64, "nifti"), AFFINE, data, out_file,
-               dtype=storable_dtype(data))
-
-    assert written(out_file).get_data_dtype() == np.dtype(">f4")
-
-
-def test_int64_survives_where_the_format_allows_it(tmp_path):
-    """NIfTI can store int64, so the same data keeps its type there."""
-    labels = np.zeros(SHAPE, dtype=np.int64)
-    labels[0, 0, 0] = 2 ** 40
-
-    out_file = tmp_path / "labels.nii.gz"
-    save_image(header_of(np.int64, "nifti"), AFFINE, labels, out_file)
-
-    assert written(out_file).get_data_dtype() == np.dtype(np.int64)
-    assert np.asarray(written(out_file).dataobj).max() == 2 ** 40
 
 
 def test_an_integer_nifti_carries_no_scale_factor(tmp_path):
@@ -271,9 +253,14 @@ def test_fits_dtype():
     assert not fits_dtype(np.zeros(SHAPE, np.float32), np.uint8), "a float would be rounded"
     assert fits_dtype(np.zeros(SHAPE, np.uint8), np.int16), "widening always fits"
     assert fits_dtype(np.zeros(SHAPE, np.int16), np.float32), "a float holds a small integer"
-    assert not fits_dtype(np.full(SHAPE, 2 ** 40, np.int64), np.float32), "but not a large one"
     assert fits_dtype(np.zeros(SHAPE, np.float64), np.float32), "a float may lose only precision"
     assert fits_dtype(np.zeros((0,), np.int16), np.uint8), "an empty array has nothing to clip"
+    assert fits_dtype(np.zeros(SHAPE, bool), np.uint8), "a bool is 0 or 1, so it always fits"
+    # an integer rounded into a float loses its identity, so a float target has a range too
+    exact = np.full(SHAPE, 2 ** 24, dtype=np.int64)
+    assert fits_dtype(exact, np.float32), "float32 counts every integer up to 2**24"
+    assert not fits_dtype(exact + 1, np.float32), "and not the one after it"
+    assert fits_dtype(exact + 1, np.float64), "float64 counts far past it"
 
 
 def test_only_the_type_changes_not_the_rest_of_the_header(tmp_path):

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -16,7 +16,9 @@ import numpy as np
 import pytest
 
 from FastSurferCNN.data_loader.data_utils import (
+    MGH_INT_DTYPES,
     as_mgh_image,
+    choose_dtype,
     fits_dtype,
     load_maybe_conform,
     save_image,
@@ -114,20 +116,17 @@ def test_integer_data_wider_than_the_header_is_not_clipped(container, tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("values", "expected"),
-    [
-        ([0, 500], np.dtype(">u2")),
-        ([-1, 500], np.dtype(">i2")),
-        ([0, 2 ** 20], np.dtype(">i4")),
-    ],
-    ids=["fits uint16", "needs a sign", "needs int32"],
+    "values", [[0, 500], [-1, 500], [0, 2 ** 20]], ids=["positive", "signed", "large"],
 )
-def test_widening_picks_a_type_mgh_can_store(values, expected, tmp_path):
+def test_widening_picks_a_type_mgh_can_store(values, tmp_path):
     """int64 is the default integer width here, and MGH cannot store it.
 
     Widening to the array's own type therefore hit the MGHError fallback, which handed the type back
     to the narrow header and clipped after all: 500 was written as 255, with two log lines saying
     first that clipping had been avoided and then that it had not.
+
+    The assertion is the contract, not which type is preferred: the values survive, and the type is
+    one an MGH file can hold.
     """
     labels = np.zeros(SHAPE, dtype=np.int64)
     labels[0, 0, 0], labels[0, 0, 1] = values
@@ -137,8 +136,25 @@ def test_widening_picks_a_type_mgh_can_store(values, expected, tmp_path):
     nib.save(as_mgh_image(labels, AFFINE, header), out_file)
 
     written = nib.load(out_file)
-    assert written.get_data_dtype() == expected
     assert set(np.asarray(written.dataobj).flatten().tolist()) == {0, *values}
+    assert written.get_data_dtype().newbyteorder("=") in [np.dtype(t) for t in MGH_INT_DTYPES]
+
+
+def test_choose_dtype():
+    """The decision behind every writer, without going through a file."""
+    labels = np.zeros(SHAPE, np.int16)
+    probabilities = np.zeros(SHAPE, np.float32)
+
+    assert choose_dtype(labels, np.int16) == np.dtype(np.int16), "the header holds it"
+    assert choose_dtype(labels, np.int16, np.uint8) == np.dtype(np.uint8), "narrowed on request"
+    assert choose_dtype(probabilities, np.uint8) == np.dtype(np.float32), "a float is not rounded"
+    assert choose_dtype(probabilities, np.uint8, np.uint8) == np.dtype(np.float32), "nor on request"
+
+    wide = np.full(SHAPE, 500, np.int64)
+    assert choose_dtype(wide, np.uint8) == np.dtype(np.int16), "widened past a header that clips"
+    assert choose_dtype(wide, np.uint8, np.uint8) == np.dtype(np.int16), "a request cannot clip"
+    # narrowest first, so a value needing more range moves up one step at a time
+    assert choose_dtype(np.full(SHAPE, 2 ** 20, np.int64), np.uint8) == np.dtype(np.int32)
 
 
 def test_prefer_dtype_is_ignored_when_it_would_lose_data(tmp_path):

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -1,14 +1,20 @@
-"""Regression tests for the data type of the .mgz files FastSurfer writes.
+"""Regression tests for the data type of the image files FastSurfer writes.
 
 `MGHHeader.from_header` does not carry the data type over from a non-MGH header: it returns float32
 whatever the source says. Every .mgz written with a header that came from a .nii was therefore stored
 as float32, which is how the 1mm copy CerebNet conforms for a high-res subject became a float32 file
 four times the size of the uint8 one it asked for, holding nothing but integers.
 
-The rule pinned here is that the written type must not depend on the container the header came from.
+Three rules are pinned here.
 
-The aseg files are the second half of the same problem: they inherit the header of the int16
-segmentation they are reduced from, where FreeSurfer, and FastSurfer up to v2.3.3, write uchar.
+- The written type does not depend on the container the header came from, nor on the container it is
+  written to. Only where a format cannot store the answer, as MGH cannot store float64, does the
+  file name change what is written.
+- A type that would round or clip the data is refused, not quietly replaced. Narrowing is the
+  caller's to do, deliberately and outside, because only the caller knows whether to cast, to
+  rescale or to refuse.
+- The aseg files are written as uchar, as FreeSurfer writes them, rather than inheriting the int16
+  of the segmentation they are reduced from.
 """
 
 import nibabel as nib
@@ -16,128 +22,227 @@ import numpy as np
 import pytest
 
 from FastSurferCNN.data_loader.data_utils import (
-    MGH_INT_DTYPES,
+    MGH_DTYPES,
+    NIFTI_DTYPES,
     as_mgh_image,
     choose_dtype,
     fits_dtype,
     load_maybe_conform,
     save_image,
+    storable_dtype,
 )
 from FastSurferCNN.reduce_to_aseg import create_mask_and_save, reduce_to_aseg_and_save
 
 AFFINE = np.eye(4)
 SHAPE = (8, 8, 8)
+BOTH_FORMATS = pytest.mark.parametrize("suffix", [".mgz", ".nii.gz"], ids=["mgz", "nii.gz"])
 
 
-def headers_of(dtype):
-    """The same image as a NIfTI and as an MGH header, plus no header at all."""
+def header_of(dtype, container="mgh"):
+    """A header of `dtype`, in either container."""
     data = np.zeros(SHAPE, dtype=dtype)
-    return {
-        "nifti": nib.Nifti1Image(data, AFFINE).header,
-        "mgh": nib.MGHImage(data, AFFINE).header,
-        "none": None,
-    }
+    if container == "mgh":
+        return nib.MGHImage(data, AFFINE).header
+    # nibabel refuses to guess int64 from the data, so the type is stated either way
+    return nib.Nifti1Image(data, AFFINE, dtype=dtype).header
+
+
+def written(path):
+    """The image at `path`, reloaded, so the assertions are about the file and not the object."""
+    return nib.load(path)
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.int32, np.float32], ids=str)
-@pytest.mark.parametrize("source", ["nifti", "mgh", "none"])
-def test_dtype_does_not_depend_on_the_source_container(dtype, source):
-    """The bug: a NIfTI header silently produced float32, an MGH header did not."""
-    data = np.zeros(SHAPE, dtype=dtype)
-    img = as_mgh_image(data, AFFINE, headers_of(dtype)[source])
-    # MGH stores big-endian, so compare in native byte order
-    assert img.get_data_dtype().newbyteorder("=") == np.dtype(dtype)
+@pytest.mark.parametrize("source", ["mgh", "nifti"])
+@BOTH_FORMATS
+def test_dtype_depends_on_neither_container(dtype, source, suffix, tmp_path):
+    """The bug: a NIfTI header silently produced float32, an MGH header did not.
 
-
-@pytest.mark.parametrize("with_header", [True, False], ids=["from a header", "headerless"])
-def test_unstorable_dtype_falls_back_instead_of_raising(with_header, caplog):
-    """MGH has no float64. That must degrade to float32 with a warning, not abort a run.
-
-    The headerless case is the one that bites: nibabel raises while constructing the image, before
-    any fallback of ours could run.
+    Extended to the output side, which was never handled at all: the same data and header written
+    as .mgz and as .nii.gz have to end up with the same type.
     """
+    data = np.zeros(SHAPE, dtype=dtype)
+    out_file = tmp_path / f"x{suffix}"
+    save_image(header_of(dtype, source), AFFINE, data, out_file)
+
+    # MGH stores big-endian, so compare in native byte order
+    assert written(out_file).get_data_dtype().newbyteorder("=") == np.dtype(dtype)
+
+
+def test_float64_survives_where_the_format_allows_it(tmp_path):
+    """NIfTI can store float64, so nothing is degraded there."""
     data = np.zeros(SHAPE, dtype=np.float64)
-    data[0, 0, 0] = 0.37
-    header = nib.Nifti1Image(data, AFFINE).header if with_header else None
+    data[0, 0, 0] = 0.1 + 0.2  # not representable in float32
 
-    img = as_mgh_image(data, AFFINE, header)
+    out_file = tmp_path / "x.nii.gz"
+    save_image(header_of(np.float64, "nifti"), AFFINE, data, out_file)
 
-    assert img.get_data_dtype() == np.dtype(">f4")
-    assert "cannot store" in caplog.text
+    assert written(out_file).get_data_dtype() == np.dtype(np.float64)
+    assert np.asarray(written(out_file).dataobj)[0, 0, 0] == 0.1 + 0.2
 
 
-@pytest.mark.parametrize("header_dtype", [np.uint8, np.int16], ids=["uint8", "int16"])
-@pytest.mark.parametrize("container", ["nifti", "mgh", "none"])
-def test_float_data_is_never_stored_as_an_integer(container, header_dtype, tmp_path):
-    """Probabilities must survive, whatever integer type the header carries.
+@pytest.mark.parametrize("container", ["mgh", "nifti"])
+@BOTH_FORMATS
+def test_float_data_with_an_integer_header_is_refused(container, suffix, tmp_path):
+    """Probabilities must never be rounded into a label type, in either direction.
 
     The CC module writes its soft labels with the header of the conformed image, which is uchar, so
-    0.37 was stored as 0 and the probability map came back as a binary mask. An MGH header is the
-    case that matters: nibabel applies its type while constructing the image, not only afterwards.
+    0.37 was stored as 0 and the probability map came back as a binary mask. The module now says
+    float32 at the call site; anything that does not is a bug, and says so.
     """
     soft_labels = np.zeros(SHAPE, dtype=np.float32)
     soft_labels[0, 0, 0] = 0.37
-    integers = np.zeros(SHAPE, dtype=header_dtype)
-    headers = {
-        "nifti": nib.Nifti1Image(integers, AFFINE).header,
-        "mgh": nib.MGHImage(integers, AFFINE).header,
-        "none": None,
-    }
 
-    out_file = tmp_path / "soft.mgz"
-    nib.save(as_mgh_image(soft_labels, AFFINE, headers[container]), out_file)
-
-    written = nib.load(out_file)
-    assert written.get_data_dtype() == np.dtype(">f4")
-    assert np.asarray(written.dataobj)[0, 0, 0] == pytest.approx(0.37)
+    with pytest.raises(ValueError, match="would be rounded"):
+        save_image(header_of(np.uint8, container), AFFINE, soft_labels, tmp_path / f"soft{suffix}")
 
 
-@pytest.mark.parametrize("container", ["nifti", "mgh"])
-def test_integer_data_wider_than_the_header_is_not_clipped(container, tmp_path):
+@pytest.mark.parametrize("container", ["mgh", "nifti"])
+@BOTH_FORMATS
+def test_integer_data_wider_than_the_header_is_refused(container, suffix, tmp_path):
     """The mirror of the float case: a header narrower than its data must not silently clip it.
 
-    A uchar header with int16 data holding 500 wrote 255, losing the label. The NIfTI path used to
-    escape it only because the type was dropped entirely and everything became float32.
+    A uchar header with int16 data holding 500 wrote 255, losing the label. The NIfTI path escaped
+    the clipping only by rescaling instead, which turns the label into 500.00000059604645.
     """
     labels = np.zeros(SHAPE, dtype=np.int16)
     labels[0, 0, 0] = 500
-    narrow = np.zeros(SHAPE, dtype=np.uint8)
-    header = {
-        "nifti": nib.Nifti1Image(narrow, AFFINE).header,
-        "mgh": nib.MGHImage(narrow, AFFINE).header,
-    }[container]
 
-    out_file = tmp_path / "labels.mgz"
-    nib.save(as_mgh_image(labels, AFFINE, header), out_file)
+    with pytest.raises(ValueError, match="would be clipped"):
+        save_image(header_of(np.uint8, container), AFFINE, labels, tmp_path / f"labels{suffix}")
 
-    written = nib.load(out_file)
-    assert written.get_data_dtype() != np.dtype(np.uint8)
-    assert np.asarray(written.dataobj).max() == 500
+
+def test_explicit_dtype_that_would_lose_data_is_refused(tmp_path):
+    """The knob cannot be used to clip. `data.astype(...)` at the call site is how you ask for that."""
+    labels = np.zeros(SHAPE, dtype=np.int16)
+    labels[0, 0, 0] = 500
+
+    with pytest.raises(ValueError, match="would be clipped"):
+        save_image(header_of(np.int16), AFFINE, labels, tmp_path / "forced.mgz", dtype=np.uint8)
+
+
+def test_explicit_dtype_overrides_the_header(tmp_path):
+    """What the knob is for: the aseg is uchar even though its header says int16."""
+    labels = np.zeros(SHAPE, dtype=np.int16)
+    labels[0, 0, 0] = 42
+
+    out_file = tmp_path / "explicit.mgz"
+    save_image(header_of(np.int16), AFFINE, labels, out_file, dtype=np.uint8)
+
+    assert written(out_file).get_data_dtype() == np.dtype(np.uint8)
+    assert np.asarray(written(out_file).dataobj).max() == 42
 
 
 @pytest.mark.parametrize(
-    "values", [[0, 500], [-1, 500], [0, 2 ** 20]], ids=["positive", "signed", "large"],
+    ("values", "expected"),
+    [([0, 250], np.int16), ([-1, 500], np.int16), ([0, 2 ** 20], np.int32)],
+    ids=["small", "signed", "large"],
 )
-def test_widening_picks_a_type_mgh_can_store(values, tmp_path):
-    """int64 is the default integer width here, and MGH cannot store it.
+def test_storable_dtype_moves_up_one_step_at_a_time(values, expected, tmp_path):
+    """int64 is the default integer width in numpy, and MGH cannot store it.
 
-    Widening to the array's own type therefore hit the MGHError fallback, which handed the type back
-    to the narrow header and clipped after all: 500 was written as 255, with two log lines saying
-    first that clipping had been avoided and then that it had not.
-
-    The assertion is the contract, not which type is preferred: the values survive, and the type is
-    one an MGH file can hold.
+    An archival copy of such data has to land on a type the format has: the narrowest that holds
+    every value, and signed, because the source was. Values in 0 to 250 would fit uchar, but
+    changing the signedness of someone else's data is a bigger liberty than a wider file.
     """
     labels = np.zeros(SHAPE, dtype=np.int64)
     labels[0, 0, 0], labels[0, 0, 1] = values
-    header = nib.MGHImage(np.zeros(SHAPE, dtype=np.uint8), AFFINE).header
-
     out_file = tmp_path / "labels.mgz"
-    nib.save(as_mgh_image(labels, AFFINE, header), out_file)
 
-    written = nib.load(out_file)
-    assert set(np.asarray(written.dataobj).flatten().tolist()) == {0, *values}
-    assert written.get_data_dtype().newbyteorder("=") in [np.dtype(t) for t in MGH_INT_DTYPES]
+    save_image(header_of(np.int64, "nifti"), AFFINE, labels, out_file,
+               dtype=storable_dtype(labels))
+
+    assert set(np.asarray(written(out_file).dataobj).flatten().tolist()) == {0, *values}
+    assert written(out_file).get_data_dtype().newbyteorder("=") == np.dtype(expected)
+
+
+@pytest.mark.parametrize("wanted", [np.int64, np.float64], ids=["int64", "float64"])
+def test_a_type_mgh_cannot_store_is_refused(wanted, tmp_path):
+    """MGH has no int64 and no float64, so it says so rather than picking something else.
+
+    Substituting was the earlier behaviour and it could answer a float64 request with uint8, which
+    is not a narrower version of the request but a different file. Callers that genuinely do not
+    choose their own type ask for `storable_dtype` instead.
+    """
+    data = np.zeros(SHAPE, dtype=wanted)
+
+    with pytest.raises(ValueError, match="cannot store"):
+        save_image(header_of(wanted, "nifti"), AFFINE, data, tmp_path / "x.mgz", dtype=wanted)
+
+
+def test_the_exactness_boundary_is_where_the_float_stops_counting():
+    """An integer rounded into a float loses its identity, so a float target has a range too."""
+    fits = np.full(SHAPE, 2 ** 24, dtype=np.int64)
+    assert fits_dtype(fits, np.float32), "float32 counts every integer up to 2**24"
+    assert not fits_dtype(fits + 1, np.float32), "and not the one after it"
+    assert fits_dtype(fits + 1, np.float64), "float64 counts far past it"
+
+
+def test_storable_dtype_keeps_the_kind_and_the_values():
+    """The archival copy of the input, whose type was chosen by whoever produced the file."""
+    for dtype in (np.uint8, np.int16, np.int32, np.float32):
+        own = np.zeros(SHAPE, dtype)
+        assert storable_dtype(own) == np.dtype(dtype), "a storable type is kept as it is"
+
+    # MGH has no float64, and the answer must still be a float rather than the narrowest that fits
+    assert storable_dtype(np.zeros(SHAPE, np.float64)) == np.dtype(np.float32)
+    # nor is an integer request answered with a float
+    assert np.issubdtype(storable_dtype(np.full(SHAPE, 300, np.int64)), np.integer)
+    assert fits_dtype(np.full(SHAPE, 300, np.int64), storable_dtype(np.full(SHAPE, 300, np.int64)))
+
+    with pytest.raises(ValueError, match="cannot store"):
+        storable_dtype(np.full(SHAPE, 2 ** 40, np.int64))
+
+
+def test_storable_dtype_lets_the_archival_copy_be_written(tmp_path):
+    """The one caller: a float64 or scaled NIfTI input copied to mri/orig/001.mgz."""
+    data = np.zeros(SHAPE, dtype=np.float64)
+    data[0, 0, 0] = 0.1 + 0.2
+
+    out_file = tmp_path / "001.mgz"
+    save_image(header_of(np.float64, "nifti"), AFFINE, data, out_file,
+               dtype=storable_dtype(data))
+
+    assert written(out_file).get_data_dtype() == np.dtype(">f4")
+
+
+def test_int64_survives_where_the_format_allows_it(tmp_path):
+    """NIfTI can store int64, so the same data keeps its type there."""
+    labels = np.zeros(SHAPE, dtype=np.int64)
+    labels[0, 0, 0] = 2 ** 40
+
+    out_file = tmp_path / "labels.nii.gz"
+    save_image(header_of(np.int64, "nifti"), AFFINE, labels, out_file)
+
+    assert written(out_file).get_data_dtype() == np.dtype(np.int64)
+    assert np.asarray(written(out_file).dataobj).max() == 2 ** 40
+
+
+def test_an_integer_nifti_carries_no_scale_factor(tmp_path):
+    """Left free, nibabel may add one, and a label read back through a scale is no longer an integer.
+
+    Pinned rather than assumed, because the slope is only visible in the file: nibabel folds it into
+    the array proxy on load and blanks the header field.
+    """
+    labels = np.zeros(SHAPE, dtype=np.int16)
+    labels[0, 0, 0] = 253
+
+    out_file = tmp_path / "labels.nii.gz"
+    save_image(header_of(np.int16, "nifti"), AFFINE, labels, out_file)
+
+    assert written(out_file).dataobj.slope == 1.0
+    assert written(out_file).dataobj.inter == 0.0
+    assert np.asarray(written(out_file).dataobj)[0, 0, 0] == 253
+
+
+def test_header_is_required():
+    """The affine covers the geometry, but only the header carries the acquisition parameters.
+
+    Every caller has one. Leaving the argument optional meant a headerless call fell through to the
+    data's own type, which for int64 is a type no MGH file can store.
+    """
+    with pytest.raises(TypeError):
+        as_mgh_image(np.zeros(SHAPE, dtype=np.uint8), AFFINE)
 
 
 def test_choose_dtype():
@@ -145,60 +250,34 @@ def test_choose_dtype():
     labels = np.zeros(SHAPE, np.int16)
     probabilities = np.zeros(SHAPE, np.float32)
 
-    assert choose_dtype(labels, np.int16) == np.dtype(np.int16), "the header holds it"
-    assert choose_dtype(labels, np.int16, np.uint8) == np.dtype(np.uint8), "narrowed on request"
-    assert choose_dtype(probabilities, np.uint8) == np.dtype(np.float32), "a float is not rounded"
-    assert choose_dtype(probabilities, np.uint8, np.uint8) == np.dtype(np.float32), "nor on request"
+    assert choose_dtype(labels, header_of(np.int16)) == np.dtype(np.int16), "the header holds it"
+    assert choose_dtype(labels, header_of(np.int16), np.uint8) == np.dtype(np.uint8), "narrowed on request"
+    # the byte order belongs to the format, not to the decision
+    assert choose_dtype(labels, header_of(np.int16)).byteorder in "=|"
 
-    wide = np.full(SHAPE, 500, np.int64)
-    assert choose_dtype(wide, np.uint8) == np.dtype(np.int16), "widened past a header that clips"
-    assert choose_dtype(wide, np.uint8, np.uint8) == np.dtype(np.int16), "a request cannot clip"
-    # narrowest first, so a value needing more range moves up one step at a time
-    assert choose_dtype(np.full(SHAPE, 2 ** 20, np.int64), np.uint8) == np.dtype(np.int32)
-
-
-def test_prefer_dtype_is_ignored_when_it_would_lose_data(tmp_path):
-    """The narrowing knob is a preference, not a force, so it cannot be used to clip."""
-    labels = np.zeros(SHAPE, dtype=np.int16)
-    labels[0, 0, 0] = 500
-    header = nib.MGHImage(labels, AFFINE).header
-
-    fitting = as_mgh_image(np.zeros(SHAPE, dtype=np.int16), AFFINE, header, prefer_dtype=np.uint8)
-    assert fitting.get_data_dtype() == np.dtype(np.uint8), "honoured where the data fits"
-
-    out_file = tmp_path / "labels.mgz"
-    nib.save(as_mgh_image(labels, AFFINE, header, prefer_dtype=np.uint8), out_file)
-    written = nib.load(out_file)
-    assert written.get_data_dtype() != np.dtype(np.uint8)
-    assert np.asarray(written.dataobj).max() == 500
-
-
-def test_explicit_dtype_says_when_it_clips(tmp_path, caplog):
-    """save_image still forces the type, since run_prediction narrows with it, but no longer silently."""
-    labels = np.zeros(SHAPE, dtype=np.int16)
-    labels[0, 0, 0] = 500
-    header = nib.MGHImage(labels, AFFINE).header
-
-    out_file = tmp_path / "forced.mgz"
-    save_image(header, AFFINE, labels, out_file, dtype=np.uint8)
-
-    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8), "the caller's decision stands"
-    assert "does not fit" in caplog.text
+    with pytest.raises(ValueError, match="would be rounded"):
+        choose_dtype(probabilities, header_of(np.uint8))
+    with pytest.raises(ValueError, match="would be rounded"):
+        choose_dtype(probabilities, header_of(np.int16), np.uint8)
+    with pytest.raises(ValueError, match="would be clipped"):
+        choose_dtype(np.full(SHAPE, 500, np.int16), header_of(np.uint8))
 
 
 def test_fits_dtype():
-    """The shared rule the writers narrow by."""
+    """The shared rule the writers decide by."""
     assert fits_dtype(np.zeros(SHAPE, np.int16), np.uint8), "in range"
     assert not fits_dtype(np.full(SHAPE, 500, np.int16), np.uint8), "above the range"
     assert not fits_dtype(np.full(SHAPE, -1, np.int16), np.uint8), "below the range"
     assert not fits_dtype(np.zeros(SHAPE, np.float32), np.uint8), "a float would be rounded"
     assert fits_dtype(np.zeros(SHAPE, np.uint8), np.int16), "widening always fits"
-    assert fits_dtype(np.zeros(SHAPE, np.int16), np.float32), "a float target holds any integer"
+    assert fits_dtype(np.zeros(SHAPE, np.int16), np.float32), "a float holds a small integer"
+    assert not fits_dtype(np.full(SHAPE, 2 ** 40, np.int64), np.float32), "but not a large one"
+    assert fits_dtype(np.zeros(SHAPE, np.float64), np.float32), "a float may lose only precision"
     assert fits_dtype(np.zeros((0,), np.int16), np.uint8), "an empty array has nothing to clip"
 
 
 def test_only_the_type_changes_not_the_rest_of_the_header(tmp_path):
-    """Widening the type must not cost the header. Only the type is ours to override."""
+    """Setting the type must not cost the header. Only the type is ours to override."""
     source = nib.MGHImage(np.zeros(SHAPE, dtype=np.uint8), AFFINE)
     # the keys are MGH header field names, hence the ignore for the echo time one
     acquisition = {"tr": 2300.0, "te": 2.98, "ti": 900.0, "flip_angle": 0.15708}  # codespell:ignore te
@@ -208,24 +287,22 @@ def test_only_the_type_changes_not_the_rest_of_the_header(tmp_path):
     soft_labels = np.zeros(SHAPE, dtype=np.float32)
     soft_labels[0, 0, 0] = 0.37
     out_file = tmp_path / "soft.mgz"
-    nib.save(as_mgh_image(soft_labels, AFFINE, source.header), out_file)
+    nib.save(as_mgh_image(soft_labels, AFFINE, source.header, dtype=np.float32), out_file)
 
-    written = nib.load(out_file)
-    assert written.get_data_dtype() == np.dtype(">f4"), "the type is widened"
+    assert written(out_file).get_data_dtype() == np.dtype(">f4"), "the requested type is used"
     for field, value in acquisition.items():
-        assert float(written.header[field]) == pytest.approx(value), f"{field} survives"
-    assert np.allclose(written.affine, AFFINE)
+        assert float(written(out_file).header[field]) == pytest.approx(value), f"{field} survives"
+    assert np.allclose(written(out_file).affine, AFFINE)
 
 
-def test_explicit_dtype_still_wins(tmp_path):
-    """save_image(dtype=...) overrides whatever the header carried."""
-    data = np.zeros(SHAPE, dtype=np.float32)
-    header = nib.Nifti1Image(data, AFFINE).header
+def test_the_caller_header_is_not_modified():
+    """The aseg and the mask are written from one header on two threads, so it must not be touched."""
+    header = header_of(np.uint8)
+    before = (header.get_data_dtype(), float(header["fov"]))
 
-    out_file = tmp_path / "explicit.mgz"
-    save_image(header, AFFINE, data, out_file, dtype=np.uint8)
+    as_mgh_image(np.zeros(SHAPE, dtype=np.uint8), AFFINE, header, dtype=np.int16)
 
-    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)
+    assert (header.get_data_dtype(), float(header["fov"])) == before
 
 
 def dkt_segmentation():
@@ -244,10 +321,9 @@ def test_aseg_is_written_as_uchar(tmp_path):
     out_file = tmp_path / "aseg.auto.mgz"
     reduce_to_aseg_and_save(seg, AFFINE, header, out_file)
 
-    written = nib.load(out_file)
-    assert written.get_data_dtype() == np.dtype(np.uint8)
+    assert written(out_file).get_data_dtype() == np.dtype(np.uint8)
     # the labels survive the narrowing: cortex became 3 and 42, the rest is unchanged
-    assert set(np.unique(np.asarray(written.dataobj))) == {0, 3, 17, 42, 251}
+    assert set(np.unique(np.asarray(written(out_file).dataobj))) == {0, 3, 17, 42, 251}
 
 
 def test_mask_is_written_as_uchar(tmp_path):
@@ -259,46 +335,32 @@ def test_mask_is_written_as_uchar(tmp_path):
     out_file = tmp_path / "mask.mgz"
     create_mask_and_save(seg, AFFINE, header, out_file)
 
-    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)
+    assert written(out_file).get_data_dtype() == np.dtype(np.uint8)
 
 
 def label_above_255():
     seg = dkt_segmentation()
     seg[4] = 500
-    return seg, 500.0
+    return seg
 
 
 def negative_label():
     seg = dkt_segmentation()
     seg[4] = -1
-    return seg, -1.0
+    return seg
 
 
-def fractional_float():
-    # 17.5 is exact in float32, so the assertion tests the narrowing and not float promotion
-    seg = dkt_segmentation().astype(np.float32)
-    seg[4] = 17.5
-    return seg, 17.5
+@pytest.mark.parametrize("case", [label_above_255, negative_label], ids=["above 255", "negative"])
+def test_an_aseg_uchar_would_damage_is_refused(case, tmp_path):
+    """reduce_to_aseg asks for uchar because an aseg has no label outside it.
 
-
-@pytest.mark.parametrize(
-    "case", [label_above_255, negative_label, fractional_float],
-    ids=["above 255", "negative", "fractional float"],
-)
-def test_data_that_uchar_would_damage_is_not_narrowed(case, tmp_path):
-    """Narrowing must never round or clip. Only integer labels within 0 to 255 are eligible.
-
-    Without the range and dtype check, uchar turned 17.6 into 18 and -1 into 0, silently.
+    If one ever appears, that is a bug upstream, and it has to surface rather than be papered over
+    by writing a type FreeSurfer does not expect here.
     """
-    seg, sentinel = case()
-    header = nib.MGHImage(seg, AFFINE).header
+    header = nib.MGHImage(case(), AFFINE).header
 
-    out_file = tmp_path / "wide.mgz"
-    reduce_to_aseg_and_save(seg, AFFINE, header, out_file)
-
-    written = nib.load(out_file)
-    assert written.get_data_dtype() != np.dtype(np.uint8)
-    assert sentinel in np.asarray(written.dataobj)
+    with pytest.raises(ValueError, match="would be clipped"):
+        reduce_to_aseg_and_save(case(), AFFINE, header, tmp_path / "wide.mgz")
 
 
 def test_conformed_copy_of_a_float_input_is_not_float(tmp_path):
@@ -318,4 +380,27 @@ def test_conformed_copy_of_a_float_input_is_not_float(tmp_path):
         dtype=np.uint8,
     )
 
-    assert nib.load(out_file).get_data_dtype() == np.dtype(np.uint8)
+    assert written(out_file).get_data_dtype() == np.dtype(np.uint8)
+
+
+@pytest.mark.parametrize(
+    ("candidates", "container"), [(MGH_DTYPES, nib.MGHImage), (NIFTI_DTYPES, nib.Nifti1Image)],
+    ids=["mgz", "nii.gz"],
+)
+def test_the_dtype_lists_are_what_the_format_really_takes(candidates, container):
+    """The lists decide what is refused, so a missing entry refuses something that would have worked.
+
+    Checked against nibabel rather than trusted, because that is the only authority on it.
+    """
+    every = (np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32,
+             np.uint64, np.int64, np.float32, np.float64)
+    accepted = set()
+    for dtype in every:
+        img = container(np.zeros((2, 2, 2), np.uint8), AFFINE)
+        try:
+            img.set_data_dtype(dtype)
+            accepted.add(np.dtype(dtype))
+        except Exception:  # noqa: BLE001  the format refusing is the answer we want
+            pass
+
+    assert {np.dtype(c) for c in candidates} == accepted

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -1,11 +1,8 @@
-"""Regression tests for the data type of the image files FastSurfer writes.
+"""Tests for the data type of the image files FastSurfer writes.
 
 `MGHHeader.from_header` does not carry the data type over from a non-MGH header: it returns float32
-whatever the source says. Every .mgz written with a header that came from a .nii was therefore stored
-as float32, which is how the 1mm copy CerebNet conforms for a high-res subject became a float32 file
-four times the size of the uint8 one it asked for, holding nothing but integers.
-
-Three rules are pinned here.
+whatever the source says. `as_mgh_image` sets it instead, which is what makes the three rules below
+hold.
 
 - The written type does not depend on the container the header came from, nor on the container it is
   written to. The output format only decides which types are available at all.
@@ -13,8 +10,8 @@ Three rules are pinned here.
   clip the data, nor one the format cannot store. Narrowing is the caller's to do, deliberately and
   outside, because only the caller knows whether to cast, to rescale or to refuse. The single output
   whose type is not ours to choose asks for `storable_dtype` on purpose.
-- The aseg files are written as uchar, as FreeSurfer writes them, rather than inheriting the int16
-  of the segmentation they are reduced from.
+- The aseg files are written as uchar, as FreeSurfer writes them, whatever the type of the
+  segmentation they were reduced from.
 """
 
 import nibabel as nib
@@ -56,11 +53,7 @@ def written(path):
 @pytest.mark.parametrize("source", ["mgh", "nifti"])
 @BOTH_FORMATS
 def test_dtype_depends_on_neither_container(dtype, source, suffix, tmp_path):
-    """The bug: a NIfTI header silently produced float32, an MGH header did not.
-
-    Extended to the output side, which was never handled at all: the same data and header written
-    as .mgz and as .nii.gz have to end up with the same type.
-    """
+    """The same data and header give the same type, whichever container is on either side."""
     data = np.zeros(SHAPE, dtype=dtype)
     out_file = tmp_path / f"x{suffix}"
     save_image(header_of(dtype, source), AFFINE, data, out_file)
@@ -82,14 +75,14 @@ def test_a_wide_type_survives_where_the_format_allows_it(dtype, tmp_path):
 
 
 def probabilities():
-    """The CC soft labels: written with the header of the conformed image, which is uchar."""
+    """Soft labels, as the CC module writes them with the header of the conformed image."""
     data = np.zeros(SHAPE, dtype=np.float32)
     data[0, 0, 0] = 0.37
     return data
 
 
 def label_over_uchar():
-    """A label a uchar cannot hold, which used to be written as 255."""
+    """A label a uchar cannot hold."""
     data = np.zeros(SHAPE, dtype=np.int16)
     data[0, 0, 0] = 500
     return data
@@ -109,10 +102,9 @@ def label_over_uchar():
 def test_a_type_that_would_lose_data_is_refused(data, header_dtype, explicit, damage, suffix, tmp_path):
     """Both axes, both kinds of loss, both formats.
 
-    The header axis is how the bugs arrived: 0.37 stored as 0 turned the CC probability map into a
-    binary mask, and a uchar header with a 500 in it wrote 255. The dtype axis is the same rule
-    applied to what a caller asks for, so the knob cannot be used to clip either. `data.astype(...)`
-    at the call site is how you ask for that on purpose.
+    The rule is the same whether the type came from the header or from the caller, so the `dtype`
+    knob cannot be used to clip either. `data.astype(...)` at the call site is how you ask for that
+    on purpose.
 
     The header's own container is not varied, because `test_dtype_depends_on_neither_container`
     already establishes that it makes no difference.
@@ -174,9 +166,8 @@ def test_storable_dtype_writes_the_archival_copy(data, expected, tmp_path):
 def test_a_type_mgh_cannot_store_is_refused(wanted, tmp_path):
     """MGH has no int64 and no float64, so it says so rather than picking something else.
 
-    Substituting was the earlier behaviour and it could answer a float64 request with uint8, which
-    is not a narrower version of the request but a different file. Callers that genuinely do not
-    choose their own type ask for `storable_dtype` instead.
+    A float64 request answered with an integer would not be a narrower version of the request but a
+    different file. Callers that do not choose their own type ask for `storable_dtype` instead.
     """
     data = np.zeros(SHAPE, dtype=wanted)
 
@@ -220,8 +211,8 @@ def test_an_integer_nifti_carries_no_scale_factor(tmp_path):
 def test_header_is_required():
     """The affine covers the geometry, but only the header carries the acquisition parameters.
 
-    Every caller has one. Leaving the argument optional meant a headerless call fell through to the
-    data's own type, which for int64 is a type no MGH file can store.
+    Every caller has one, so it is required rather than optional and a caller with no source image
+    has to say so by passing an `MGHHeader()`.
     """
     with pytest.raises(TypeError):
         as_mgh_image(np.zeros(SHAPE, dtype=np.uint8), AFFINE)
@@ -300,7 +291,7 @@ def dkt_segmentation():
 
 
 def test_aseg_is_written_as_uchar(tmp_path):
-    """FreeSurfer writes aseg.auto.mgz as uchar, and so did FastSurfer before the int16 carried over."""
+    """FreeSurfer writes aseg.auto.mgz as uchar, so FastSurfer does too."""
     seg = dkt_segmentation()
     header = nib.MGHImage(seg, AFFINE).header
     assert header.get_data_dtype() == np.dtype(">i2"), "the input really is int16"
@@ -341,8 +332,8 @@ def negative_label():
 def test_an_aseg_uchar_would_damage_is_refused(case, tmp_path):
     """reduce_to_aseg asks for uchar because an aseg has no label outside it.
 
-    If one ever appears, that is a bug upstream, and it has to surface rather than be papered over
-    by writing a type FreeSurfer does not expect here.
+    A label that does not fit means something went wrong upstream, so it surfaces rather than being
+    papered over by writing a type FreeSurfer does not expect here.
     """
     header = nib.MGHImage(case(), AFFINE).header
 
@@ -351,7 +342,7 @@ def test_an_aseg_uchar_would_damage_is_refused(case, tmp_path):
 
 
 def test_conformed_copy_of_a_float_input_is_not_float(tmp_path):
-    """The path that produced orig.10mm.mgz: a float NIfTI input, uint8 asked for, uint8 expected."""
+    """The orig.10mm.mgz path: conform is asked for uchar, so a float input still lands as uchar."""
     affine = np.diag([0.8, 0.8, 0.8, 1.0])
     affine[:3, 3] = -128.0
     voxels = np.rint(np.random.default_rng(0).random((64, 64, 64)) * 255).astype(np.float32)

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -166,8 +166,10 @@ def test_storable_dtype_writes_the_archival_copy(data, expected, tmp_path):
 def test_a_type_mgh_cannot_store_is_refused(wanted, tmp_path):
     """MGH has no int64 and no float64, so it says so rather than picking something else.
 
-    A float64 request answered with an integer would not be a narrower version of the request but a
-    different file. Callers that do not choose their own type ask for `storable_dtype` instead.
+    The format is asked rather than checked against a list, so this also covers a type nobody
+    thought to enumerate. A float64 request answered with an integer would not be a narrower version
+    of the request but a different file; callers that do not choose their own type ask for
+    `storable_dtype` instead.
     """
     data = np.zeros(SHAPE, dtype=wanted)
 
@@ -189,6 +191,23 @@ def test_storable_dtype_keeps_the_kind_and_the_values():
 
     with pytest.raises(ValueError, match="cannot store"):
         storable_dtype(np.full(SHAPE, 2 ** 40, np.int64))
+
+
+@pytest.mark.parametrize("conf_name", ["orig.mgz", "orig.nii.gz"], ids=["mgz", "nii.gz"])
+def test_the_image_handed_back_is_the_one_written(conf_name, tmp_path):
+    """save_image returns what it wrote, so load_maybe_conform's caller gets the right container."""
+    affine = np.diag([0.8, 0.8, 0.8, 1.0])
+    affine[:3, 3] = -128.0
+    voxels = np.zeros((64, 64, 64), dtype=np.uint8)
+    nib.save(nib.Nifti1Image(voxels, affine), tmp_path / "T1.nii.gz")
+
+    out_file, img, _ = load_maybe_conform(
+        tmp_path / conf_name, tmp_path / "T1.nii.gz",
+        vox_size=1.0, img_size="auto", orientation="lia", order=1, dtype=np.uint8,
+    )
+
+    assert out_file.name.endswith(conf_name.split(".", 1)[1])
+    assert isinstance(img, nib.MGHImage) == conf_name.endswith(".mgz")
 
 
 def test_an_integer_nifti_carries_no_scale_factor(tmp_path):

--- a/test/image/test_mgh_fov.py
+++ b/test/image/test_mgh_fov.py
@@ -81,5 +81,7 @@ def test_as_mgh_image_replaces_a_stale_fov():
 
 def test_fov_is_the_largest_extent_not_the_first():
     """The two candidate rules disagree here, and FreeSurfer's mri_info reports 120 for this .mgz."""
-    img = as_mgh_image(np.zeros((40, 200, 80), dtype=np.uint8), np.diag([2.0, 0.5, 1.5, 1.0]))
+    affine = np.diag([2.0, 0.5, 1.5, 1.0])
+    data = np.zeros((40, 200, 80), dtype=np.uint8)
+    img = as_mgh_image(data, affine, nib.MGHImage(data, affine).header)
     assert float(img.header["fov"]) == pytest.approx(120.0)

--- a/test/image/test_mgh_fov.py
+++ b/test/image/test_mgh_fov.py
@@ -1,10 +1,10 @@
-"""Regression tests for the field-of-view header field of the .mgz files FastSurfer writes.
+"""Tests for the field-of-view header field of the .mgz files FastSurfer writes.
 
-``MGHHeader`` defaults ``fov`` to 0 and a NIfTI header has no ``fov`` at all, so every .mgz written
-from a NIfTI input carried ``fov=0``, while the files FreeSurfer writes carry the real extent. The
-value pinned here is the one FreeSurfer computes for an MGZ, the largest of the three extents, which
-``mri_info`` reports regardless of what the file stores. These tests cover both the header ``conform``
-builds and one inherited from a volume of a different shape.
+``MGHHeader`` defaults ``fov`` to 0 and a NIfTI header has no ``fov`` at all, so ``as_mgh_image``
+sets it from the data rather than leaving it to the conversion. The value is the one FreeSurfer
+keeps, the largest of the three extents, which ``mri_info`` reports regardless of what the file
+stores. These tests cover both the header ``conform`` builds and one inherited from a volume of a
+different shape.
 """
 
 import nibabel as nib


### PR DESCRIPTION
# Decide the data type once, and refuse one that cannot be honoured

Four outputs came out with the wrong data type. Found by comparing a released v2.5.4 run against the
v2.3.3 reference and against what FreeSurfer writes, then tracing each one to the writer.

The fixes are small. Most of this branch is the rule that replaces them, because every one of the
four was a different symptom of the same missing decision: nothing owned the question "what type
does this file get".

## The rule

`save_image` and `as_mgh_image` now decide the type in one place, `choose_dtype`:

1. The type is what the caller passed as `dtype`, or else what the header carries.
2. That type is used or nothing is. If it would round or clip the data, the write **raises**.
   Narrowing is the caller's to do, deliberately and outside, because only the caller knows whether
   to cast, to rescale or to refuse.
3. Whether the type can be stored at all is the output format's answer, not ours. It is asked when
   the type is applied, so a wrong list on our side cannot cause a wrong refusal.

Nothing is substituted and nothing is guessed. The one output whose type is genuinely not ours to
choose, the archival copy of the input in `mri/orig/001.mgz`, asks for `storable_dtype` explicitly.

The rule is the same for every format. The file name only decides which types are available at all:
MGH has no int64 and no float64, NIfTI has both.

| data, `.mgz` target | requested uint8 | int16 | int32 | int64 | float32 | float64 |
|---|---|---|---|---|---|---|
| uint8 | uint8 | int16 | int32 | raise | float32 | raise |
| int16 holding 2035 | raise | int16 | int32 | raise | float32 | raise |
| int64 holding 2²⁰ | raise | raise | int32 | raise | float32 | raise |
| float32 | raise | raise | raise | raise | float32 | raise |

The same table for a `.nii.gz` target has the int64 and float64 columns filled in rather than
refusing. Every cell is either the requested type or a refusal; nothing warns.

## What was wrong

### A header from a NIfTI lost the type

`MGHHeader.from_header` returns float32 whatever the source header says, so the written type
depended on which container the header came from:

| data | header | before | after |
|---|---|---|---|
| uint8 | NIfTI uint8 | `>f4` | uint8 |
| uint8 | MGH uint8 | uint8 | uint8 |

The 1 mm copy CerebNet conforms for a high-res subject, `orig.10mm.mgz`, was stored as float32 at
four times the size holding only integers, although uint8 was asked for and honoured all the way
down to the write. This is the same nibabel behaviour as the `fov=0` bug in #873 on a different
field, so the fix sits in the same function.

### The aseg files were int16 instead of uchar

`reduce_to_aseg_and_save` kept the type of the segmentation it reduces:

| file | FreeSurfer | v2.3.3 | v2.5.4 | after |
|---|---|---|---|---|
| `aseg.auto_noCCseg.mgz` | uint8 | uint8 | uint8 | uint8 |
| `aseg.auto.mgz` | uint8 | uint8 | `>i2` | uint8 |
| `aseg.presurf.mgz` | uint8 | uint8 | `>i2` | follows `aseg.auto.mgz` |
| `aseg.presurf.hypos.mgz` | uint8 | uint8 | `>i2` | follows `aseg.auto.mgz` |

The module's own `__main__` path already narrowed, which is why `aseg.auto_noCCseg.mgz` stayed
uint8; the library path used by `paint_cc_into_pred` did not. The two `presurf` files are derived
from `aseg.auto.mgz` by FreeSurfer, so they are expected to follow rather than measured to; the
refreshed quicktest reference will confirm it.

Both call sites now ask for uchar explicitly. An aseg has no label outside 0 to 255, so a label that
does not fit means something went wrong upstream and now says so instead of being written as a type
FreeSurfer does not expect.

### Probabilities were stored as uchar

The corpus callosum soft labels are softmax outputs written with the header of the conformed image.
That header is uchar, so every value below 0.5 became 0 and the probability map came back as a
binary mask. `callosum.CC.soft.mgz` and its two siblings now carry real probabilities.

The call site says `dtype=np.float32`, which is where that decision belongs. Any writer that hands
float data to an integer type now raises rather than rounding it away.

### The hypothalamus mask was float32 instead of uchar

| file | v2.3.3 | v2.5.4 | after |
|---|---|---|---|
| `hypothalamus_mask.HypVINN.nii.gz` | uint8 | float32 | uint8 |

A copy-paste slip in the reorientation rework: the mask block set uchar on its header and then
overwrote it with the float32 line from the logits block two functions down. The prediction block
next to it got the right type, which is why only the mask was affected.

## Also in this branch

- **`save_image` returns the image it wrote.** `load_maybe_conform` built a second one, so the type
  was decided twice and a `.nii.gz` `conf_name` was handed back as an `MGHImage` that did not match
  the file on disk.
- **Integer NIfTI outputs carry an explicit scale of 1.** Left free, nibabel is entitled to add a
  scale factor, and a label read back through one is no longer the integer it was written as. In
  practice this is belt and braces, since the refusal rule prevents the case that would trigger it.
- **HypVINN's three writes go through `save_image`** instead of assembling headers by hand. Two of
  the four bugs above lived in that function. Verified byte-identical to the previous code path on
  the same inputs, so this is a simplification with no output change.
- **`save_logits` called a method nibabel does not have.** `Nifti1Header.set_data_type` does not
  exist, so the function raised `AttributeError` on its first line. Kept rather than removed, since
  it is a debugging aid.
- **`header` is now required** in `as_mgh_image`. Every image we write is derived from one we read,
  and the header is the only carrier of the acquisition parameters and of the type.
- **A redundant `assert` on the output extension is gone.** It could not fire without the `else`
  branch below also firing, and it was validating input with an `assert`, which vanishes under
  `python -O`.

Two commits at the end are unrelated to data types: they write the comment and dash conventions into
`CONTRIBUTING.md` and fix a code fence that had drifted out of the numbered list.

## Impact

Six files per subject change type, four of them back to what v2.3.3 and FreeSurfer write:

| file | before | after |
|---|---|---|
| `aseg.auto.mgz` and the two `presurf` files | `>i2` | uint8 |
| `hypothalamus_mask.HypVINN.nii.gz` | float32 | uint8 |
| `orig.10mm.mgz`, high-res subjects only | `>f4` | uint8 |
| `callosum.CC.soft.mgz` and its two siblings | uint8 | `>f4` |

`aseg.mgz`, `aparc+aseg.mgz` and `wmparc.mgz` already matched FreeSurfer and are untouched.

**One measurement changes.** The CC soft labels go from a binary mask to real probabilities. That is
the point of the fix, not a side effect. Nothing else changes numerically.

Header bytes and file sizes change on the files above, so the quicktest reference will differ. Every
image the current dev pipeline produces was re-checked against the new rule and **none of the 86 is
refused**, so no existing run turns into a failure.

## Tests

`test/image/test_mgh_dtype.py`, 49 cases:

- the written type across every combination of source container, output container and data type
- refusal of a type that would round or clip, from the header and from `dtype`, in both formats
- refusal of a type the format cannot store, and of one no storable type can hold
- the exactness boundary where a float stops counting integers, 2²⁴ for float32
- `storable_dtype` keeping the kind and the signedness, and writing the archival copy
- the aseg and mask narrowing, and the labels that must not be narrowed
- an integer NIfTI carrying no scale factor
- the rest of the header surviving: a uchar source header with `tr`, `te`, `ti` and `flip_angle`
  produces a `>f4` image that keeps all four fields and the affine, and the caller's header object
  is not modified, which matters because the aseg and the mask are written from one header on two
  threads
- both dtype lists derived from nibabel rather than trusted, so a stale entry cannot make
  `storable_dtype` pick something unstorable

478 tests pass in `test/image` and `test/config`, 534 including `test/shell/test_bash4_lint.py`.
Ruff and codespell clean.

## Follow-ups, not in this PR

- `mri/orig/001.mgz` is not written at all for `.nii.gz` input, a regression since v2.5.4 that is
  separate from the type question. The plan is to make it a verbatim copy of the input under the
  input's own extension, which loses nothing, needs no type policy, and removes the only caller of
  `storable_dtype`.
- `rawavg.mgz` is currently a link to the conformed `orig.mgz` rather than being built from the
  input, because the conform step moved out of `recon-surf.sh`. It should be built from `001`.
- The quicktest reference has to be regenerated after this lands, and the CerebNet output of the
  shipped v2.5.4 image is not reproducible from source, which needs settling first.