### PR TITLE
Keep the input verbatim in  mri/orig/001.<ext> , and write  mri/rawavg.mgz  for the tools

### DIFF
--- a/CerebNet/config/dataset.py
+++ b/CerebNet/config/dataset.py
@@ -58,7 +58,7 @@ _C.VAL_CSV_FILE_PATH = "val_split.csv"
 
 # Default name of original images. FreeSurfer orig.mgz is default (mri/orig.mgz)
 # or native_t1.nii for image in native space
-_C.IMAGE_NAME = "mri/orig/001.mgz"
+_C.IMAGE_NAME = "mri/rawavg.mgz"
 
 # Name of the cerebellum sub-segmentation file,
 # SUIT labels: suit_fs_merged_cleaned.mgz

--- a/CerebNet/config/dataset.py
+++ b/CerebNet/config/dataset.py
@@ -56,8 +56,8 @@ _C.TRAIN_CSV_FILE_PATH = "train_split.csv"
 # Csv-file listing subjects to include in file validation
 _C.VAL_CSV_FILE_PATH = "val_split.csv"
 
-# Default name of original images. FreeSurfer orig.mgz is default (mri/orig.mgz)
-# or native_t1.nii for image in native space
+# Default name of original images. FastSurfer's copy of the input is the default (mri/rawavg.mgz);
+# the conformed image (mri/orig.mgz) or native_t1.nii for image in native space also work
 _C.IMAGE_NAME = "mri/rawavg.mgz"
 
 # Name of the cerebellum sub-segmentation file,

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -121,10 +121,11 @@ def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
     }
     conflicting = sorted(present - unchanged)
     if conflicting:
+        kept = ", ".join(str(orig_dir / name) for name in conflicting)
         raise FileExistsError(
             f"{orig_dir} already holds {', '.join(conflicting)}, which is not {source}. One subject "
-            f"directory belongs to one input: process a different image under a new subject id, or "
-            f"remove the archive to reprocess this directory from scratch."
+            f"directory belongs to one input: to reprocess this one, pass {kept} as the input, and "
+            f"to process a different image, give it a subject id of its own."
         )
 
     for key, part in parts.items():

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -18,17 +18,20 @@ Put the input images into the subject directory: an archival copy, and the rawav
 ``mri/orig/001.<ext>`` is a byte-for-byte copy of the input, in the format it arrived in, so no
 header field, scale factor or data type is lost. Nothing in FastSurfer reads it back; it is there so
 the subject directory records what was processed. A T2 is copied the same way, as
-``mri/orig/T2.001.<ext>``.
+``mri/orig/T2raw.<ext>``.
 
 ``mri/rawavg.mgz`` is the copy the tools read. ``pctsurfcon`` builds that path itself and hardcodes
 the name, so it has to be an MGH file whatever the input was. Where the input is already an .mgz it
 is a symlink to the archival copy; otherwise it is converted, through ``save_image`` rather than
 nibabel directly, because a plain nibabel write leaves ``fov`` at 0 and FreeSurfer reports that
-field as the field of view. A T2 gets the same pair, ``mri/T2.rawavg.mgz``.
+field as the field of view. The T2 equivalent is ``mri/orig/T2raw.mgz``, which for an .mgz input is
+the archival copy itself.
 
-The name 001 is historic: 001, 002 and so on were the separate runs of one session, which FreeSurfer
-registered and averaged into rawavg. FastSurfer takes a single input and conforms it instead, so
-rawavg here is that one input rather than an average.
+The names follow recon-all: it converts a ``-T2`` input to ``mri/orig/T2raw.mgz`` with
+``--no_scale 1``, and ``samseg`` and ``-T2pial`` look for it there. 001 is historic, 001, 002 and so
+on being the separate runs of one session that FreeSurfer registered and averaged into rawavg;
+FastSurfer takes a single input and conforms it instead, so rawavg here is that one input rather
+than an average.
 """
 
 import argparse
@@ -45,7 +48,7 @@ from FastSurferCNN.utils import logging
 LOGGER = logging.getLogger(__name__)
 
 RAWAVG_NAME = "rawavg.mgz"
-T2_RAWAVG_NAME = "T2.rawavg.mgz"
+T2_RAWAVG_NAME = "orig/T2raw.mgz"
 
 
 def image_suffix(path: Path) -> str:
@@ -110,6 +113,10 @@ def write_rawavg(source: Path, rawavg: Path) -> None:
         The `mri/rawavg.mgz` to create.
     """
     rawavg.parent.mkdir(parents=True, exist_ok=True)
+    if source.resolve() == rawavg.resolve():
+        # an .mgz T2, whose archival copy is already at the name the tools read
+        LOGGER.info(f"{rawavg} is the archival copy, nothing to convert.")
+        return
     if rawavg.is_symlink() or rawavg.exists():
         rawavg.unlink()
 
@@ -167,7 +174,7 @@ def main(t1: Path, sd: Path, sid: str, t2: Path | None = None) -> int:
     # (modality, source, name for the archival copy, name for the mgz the tools read)
     inputs = [("T1", t1, "001", RAWAVG_NAME)]
     if t2 is not None:
-        inputs.append(("T2", t2, "T2.001", T2_RAWAVG_NAME))
+        inputs.append(("T2", t2, "T2raw", T2_RAWAVG_NAME))
 
     for modality, source, _stem, _rawavg in inputs:
         if not source.is_file():

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -17,8 +17,8 @@ Put the input images into the subject directory: an archival copy, and the rawav
 
 ``mri/orig/001.<ext>`` is a byte-for-byte copy of the input, in the format it arrived in, so no
 header field, scale factor or data type is lost. Nothing in FastSurfer reads it back; it is there so
-the subject directory records what was processed. A T2 is copied the same way, as
-``mri/orig/T2raw.<ext>``.
+the subject directory records what was processed, which is also why an archive left by a different
+input stops the run. A T2 is copied the same way, as ``mri/orig/T2raw.<ext>``.
 
 ``mri/rawavg.mgz`` is the copy the tools read. ``pctsurfcon`` builds that path itself and hardcodes
 the name, so it has to be an MGH file whatever the input was. Where the input is already an .mgz it
@@ -35,6 +35,7 @@ than an average.
 """
 
 import argparse
+import filecmp
 import os
 import shutil
 import sys
@@ -77,7 +78,15 @@ def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
     """
     Copy `source` into `orig_dir` as `stem` plus the source's own extension.
 
-    The copy is byte for byte, so it is the input and not a re-encoding of it.
+    The copy is byte for byte, so it is the input and not a re-encoding of it. Formats that spread
+    one image over several files, such as an Analyze .hdr and .img pair, are copied whole, and every
+    part keeps `stem` so they still find each other.
+
+    An archive already in `orig_dir` is compared with `source` byte for byte. Equal means this is a
+    re-run and the copy is skipped; anything else is a second input arriving in a directory that
+    belongs to the first, which nothing downstream could tell apart, so it raises. Comparing the
+    bytes rather than only the file names catches the case where the extension is the same and the
+    image is not.
 
     Parameters
     ----------
@@ -91,43 +100,67 @@ def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
     Returns
     -------
     Path
-        The path the copy was written to.
+        The path of the copy, the one nibabel names when it loads the image.
+
+    Raises
+    ------
+    FileExistsError
+        If an archive for `stem` exists and is not this input.
     """
     orig_dir.mkdir(parents=True, exist_ok=True)
-    destination = orig_dir / f"{stem}{image_suffix(source)}"
-    if destination.resolve() == source.resolve():
-        LOGGER.info(f"The input is already at {destination}, not copying it onto itself.")
-        return destination
-    LOGGER.info(f"Copying {source} to {destination}")
-    shutil.copyfile(source, destination)
-    return destination
+    # every file of the image, so a .hdr/.img pair is not split in half
+    file_map = nib.load(source).file_map
+    parts = {key: Path(holder.filename) for key, holder in file_map.items()}
+    destinations = {key: orig_dir / f"{stem}{image_suffix(part)}" for key, part in parts.items()}
+    by_name = {destination.name: key for key, destination in destinations.items()}
+
+    present = {p.name for p in orig_dir.glob(f"{stem}.*")}
+    unchanged = {
+        name for name in present & set(by_name)
+        if filecmp.cmp(parts[by_name[name]], destinations[by_name[name]], shallow=False)
+    }
+    conflicting = sorted(present - unchanged)
+    if conflicting:
+        raise FileExistsError(
+            f"{orig_dir} already holds {', '.join(conflicting)}, which is not {source}. One subject "
+            f"directory belongs to one input: process a different image under a new subject id, or "
+            f"remove the archive to reprocess this directory from scratch."
+        )
+
+    for key, part in parts.items():
+        destination = destinations[key]
+        if destination.name in unchanged:
+            LOGGER.info(f"{destination} is already this input, not copying it again.")
+            continue
+        LOGGER.info(f"Copying {part} to {destination}")
+        shutil.copyfile(part, destination)
+    return destinations["image"]
 
 
-def write_rawavg(archive: Path, rawavg: Path, source: Path | None = None) -> None:
+def write_rawavg(source: Path, rawavg: Path, archive: Path | None = None) -> None:
     """
     Provide `rawavg` as an MGH file, by symlink where the input is one already and by conversion else.
 
     Parameters
     ----------
-    archive : Path
-        The archival copy of the input, which the symlink points at.
+    source : Path
+        The image the user passed, which the voxels are read from. Reading the input rather than the
+        archival copy matters when the subject directory is on slower storage.
     rawavg : Path
         The `mri/rawavg.mgz` to create.
-    source : Path, optional
-        Where to read the voxels from, defaulting to `archive`. Passing the original input avoids
-        reading the copy back, which matters when the subject directory is on slower storage than
-        the input.
+    archive : Path, optional
+        The archival copy of the input, if one was made. An .mgz one is linked to instead of being
+        written a second time.
     """
-    source = archive if source is None else source
     rawavg.parent.mkdir(parents=True, exist_ok=True)
-    if archive.resolve() == rawavg.resolve():
+    if archive is not None and archive.resolve() == rawavg.resolve():
         # an .mgz T2, whose archival copy is already at the name the tools read
         LOGGER.info(f"{rawavg} is the archival copy, nothing to convert.")
         return
     if rawavg.is_symlink() or rawavg.exists():
         rawavg.unlink()
 
-    if image_suffix(archive) == ".mgz":
+    if archive is not None and image_suffix(archive) == ".mgz":
         # relative, so the subject directory stays movable; relpath rather than relative_to, which
         # refuses any layout where the archive is not below the link
         target = Path(os.path.relpath(archive, rawavg.parent))
@@ -139,6 +172,13 @@ def write_rawavg(archive: Path, rawavg: Path, source: Path | None = None) -> Non
             LOGGER.info(f"Could not link {rawavg} ({error}), copying instead.")
             shutil.copyfile(archive, rawavg)
             return
+
+    if image_suffix(source) == ".mgz":
+        # already the right container, and a copy keeps rawavg inside the subject directory rather
+        # than linking out to an input that may not stay where it is
+        LOGGER.info(f"Copying {source} to {rawavg}")
+        shutil.copyfile(source, rawavg)
+        return
 
     LOGGER.info(f"Converting {source} to {rawavg}")
     image = nib.load(source)
@@ -155,10 +195,22 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument("--t2", type=Path, default=None, help="the T2 image, if one was passed")
     parser.add_argument("--sd", type=Path, required=True, help="the subjects directory")
     parser.add_argument("--sid", required=True, help="the subject id")
+    parser.add_argument(
+        "--rawavg_only",
+        action="store_true",
+        help="write rawavg but no archival copy, for an input the pipeline built itself rather than "
+             "one the user passed, such as a longitudinal time point resampled into base space",
+    )
     return parser
 
 
-def main(t1: Path, sd: Path, sid: str, t2: Path | None = None) -> int:
+def main(
+        t1: Path,
+        sd: Path,
+        sid: str,
+        t2: Path | None = None,
+        rawavg_only: bool = False,
+) -> int:
     """
     Copy the inputs into the subject directory and provide rawavg.
 
@@ -172,26 +224,35 @@ def main(t1: Path, sd: Path, sid: str, t2: Path | None = None) -> int:
         The subject id.
     t2 : Path, optional
         The T2 image, if one was passed.
+    rawavg_only : bool, default=False
+        Write rawavg but no archival copy.
 
     Returns
     -------
     int
-        0 on success.
+        0 on success, 1 if an input is missing or an archive of a different image is already there.
     """
+    if not t1.is_file():
+        LOGGER.error(f"The T1 file {t1} does not exist.")
+        return 1
     mri_dir = sd / sid / "mri"
     # (modality, source, name for the archival copy, path of the mgz the tools read)
     inputs = [("T1", t1, "001", RAWAVG_PATH)]
     if t2 is not None:
+        if not t2.is_file():
+            LOGGER.error(f"The T2 file {t2} does not exist.")
+            return 1
         inputs.append(("T2", t2, "T2raw", T2_RAWAVG_PATH))
 
-    for modality, source, _stem, _rawavg in inputs:
-        if not source.is_file():
-            LOGGER.error(f"The {modality} file {source} does not exist.")
-            return 1
-
     for _modality, source, stem, rawavg in inputs:
-        archive = archive_input(source, mri_dir / "orig", stem=stem)
-        write_rawavg(archive, mri_dir / rawavg, source=source)
+        archive = None
+        if not rawavg_only:
+            try:
+                archive = archive_input(source, mri_dir / "orig", stem=stem)
+            except FileExistsError as error:
+                LOGGER.error(str(error))
+                return 1
+        write_rawavg(source, mri_dir / rawavg, archive=archive)
     return 0
 
 

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -74,7 +74,12 @@ def image_suffix(path: Path) -> str:
     return path.suffix
 
 
-def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
+def archive_input(
+        source: Path,
+        orig_dir: Path,
+        stem: str = "001",
+        derived: Path | None = None,
+) -> Path:
     """
     Copy `source` into `orig_dir` as `stem` plus the source's own extension.
 
@@ -96,6 +101,11 @@ def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
         The `mri/orig` directory of the subject, created if it does not exist.
     stem : str, default="001"
         The name to give the copy, without an extension.
+    derived : Path, optional
+        A file the caller writes into `orig_dir` itself, the T2 rawavg in practice, which shares
+        `stem` and so matches the same names as an archive. It is left out of the check, but only
+        once the archive of this very input has been found unchanged, so that switching to a
+        different input still reports the old copies rather than overwriting them.
 
     Returns
     -------
@@ -119,7 +129,13 @@ def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
         name for name in present & set(by_name)
         if filecmp.cmp(parts[by_name[name]], destinations[by_name[name]], shallow=False)
     }
-    conflicting = sorted(present - unchanged)
+    # the archive of this input is already here, so this is a re-run and whatever else the caller
+    # derives into the directory is its own output from the previous one, not a competing archive
+    rerun = destinations["image"].name in unchanged
+    ignored = set()
+    if rerun and derived is not None and derived.parent == orig_dir:
+        ignored = {derived.name}
+    conflicting = sorted(present - unchanged - ignored)
     if conflicting:
         kept = ", ".join(str(orig_dir / name) for name in conflicting)
         raise FileExistsError(
@@ -249,7 +265,9 @@ def main(
         archive = None
         if not rawavg_only:
             try:
-                archive = archive_input(source, mri_dir / "orig", stem=stem)
+                archive = archive_input(
+                    source, mri_dir / "orig", stem=stem, derived=mri_dir / rawavg,
+                )
             except FileExistsError as error:
                 LOGGER.error(str(error))
                 return 1

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -35,6 +35,7 @@ than an average.
 """
 
 import argparse
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -47,8 +48,9 @@ from FastSurferCNN.utils import logging
 
 LOGGER = logging.getLogger(__name__)
 
-RAWAVG_NAME = "rawavg.mgz"
-T2_RAWAVG_NAME = "orig/T2raw.mgz"
+# both relative to the subject's mri directory, so the shapes match and neither name lies
+RAWAVG_PATH = Path("rawavg.mgz")
+T2_RAWAVG_PATH = Path("orig/T2raw.mgz")
 
 
 def image_suffix(path: Path) -> str:
@@ -101,35 +103,41 @@ def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
     return destination
 
 
-def write_rawavg(source: Path, rawavg: Path) -> None:
+def write_rawavg(archive: Path, rawavg: Path, source: Path | None = None) -> None:
     """
-    Provide `rawavg` as an MGH file, by symlink where `source` is one already and by conversion else.
+    Provide `rawavg` as an MGH file, by symlink where the input is one already and by conversion else.
 
     Parameters
     ----------
-    source : Path
-        The archival copy of the input.
+    archive : Path
+        The archival copy of the input, which the symlink points at.
     rawavg : Path
         The `mri/rawavg.mgz` to create.
+    source : Path, optional
+        Where to read the voxels from, defaulting to `archive`. Passing the original input avoids
+        reading the copy back, which matters when the subject directory is on slower storage than
+        the input.
     """
+    source = archive if source is None else source
     rawavg.parent.mkdir(parents=True, exist_ok=True)
-    if source.resolve() == rawavg.resolve():
+    if archive.resolve() == rawavg.resolve():
         # an .mgz T2, whose archival copy is already at the name the tools read
         LOGGER.info(f"{rawavg} is the archival copy, nothing to convert.")
         return
     if rawavg.is_symlink() or rawavg.exists():
         rawavg.unlink()
 
-    if image_suffix(source) == ".mgz":
-        # relative, so the subject directory stays movable
-        target = source.relative_to(rawavg.parent)
+    if image_suffix(archive) == ".mgz":
+        # relative, so the subject directory stays movable; relpath rather than relative_to, which
+        # refuses any layout where the archive is not below the link
+        target = Path(os.path.relpath(archive, rawavg.parent))
         try:
             rawavg.symlink_to(target)
             LOGGER.info(f"Linking {rawavg} to {target}")
             return
         except OSError as error:
             LOGGER.info(f"Could not link {rawavg} ({error}), copying instead.")
-            shutil.copyfile(source, rawavg)
+            shutil.copyfile(archive, rawavg)
             return
 
     LOGGER.info(f"Converting {source} to {rawavg}")
@@ -171,10 +179,10 @@ def main(t1: Path, sd: Path, sid: str, t2: Path | None = None) -> int:
         0 on success.
     """
     mri_dir = sd / sid / "mri"
-    # (modality, source, name for the archival copy, name for the mgz the tools read)
-    inputs = [("T1", t1, "001", RAWAVG_NAME)]
+    # (modality, source, name for the archival copy, path of the mgz the tools read)
+    inputs = [("T1", t1, "001", RAWAVG_PATH)]
     if t2 is not None:
-        inputs.append(("T2", t2, "T2raw", T2_RAWAVG_NAME))
+        inputs.append(("T2", t2, "T2raw", T2_RAWAVG_PATH))
 
     for modality, source, _stem, _rawavg in inputs:
         if not source.is_file():
@@ -182,8 +190,8 @@ def main(t1: Path, sd: Path, sid: str, t2: Path | None = None) -> int:
             return 1
 
     for _modality, source, stem, rawavg in inputs:
-        copy = archive_input(source, mri_dir / "orig", stem=stem)
-        write_rawavg(copy, mri_dir / rawavg)
+        archive = archive_input(source, mri_dir / "orig", stem=stem)
+        write_rawavg(archive, mri_dir / rawavg, source=source)
     return 0
 
 

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -129,19 +129,21 @@ def archive_input(
         name for name in present & set(by_name)
         if filecmp.cmp(parts[by_name[name]], destinations[by_name[name]], shallow=False)
     }
+    derived_name = derived.name if derived is not None and derived.parent == orig_dir else None
     # the archive of this input is already here, so this is a re-run and whatever else the caller
     # derives into the directory is its own output from the previous one, not a competing archive
     rerun = destinations["image"].name in unchanged
-    ignored = set()
-    if rerun and derived is not None and derived.parent == orig_dir:
-        ignored = {derived.name}
+    ignored = {derived_name} if rerun and derived_name is not None else set()
     conflicting = sorted(present - unchanged - ignored)
     if conflicting:
-        kept = ", ".join(str(orig_dir / name) for name in conflicting)
+        # one file to point at, and not the rawavg we write ourselves: it is an output, so passing
+        # it back would leave the archive beside it and fail again. Either half of a pair loads.
+        archived = [name for name in conflicting if name != derived_name] or conflicting
         raise FileExistsError(
             f"{orig_dir} already holds {', '.join(conflicting)}, which is not {source}. One subject "
-            f"directory belongs to one input: to reprocess this one, pass {kept} as the input, and "
-            f"to process a different image, give it a subject id of its own."
+            f"directory belongs to one input: to reprocess the image archived here, pass "
+            f"{orig_dir / archived[0]} as the input, and to process a different image, give it a "
+            f"subject id of its own."
         )
 
     for key, part in parts.items():

--- a/FastSurferCNN/copy_input.py
+++ b/FastSurferCNN/copy_input.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Image Analysis Lab, German Center for Neurodegenerative Diseases (DZNE), Bonn
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Put the input images into the subject directory: an archival copy, and the rawavg the surfaces need.
+
+``mri/orig/001.<ext>`` is a byte-for-byte copy of the input, in the format it arrived in, so no
+header field, scale factor or data type is lost. Nothing in FastSurfer reads it back; it is there so
+the subject directory records what was processed. A T2 is copied the same way, as
+``mri/orig/T2.001.<ext>``.
+
+``mri/rawavg.mgz`` is the copy the tools read. ``pctsurfcon`` builds that path itself and hardcodes
+the name, so it has to be an MGH file whatever the input was. Where the input is already an .mgz it
+is a symlink to the archival copy; otherwise it is converted, through ``save_image`` rather than
+nibabel directly, because a plain nibabel write leaves ``fov`` at 0 and FreeSurfer reports that
+field as the field of view. A T2 gets the same pair, ``mri/T2.rawavg.mgz``.
+
+The name 001 is historic: 001, 002 and so on were the separate runs of one session, which FreeSurfer
+registered and averaged into rawavg. FastSurfer takes a single input and conforms it instead, so
+rawavg here is that one input rather than an average.
+"""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+from FastSurferCNN.data_loader.data_utils import save_image, storable_dtype
+from FastSurferCNN.utils import logging
+
+LOGGER = logging.getLogger(__name__)
+
+RAWAVG_NAME = "rawavg.mgz"
+T2_RAWAVG_NAME = "T2.rawavg.mgz"
+
+
+def image_suffix(path: Path) -> str:
+    """
+    The extension to give a copy of `path`, keeping a compound one such as .nii.gz intact.
+
+    Parameters
+    ----------
+    path : Path
+        The file whose extension is wanted.
+
+    Returns
+    -------
+    str
+        The extension, including the leading dot.
+    """
+    suffixes = path.suffixes
+    if len(suffixes) >= 2 and suffixes[-1] == ".gz":
+        return "".join(suffixes[-2:])
+    return path.suffix
+
+
+def archive_input(source: Path, orig_dir: Path, stem: str = "001") -> Path:
+    """
+    Copy `source` into `orig_dir` as `stem` plus the source's own extension.
+
+    The copy is byte for byte, so it is the input and not a re-encoding of it.
+
+    Parameters
+    ----------
+    source : Path
+        The image the user passed.
+    orig_dir : Path
+        The `mri/orig` directory of the subject, created if it does not exist.
+    stem : str, default="001"
+        The name to give the copy, without an extension.
+
+    Returns
+    -------
+    Path
+        The path the copy was written to.
+    """
+    orig_dir.mkdir(parents=True, exist_ok=True)
+    destination = orig_dir / f"{stem}{image_suffix(source)}"
+    if destination.resolve() == source.resolve():
+        LOGGER.info(f"The input is already at {destination}, not copying it onto itself.")
+        return destination
+    LOGGER.info(f"Copying {source} to {destination}")
+    shutil.copyfile(source, destination)
+    return destination
+
+
+def write_rawavg(source: Path, rawavg: Path) -> None:
+    """
+    Provide `rawavg` as an MGH file, by symlink where `source` is one already and by conversion else.
+
+    Parameters
+    ----------
+    source : Path
+        The archival copy of the input.
+    rawavg : Path
+        The `mri/rawavg.mgz` to create.
+    """
+    rawavg.parent.mkdir(parents=True, exist_ok=True)
+    if rawavg.is_symlink() or rawavg.exists():
+        rawavg.unlink()
+
+    if image_suffix(source) == ".mgz":
+        # relative, so the subject directory stays movable
+        target = source.relative_to(rawavg.parent)
+        try:
+            rawavg.symlink_to(target)
+            LOGGER.info(f"Linking {rawavg} to {target}")
+            return
+        except OSError as error:
+            LOGGER.info(f"Could not link {rawavg} ({error}), copying instead.")
+            shutil.copyfile(source, rawavg)
+            return
+
+    LOGGER.info(f"Converting {source} to {rawavg}")
+    image = nib.load(source)
+    data = np.asanyarray(image.dataobj)
+    save_image(image.header, image.affine, data, rawavg, dtype=storable_dtype(data))
+
+
+def make_parser() -> argparse.ArgumentParser:
+    """Create the command line interface."""
+    parser = argparse.ArgumentParser(
+        description="Copy the input images into the subject directory and provide mri/rawavg.mgz.",
+    )
+    parser.add_argument("--t1", type=Path, required=True, help="the T1 image the user passed")
+    parser.add_argument("--t2", type=Path, default=None, help="the T2 image, if one was passed")
+    parser.add_argument("--sd", type=Path, required=True, help="the subjects directory")
+    parser.add_argument("--sid", required=True, help="the subject id")
+    return parser
+
+
+def main(t1: Path, sd: Path, sid: str, t2: Path | None = None) -> int:
+    """
+    Copy the inputs into the subject directory and provide rawavg.
+
+    Parameters
+    ----------
+    t1 : Path
+        The T1 image the user passed.
+    sd : Path
+        The subjects directory.
+    sid : str
+        The subject id.
+    t2 : Path, optional
+        The T2 image, if one was passed.
+
+    Returns
+    -------
+    int
+        0 on success.
+    """
+    mri_dir = sd / sid / "mri"
+    # (modality, source, name for the archival copy, name for the mgz the tools read)
+    inputs = [("T1", t1, "001", RAWAVG_NAME)]
+    if t2 is not None:
+        inputs.append(("T2", t2, "T2.001", T2_RAWAVG_NAME))
+
+    for modality, source, _stem, _rawavg in inputs:
+        if not source.is_file():
+            LOGGER.error(f"The {modality} file {source} does not exist.")
+            return 1
+
+    for _modality, source, stem, rawavg in inputs:
+        copy = archive_input(source, mri_dir / "orig", stem=stem)
+        write_rawavg(copy, mri_dir / rawavg)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.setup_logging()
+    sys.exit(main(**vars(make_parser().parse_args())))

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -363,7 +363,7 @@ def storable_dtype(
 
     Closest means the same kind first, so a float is never answered with an integer and signed data
     stays signed, and within the kind the narrowest that holds every value. An MGH file has no
-    float64, so a float64 input is archived as float32.
+    float64, so a float64 input is written as float32.
 
     Parameters
     ----------

--- a/FastSurferCNN/data_loader/data_utils.py
+++ b/FastSurferCNN/data_loader/data_utils.py
@@ -356,10 +356,10 @@ def storable_dtype(
     """
     The array's own type if the output format can store it, else the closest one that holds it.
 
-    For an output whose type is not ours to choose: `mri/orig/001.mgz`, the archival copy of
-    whatever the scanner or the conversion tool produced. Every other output has a type that belongs
-    to the output rather than to the input, so its caller names it and `choose_dtype` refuses
-    anything that does not fit.
+    For an output whose type is not ours to choose: `mri/rawavg.mgz`, the MGH copy of whatever the
+    scanner or the conversion tool produced. Every other output has a type that belongs to the
+    output rather than to the input, so its caller names it and `choose_dtype` refuses anything that
+    does not fit.
 
     Closest means the same kind first, so a float is never answered with an integer and signed data
     stays signed, and within the kind the narrowest that holds every value. An MGH file has no

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -27,6 +27,7 @@ See Also
 import argparse
 import sys
 import warnings
+from collections import deque
 from collections.abc import Iterator, Sequence
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from pathlib import Path
@@ -207,8 +208,10 @@ class RunModelOnData:
         self._async_io = async_io
         self.orientation = orientation
         self.image_size = image_size
-        # writes started while conforming, for the caller to await; see pending_writes
-        self._pending: list[Future[None]] = []
+        # writes started while conforming, for the caller to await; see pending_writes. A deque
+        # because the pool appends to it while the main thread drains it, and append and popleft
+        # are each atomic, so neither side needs a lock
+        self._pending: deque[Future[None]] = deque()
 
         self.sf = 1.0
 
@@ -466,13 +469,21 @@ class RunModelOnData:
         A write runs in the pool, so its exception only surfaces when someone asks the future for
         its result. Anything not awaited fails silently.
 
+        Draining one at a time rather than swapping the container, because the pool keeps appending
+        to it while this runs: a swap can drop a future that was appended between reading the
+        container and copying out of it, which is the write whose failure would then go unreported.
+
         Returns
         -------
         list of Future
             The futures, which are handed over and no longer tracked here.
         """
-        pending, self._pending = self._pending, []
-        return pending
+        pending = []
+        while True:
+            try:
+                pending.append(self._pending.popleft())
+            except IndexError:
+                return pending
 
     def set_up_model_params(self, plane: Plane, cfg: CfgNode, ckpt: "torch.Tensor") -> None:
         """

--- a/FastSurferCNN/run_prediction.py
+++ b/FastSurferCNN/run_prediction.py
@@ -207,6 +207,8 @@ class RunModelOnData:
         self._async_io = async_io
         self.orientation = orientation
         self.image_size = image_size
+        # writes started while conforming, for the caller to await; see pending_writes
+        self._pending: list[Future[None]] = []
 
         self.sf = 1.0
 
@@ -314,14 +316,6 @@ class RunModelOnData:
         orig, orig_data = du.load_image(subject.orig_name, "orig image")
         LOGGER.info(f"Successfully loaded image from {subject.orig_name}.")
 
-        # Save input image to standard location, but only
-        if subject.has_attribute("copy_orig_name") and subject.can_resolve_attribute("copy_orig_name"):
-            # an archival copy, so the type is the input's rather than one we name; a scaled or
-            # float64 NIfTI carries one no .mgz can hold, hence the closest the format offers
-            self.async_save_img(
-                subject.copy_orig_name, orig_data, orig, du.storable_dtype(orig_data),
-            )
-
         if not is_conform(orig, **self.__conform_kwargs(verbose=True)):
             if (self.orientation is None or self.orientation == "native") and \
                     not is_conform(orig, **self.__conform_kwargs(verbose=False, dtype=None, vox_size="min")):
@@ -333,7 +327,8 @@ class RunModelOnData:
 
         # Save conformed input image
         if subject.can_resolve_attribute("conf_name"):
-            self.async_save_img(subject.conf_name, orig_data, orig, dtype=np.uint8)
+            # kept so main can await it; a write that fails in the pool has to reach the exit code
+            self._pending.append(self.async_save_img(subject.conf_name, orig_data, orig, dtype=np.uint8))
             LOGGER.info(f"Saving conformed image to {subject.conf_name}...")
         else:
             raise RuntimeError("Cannot resolve the name to the conformed image, please specify an absolute path.")
@@ -463,6 +458,21 @@ class RunModelOnData:
             A Future object to synchronize (and catch/handle exceptions in the save_img method).
         """
         return self.pool.submit(self.save_img, save_as, data, orig, dtype)
+
+    def pending_writes(self) -> list["Future[None]"]:
+        """
+        The writes started while conforming, so the caller can await them with its own.
+
+        A write runs in the pool, so its exception only surfaces when someone asks the future for
+        its result. Anything not awaited fails silently.
+
+        Returns
+        -------
+        list of Future
+            The futures, which are handed over and no longer tracked here.
+        """
+        pending, self._pending = self._pending, []
+        return pending
 
     def set_up_model_params(self, plane: Plane, cfg: CfgNode, ckpt: "torch.Tensor") -> None:
         """
@@ -626,9 +636,6 @@ def main(
         out_dir=out_dir,
     )
     slist_kwargs = {"segfile": "pred_name"}
-    if out_dir is not None and out_dir != Path(""):
-        config.copy_orig_name = "mri/orig/001.mgz"
-        slist_kwargs["copy_orig_name"] = "copy_orig_name"
 
     try:
         # Get all subjects of interest
@@ -662,6 +669,8 @@ def main(
     iter_subjects = eval.pipeline_conform_and_save_orig(subjects)
     futures = []
     for subject, (orig_img, data_array) in iter_subjects:
+        # the conformed image is written while the subject is prepared, so pick that write up here
+        futures.extend(eval.pending_writes())
         # Run model
         try:
             # The orig_t1_file is only used to populate verbose messages here

--- a/FastSurferCNN/utils/common.py
+++ b/FastSurferCNN/utils/common.py
@@ -239,7 +239,6 @@ class SubjectDirectory:
     """
 
     _orig_name: str
-    _copy_orig_name: str
     _conf_name: str
     _segfile: str
     _asegdkt_segfile: str
@@ -425,38 +424,6 @@ class SubjectDirectory:
             The orig name.
         """
         self._orig_name = _orig_name
-
-    @property
-    def copy_orig_name(self) -> Path:
-        """
-        Try to return absolute path.
-
-        If the copy_orig_t1_file is a relative path, it will be interpreted as relative to folder.
-
-        Returns
-        -------
-        Path
-            The copy of orig name.
-        """
-        assert hasattr(self, "_copy_orig_name"), "The copy_orig_name attribute has not been set!"
-        return self.filename_in_subject_folder(self._copy_orig_name)
-
-    @copy_orig_name.setter
-    def copy_orig_name(self, _copy_orig_name: str):
-        """
-        Set the copy of orig name.
-
-        Parameters
-        ----------
-        _copy_orig_name : str
-            The copy of the orig name.
-
-        Returns
-        -------
-        str
-            Original name.
-        """
-        self._copy_orig_name = _copy_orig_name
 
     @property
     def conf_name(self) -> Path:

--- a/FastSurferCNN/utils/parser_defaults.py
+++ b/FastSurferCNN/utils/parser_defaults.py
@@ -171,8 +171,7 @@ class SubjectDirectoryConfig:
     conf_name: str = field(
         default="mri/orig.mgz",
         help="Name under which the conformed input image will be saved, in the same directory as the segmentation (the "
-             "input image is always conformed first, if it is not already conformed). The original input image is "
-             "saved in the output directory as $id/mri/orig/001.mgz. Default: mri/orig.mgz.",
+             "input image is always conformed first, if it is not already conformed). Default: mri/orig.mgz.",
         flags=("--conformed_name",),
     )
 

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -63,10 +63,15 @@ export SUBJECTS_DIR=$HOME/my_fastsurfer_analysis
 # Run FastSurfer
 $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
-    --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
+    --t1 $SUBJECTS_DIR/case_with_edits/mri/rawavg.mgz \
     --fs_license $FREESURFER_HOME/.license \
     --edits # more flags as needed, e.g. --3T --threads 4
 ```
+
+`mri/rawavg.mgz` is FastSurfer's copy of the input, so it is the right image to pass back in. It is
+named the same for every subject, which `mri/orig/001.<ext>` is not: that one keeps the extension of
+whatever you originally passed, `001.mgz` for an MGH input and `001.nii.gz` for a NIfTI one, and is
+a byte-for-byte copy of it. Either works as `--t1`.
 
 Note, a re-run of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited. Therefore, in most cases, we can skip the segmentation step with
 ```bash
@@ -75,7 +80,7 @@ Note, a re-run of the segmentation pipeline, as in the command above, should not
 # Run FastSurfer
 $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
-    --t1 $SUBJECTS_DIR/case_with_edits/mri/orig/001.mgz \
+    --t1 $SUBJECTS_DIR/case_with_edits/mri/rawavg.mgz \
     --fs_license $FREESURFER_HOME/.license \
     --edits --surf_only # more flags as needed, e.g. --3T --threads 4
 ```

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -63,15 +63,17 @@ export SUBJECTS_DIR=$HOME/my_fastsurfer_analysis
 # Run FastSurfer
 $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
-    --t1 $SUBJECTS_DIR/case_with_edits/mri/rawavg.mgz \
+    --t1 /path/to/the/original/T1.mgz \
     --fs_license $FREESURFER_HOME/.license \
     --edits # more flags as needed, e.g. --3T --threads 4
 ```
 
-`mri/rawavg.mgz` is FastSurfer's copy of the input, so it is the right image to pass back in. It is
-named the same for every subject, which `mri/orig/001.<ext>` is not: that one keeps the extension of
-whatever you originally passed, `001.mgz` for an MGH input and `001.nii.gz` for a NIfTI one, and is
-a byte-for-byte copy of it. Either works as `--t1`.
+Pass the same `--t1` as the first run. Editing refines results for one image, so the subject
+directory belongs to that image, and FastSurfer stops with an error rather than mixing two inputs
+into one directory. If you no longer have the original, `<subject_dir>/mri/orig/001.<ext>` is a
+byte-for-byte copy of it, under whatever extension you passed, `001.mgz` for an MGH input and
+`001.nii.gz` for a NIfTI one. Processing a genuinely different image, a bias field corrected version
+for instance, is a new run into a new `--sid`.
 
 Note, a re-run of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited. Therefore, in most cases, we can skip the segmentation step with
 ```bash
@@ -80,7 +82,7 @@ Note, a re-run of the segmentation pipeline, as in the command above, should not
 # Run FastSurfer
 $FASTSURFER_HOME/run_fastsurfer.sh \
     --sd $SUBJECTS_DIR --sid case_with_edits \
-    --t1 $SUBJECTS_DIR/case_with_edits/mri/rawavg.mgz \
+    --t1 /path/to/the/original/T1.mgz \
     --fs_license $FREESURFER_HOME/.license \
     --edits --surf_only # more flags as needed, e.g. --3T --threads 4
 ```

--- a/doc/overview/EDITING.md
+++ b/doc/overview/EDITING.md
@@ -70,10 +70,11 @@ $FASTSURFER_HOME/run_fastsurfer.sh \
 
 Pass the same `--t1` as the first run. Editing refines results for one image, so the subject
 directory belongs to that image, and FastSurfer stops with an error rather than mixing two inputs
-into one directory. If you no longer have the original, `<subject_dir>/mri/orig/001.<ext>` is a
-byte-for-byte copy of it, under whatever extension you passed, `001.mgz` for an MGH input and
-`001.nii.gz` for a NIfTI one. Processing a genuinely different image, a bias field corrected version
-for instance, is a new run into a new `--sid`.
+into one directory. The surest way to pass the same file is to pass the copy FastSurfer kept,
+`<subject_dir>/mri/orig/001.<ext>`, which is byte for byte the image you originally gave it, under
+whatever extension you gave it in, `001.mgz` for an MGH input and `001.nii.gz` for a NIfTI one.
+Processing a genuinely different image, a bias field corrected version for instance, is a new run
+into a new `--sid`.
 
 Note, a re-run of the segmentation pipeline, as in the command above, should not be harmful, but is only required if the [asegdkt_segfile](#asegdkt_segfile) was edited. Therefore, in most cases, we can skip the segmentation step with
 ```bash

--- a/doc/overview/OUTPUT_FILES.md
+++ b/doc/overview/OUTPUT_FILES.md
@@ -11,7 +11,8 @@ The segmentation module outputs the files shown in the table below. The two prim
 | mri       | mask.mgz                     | asegdkt | brainmask                                                          |
 | mri       | orig.mgz                     | asegdkt | conformed image                                                    |
 | mri       | orig_nu.mgz                  | asegdkt | biasfield-corrected image                                          |
-| mri/orig  | 001.mgz                      | asegdkt | original image                                                     |
+| mri       | rawavg.mgz                   | input   | input image in MGH format, read by the surface pipeline            |
+| mri/orig  | 001.\<ext\>                  | input   | verbatim copy of the input, in the format it was passed            |
 | scripts   | deep-seg.log                 | asegdkt | logfile                                                            |
 | stats     | aseg+DKT.stats               | asegdkt | table of cortical and subcortical segmentation statistics          |
 

--- a/recon_surf/long_prepare_template.sh
+++ b/recon_surf/long_prepare_template.sh
@@ -329,10 +329,13 @@ for ((i=0;i<${#tpids[@]};++i)); do
   echo "${tpids[i]} with T1 ${t1s[i]}" | tee -a "$LF"
   mdir="$SUBJECTS_DIR/$tid/long-inputs/${tpids[i]}"
   mkdir -p "$mdir"
-  # Import (copy) raw inputs (convert to extension format)
-  t1input=$mdir/cross_input${extension}
-  cmd="mri_convert ${t1s[i]} $t1input"
-  RunIt "$cmd" "$LF"
+  # Import the raw input. copy_input.py archives it verbatim as mri/orig/001.<ext>, which is the
+  # only copy of a time point input the longitudinal stream keeps, and writes mri/rawavg.mgz beside
+  # it. Everything downstream reads the rawavg, so it is an .mgz whatever arrived.
+  cmda=($python "$fastsurfercnndir/copy_input.py" --t1 "${t1s[i]}"
+        --sd "$SUBJECTS_DIR/$tid/long-inputs" --sid "${tpids[i]}")
+  run_it "$LF" "${cmda[@]}"
+  t1input="$mdir/mri/rawavg.mgz"
   
   # conform !!!!!!! should we conform to some common value, determined from all time points?? !!!!!!
   # this is relevant if input resolutions different (which they should not), currently conform min may not work as expected
@@ -355,10 +358,6 @@ for ((i=0;i<${#tpids[@]};++i)); do
          --seg_log "$seg_log" "${run_pred_flags[@]}")
   run_it "$LF" "${cmda[@]}"
 
-  # remove mri subdirectory (run_prediction creates 001 there)
-  cmda=(rm -rf "$mdir/mri")
-  run_it "$LF" "${cmda[@]}"
-  
   # mask is binary, we need to use on conformed image:
   cmda=(mri_mask "$conformed_name" "$mask_name" "$mdir/cross_brainmask${extension}")
   run_it "$LF" "${cmda[@]}"
@@ -452,7 +451,7 @@ for ((i=0;i<${#tpids[@]};++i))
 do
   mdir="$SUBJECTS_DIR/$tid/long-inputs/${tpids[i]}"
   # map orig to base space
-  cmd="mri_convert -at ${ltaXforms[$i]} -rt $interpol $mdir/cross_input${extension} $mdir/long_conform${extension}"
+  cmd="mri_convert -at ${ltaXforms[$i]} -rt $interpol $mdir/mri/rawavg.mgz $mdir/long_conform${extension}"
   RunIt "$cmd" "$LF"
 done
 

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -505,7 +505,8 @@ RunIt "$cmd" "$LF"
 # pctsurfcon reads mri/rawavg.mgz and hardcodes that path. run_fastsurfer.sh writes it from the
 # input, which is the intensity scale FreeSurfer expects there. A subject directory prepared without
 # that step has no rawavg, so fall back to the T1 we were given, which is the conformed image.
-if [[ ! -e "$mdir/rawavg.mgz" ]]
+# --base runs no pctsurfcon, so it needs no rawavg and gets no warning about one.
+if [[ ! -e "$mdir/rawavg.mgz" ]] && [[ "$base" != "true" ]]
 then
   {
     echo "WARNING: $mdir/rawavg.mgz does not exist, linking the passed T1 instead. Gray/white"

--- a/recon_surf/recon-surf.sh
+++ b/recon_surf/recon-surf.sh
@@ -502,10 +502,19 @@ fi
 cmd="mri_convert $asegdkt_segfile $mdir/aparc.DKTatlas+aseg.orig.mgz"
 RunIt "$cmd" "$LF"
 
-# link original T1 input to rawavg (needed by pctsurfcon)
-pushd "$mdir" > /dev/null || ( echo "Could not change to $mdir" ; exit 1 )
-  softlink_or_copy "orig.mgz" "rawavg.mgz" "$LF"
-popd > /dev/null || ( echo "Could not change to subject_dir" ; exit 1 )
+# pctsurfcon reads mri/rawavg.mgz and hardcodes that path. run_fastsurfer.sh writes it from the
+# input, which is the intensity scale FreeSurfer expects there. A subject directory prepared without
+# that step has no rawavg, so fall back to the T1 we were given, which is the conformed image.
+if [[ ! -e "$mdir/rawavg.mgz" ]]
+then
+  {
+    echo "WARNING: $mdir/rawavg.mgz does not exist, linking the passed T1 instead. Gray/white"
+    echo "  contrast (?h.w-g.pct) is then measured on the conformed image rather than on the input."
+  } | tee -a "$LF"
+  pushd "$mdir" > /dev/null || ( echo "Could not change to $mdir" ; exit 1 )
+    softlink_or_copy "orig.mgz" "rawavg.mgz" "$LF"
+  popd > /dev/null || ( echo "Could not change to subject_dir" ; exit 1 )
+fi
 
 
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1081,12 +1081,16 @@ asegdkt_segfile_manedit=$(add_file_suffix "$asegdkt_segfile" "manedit")
 # feeds the gray/white contrast, and measuring that on inpainted voxels would report synthetic
 # tissue. Sampling the original is the better of the two; masking the lesion out of the contrast
 # computation would be better still and is not done here.
-if [[ -n "$t1" ]] && [[ -f "$t1" ]]
+# --base and --long archive nothing: their $t1 is not a user input but an image the pipeline built
+# itself, and long_prepare_template.sh already archived the time point inputs it was built from.
+# --base needs no rawavg either, since it skips pctsurfcon, the one consumer.
+if [[ -n "$t1" ]] && [[ -f "$t1" ]] && [[ "$base" != "true" ]]
 then
   echo "MODULE: Input copy" >> "$exec_time_log"
   {
     cmd=($python "${fastsurfercnndir}/copy_input.py" --t1 "$t1" --sd "$sd" --sid "$subject")
     if [[ -n "$t2" ]] && [[ -f "$t2" ]] ; then cmd+=(--t2 "$t2") ; fi
+    if [[ "$long" == "true" ]] ; then cmd+=(--rawavg_only) ; fi
     echo "INFO: Copying the input to $subject_dir/mri/orig and creating rawavg..."
     echo_quoted "${cmd[@]}"
     "${wrap[@]}" "${cmd[@]}" 2>&1

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -692,7 +692,8 @@ if [[ -z "$build_log" ]] ; then build_log="$subject_dir/scripts/build.log" ; fi
 if [[ -n "$t2" ]] && [[ "$run_seg_pipeline" == "true" ]]
 then
   if [[ ! -f "$t2" ]] ; then echo "ERROR: T2 file $t2 does not exist!" ; exit 1 ; fi
-  copy_name_T2="$subject_dir/mri/orig/T2.001.mgz"
+  # written by copy_input.py, which also places the verbatim copy in mri/orig
+  rawavg_name_t2="$subject_dir/mri/T2.rawavg.mgz"
 fi
 
 if [[ -z "$PYTHONUNBUFFERED" ]] ; then export PYTHONUNBUFFERED=0 ; fi
@@ -1072,6 +1073,27 @@ fi
 
 asegdkt_segfile_manedit=$(add_file_suffix "$asegdkt_segfile" "manedit")
 
+# ============= Copying the input into the subject directory ==================
+# Runs for both pipelines, so that a segmentation-only run leaves behind the rawavg a later
+# surface-only run on the same directory needs.
+if [[ -n "$t1" ]] && [[ -f "$t1" ]]
+then
+  echo "MODULE: Input copy" >> "$exec_time_log"
+  {
+    cmd=($python "${fastsurfercnndir}/copy_input.py" --t1 "$t1" --sd "$sd" --sid "$subject")
+    if [[ -n "$t2" ]] && [[ -f "$t2" ]] ; then cmd+=(--t2 "$t2") ; fi
+    echo "INFO: Copying the input to $subject_dir/mri/orig and creating rawavg..."
+    echo_quoted "${cmd[@]}"
+    "${wrap[@]}" "${cmd[@]}" 2>&1
+    exit $?  # this will only terminate the subshell
+  } | tee -a "$seg_log"
+  if [[ "${PIPESTATUS[0]}" != 0 ]]
+  then
+    echo "ERROR: Copying the input failed!" | tee -a "$seg_log"
+    exit 1
+  fi
+fi
+
 if [[ "$run_seg_pipeline" == "true" ]]
 then
   # ============= Running LIT Inpainting ========================================
@@ -1275,12 +1297,6 @@ then
   then
     echo "MODULE: T2 preprocessing" >> "$exec_time_log"
     {
-      echo "INFO: Copying T2 file to ${copy_name_T2}..."
-      cmd=("nib-convert" "$t2" "$copy_name_T2")
-      echo_quoted "${cmd[@]}"
-      "${wrap[@]}" "${cmd[@]}" 2>&1
-      # do not terminate if this fails
-
       echo "INFO: Robust scaling (partial conforming) of T2 image..."
       cmd=($python "${fastsurfercnndir}/data_loader/conform.py" --orientation native --vox_size any --img_size any
            -i "$t2" -o "$conformed_name_t2")
@@ -1294,7 +1310,7 @@ then
     if [[ "$run_biasfield" == "true" ]]
     then
       # ... we have a t2 image, bias field-correct it (save robustly scaled uchar)
-      cmd=($python "${reconsurfdir}/N4_bias_correct.py" "--in" "$copy_name_T2" --out "$norm_name_t2"
+      cmd=($python "${reconsurfdir}/N4_bias_correct.py" "--in" "$rawavg_name_t2" --out "$norm_name_t2"
            --threads "$threads_seg" --uchar)
       {
         echo "INFO: Running N4 bias-field correction of the t2..."

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -441,7 +441,8 @@ case $key in
   --sid) subject="$1" ; shift ;;
   --sd) sd="$1" ; shift ;;
   --t1) t1="$1" ; shift ;;
-  --t2) t2="$1" ; shift ;;
+  # not for base: the template has no T2, long_prepare_template.sh rejects --t2 as well
+  --t2) t2="$1" ; warn_base+=("$key" "$1") ; shift ;;
   --lesion_mask) lesion_mask="$1" ; run_lit_module="true" ; shift ;;
   --seg_log) seg_log="$1" ; shift ;;
   --conformed_name) conformed_name="$1" ; warn_seg_only+=("$key" "$1") ; shift ;;

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -1077,6 +1077,10 @@ asegdkt_segfile_manedit=$(add_file_suffix "$asegdkt_segfile" "manedit")
 # ============= Copying the input into the subject directory ==================
 # Runs for both pipelines, so that a segmentation-only run leaves behind the rawavg a later
 # surface-only run on the same directory needs.
+# This is deliberately before the LIT module, which replaces $t1 with the inpainted image: rawavg
+# feeds the gray/white contrast, and measuring that on inpainted voxels would report synthetic
+# tissue. Sampling the original is the better of the two; masking the lesion out of the contrast
+# computation would be better still and is not done here.
 if [[ -n "$t1" ]] && [[ -f "$t1" ]]
 then
   echo "MODULE: Input copy" >> "$exec_time_log"

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -692,8 +692,9 @@ if [[ -z "$build_log" ]] ; then build_log="$subject_dir/scripts/build.log" ; fi
 if [[ -n "$t2" ]] && [[ "$run_seg_pipeline" == "true" ]]
 then
   if [[ ! -f "$t2" ]] ; then echo "ERROR: T2 file $t2 does not exist!" ; exit 1 ; fi
-  # written by copy_input.py, which also places the verbatim copy in mri/orig
-  rawavg_name_t2="$subject_dir/mri/T2.rawavg.mgz"
+  # written by copy_input.py, which also places the verbatim copy beside it; recon-all converts a
+  # -T2 input to this same path, so samseg and -T2pial find it where they expect
+  rawavg_name_t2="$subject_dir/mri/orig/T2raw.mgz"
 fi
 
 if [[ -z "$PYTHONUNBUFFERED" ]] ; then export PYTHONUNBUFFERED=0 ; fi

--- a/test/image/test_copy_input.py
+++ b/test/image/test_copy_input.py
@@ -15,8 +15,8 @@ import numpy as np
 import pytest
 
 from FastSurferCNN.copy_input import (
-    RAWAVG_NAME,
-    T2_RAWAVG_NAME,
+    RAWAVG_PATH,
+    T2_RAWAVG_PATH,
     archive_input,
     image_suffix,
     main,
@@ -43,16 +43,6 @@ def mgh(path, dtype=np.uint8):
     return path
 
 
-def test_image_suffix():
-    """A compound extension has to survive, or the copy silently changes format."""
-    from pathlib import Path
-    assert image_suffix(Path("T1.nii.gz")) == ".nii.gz"
-    assert image_suffix(Path("T1.mgz")) == ".mgz"
-    assert image_suffix(Path("T1.nii")) == ".nii"
-    assert image_suffix(Path("sub-01_T1w.RMS.nii.gz")) == ".nii.gz"
-    assert image_suffix(Path("T1.mgh")) == ".mgh"
-
-
 @pytest.mark.parametrize("maker", [scaled_nifti, mgh], ids=["nii.gz", "mgz"])
 def test_the_archival_copy_is_byte_for_byte(maker, tmp_path):
     """Nothing about the input may change, including the parts an .mgz could not represent."""
@@ -68,7 +58,7 @@ def test_rawavg_from_a_nifti_is_a_converted_mgz(tmp_path):
     """The values carry over and the field of view is set, which a plain nibabel write leaves at 0."""
     source = scaled_nifti(tmp_path / "input.nii.gz")
     copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
-    rawavg = tmp_path / "sub" / "mri" / RAWAVG_NAME
+    rawavg = tmp_path / "sub" / "mri" / RAWAVG_PATH
 
     write_rawavg(copy, rawavg)
 
@@ -84,7 +74,7 @@ def test_rawavg_from_an_mgz_is_a_relative_symlink(tmp_path):
     """The bytes are already right, so a second copy would only be a second copy."""
     source = mgh(tmp_path / "input.mgz")
     copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
-    rawavg = tmp_path / "sub" / "mri" / RAWAVG_NAME
+    rawavg = tmp_path / "sub" / "mri" / RAWAVG_PATH
 
     write_rawavg(copy, rawavg)
 
@@ -96,7 +86,7 @@ def test_rawavg_from_an_mgz_is_a_relative_symlink(tmp_path):
 def test_rerunning_replaces_an_existing_rawavg(tmp_path):
     """A second run must not fail on the symlink or the file the first one left."""
     orig_dir = tmp_path / "sub" / "mri" / "orig"
-    rawavg = tmp_path / "sub" / "mri" / RAWAVG_NAME
+    rawavg = tmp_path / "sub" / "mri" / RAWAVG_PATH
 
     write_rawavg(archive_input(mgh(tmp_path / "a.mgz"), orig_dir), rawavg)
     assert rawavg.is_symlink()
@@ -118,8 +108,8 @@ def test_a_nifti_t2_is_archived_and_converted(tmp_path):
     mri = tmp_path / "sub" / "mri"
     assert filecmp.cmp(t1, mri / "orig" / "001.mgz", shallow=False)
     assert filecmp.cmp(t2, mri / "orig" / "T2raw.nii.gz", shallow=False)
-    assert (mri / RAWAVG_NAME).is_symlink(), "the T1 was an mgz"
-    assert nib.load(mri / T2_RAWAVG_NAME).get_data_dtype() == np.dtype(">f4")
+    assert (mri / RAWAVG_PATH).is_symlink(), "the T1 was an mgz"
+    assert nib.load(mri / T2_RAWAVG_PATH).get_data_dtype() == np.dtype(">f4")
 
 
 def test_an_mgz_t2_needs_only_one_file(tmp_path):
@@ -129,7 +119,7 @@ def test_an_mgz_t2_needs_only_one_file(tmp_path):
 
     assert main(t1=t1, sd=tmp_path, sid="sub", t2=t2) == 0
 
-    t2raw = tmp_path / "sub" / "mri" / T2_RAWAVG_NAME
+    t2raw = tmp_path / "sub" / "mri" / T2_RAWAVG_PATH
     assert t2raw == tmp_path / "sub" / "mri" / "orig" / "T2raw.mgz"
     assert not t2raw.is_symlink(), "it is the copy, not a link to one"
     assert filecmp.cmp(t2, t2raw, shallow=False)

--- a/test/image/test_copy_input.py
+++ b/test/image/test_copy_input.py
@@ -158,6 +158,21 @@ def test_a_nifti_t2_is_archived_and_converted(tmp_path):
     assert nib.load(mri / T2_RAWAVG_PATH).get_data_dtype() == np.dtype(">f4")
 
 
+def test_rerunning_a_nifti_t2_is_not_a_conflict(tmp_path):
+    """Its rawavg is written into mri/orig too, so it matches the same names as the archive."""
+    t1 = mgh(tmp_path / "t1.mgz")
+    t2 = scaled_nifti(tmp_path / "t2.nii.gz")
+
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=t2) == 0
+    orig_dir = tmp_path / "sub" / "mri" / "orig"
+    assert sorted(p.name for p in orig_dir.iterdir()) == ["001.mgz", "T2raw.mgz", "T2raw.nii.gz"]
+
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=t2) == 0, "the same inputs again is a re-run"
+    # but a different T2 still is a conflict, and the converted rawavg must not hide the old archive
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=scaled_nifti(tmp_path / "other.nii.gz", slope=0.5)) == 1
+    assert filecmp.cmp(t2, orig_dir / "T2raw.nii.gz", shallow=False), "the first archive is intact"
+
+
 def test_an_mgz_t2_needs_only_one_file(tmp_path):
     """Its archival copy already sits at the name the tools read, so there is nothing to convert."""
     t1 = scaled_nifti(tmp_path / "t1.nii.gz")

--- a/test/image/test_copy_input.py
+++ b/test/image/test_copy_input.py
@@ -60,7 +60,7 @@ def test_rawavg_from_a_nifti_is_a_converted_mgz(tmp_path):
     copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
     rawavg = tmp_path / "sub" / "mri" / RAWAVG_PATH
 
-    write_rawavg(copy, rawavg)
+    write_rawavg(source, rawavg, archive=copy)
 
     written = nib.load(rawavg)
     assert not rawavg.is_symlink(), "a converted rawavg is a real file"
@@ -76,7 +76,7 @@ def test_rawavg_from_an_mgz_is_a_relative_symlink(tmp_path):
     copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
     rawavg = tmp_path / "sub" / "mri" / RAWAVG_PATH
 
-    write_rawavg(copy, rawavg)
+    write_rawavg(source, rawavg, archive=copy)
 
     assert rawavg.is_symlink()
     assert rawavg.readlink().as_posix() == "orig/001.mgz", "relative, so the directory can move"
@@ -85,17 +85,63 @@ def test_rawavg_from_an_mgz_is_a_relative_symlink(tmp_path):
 
 def test_rerunning_replaces_an_existing_rawavg(tmp_path):
     """A second run must not fail on the symlink or the file the first one left."""
-    orig_dir = tmp_path / "sub" / "mri" / "orig"
+    mgz = mgh(tmp_path / "a.mgz")
+    nifti = scaled_nifti(tmp_path / "b.nii.gz")
     rawavg = tmp_path / "sub" / "mri" / RAWAVG_PATH
 
-    write_rawavg(archive_input(mgh(tmp_path / "a.mgz"), orig_dir), rawavg)
+    write_rawavg(mgz, rawavg, archive=archive_input(mgz, tmp_path / "sub" / "mri" / "orig"))
     assert rawavg.is_symlink()
-    # now the other way round, so the symlink has to give way to a real file
-    write_rawavg(archive_input(scaled_nifti(tmp_path / "b.nii.gz"), orig_dir), rawavg)
+    # a second subject whose input is a NIfTI, so the symlink has to give way to a real file
+    write_rawavg(nifti, rawavg, archive=archive_input(nifti, tmp_path / "other" / "orig"))
     assert not rawavg.is_symlink()
     # and back again
-    write_rawavg(archive_input(mgh(tmp_path / "c.mgz"), orig_dir), rawavg)
+    write_rawavg(mgz, rawavg, archive=archive_input(mgz, tmp_path / "third" / "orig"))
     assert rawavg.is_symlink()
+
+
+def test_a_conflicting_archive_stops_the_run(tmp_path):
+    """Two inputs cannot share one subject directory, and nothing could tell their copies apart."""
+    assert main(t1=mgh(tmp_path / "a.mgz"), sd=tmp_path, sid="sub") == 0
+    assert main(t1=scaled_nifti(tmp_path / "b.nii.gz"), sd=tmp_path, sid="sub") == 1
+
+    orig_dir = tmp_path / "sub" / "mri" / "orig"
+    assert [p.name for p in orig_dir.iterdir()] == ["001.mgz"], "the first archive is untouched"
+    # the same input again is a re-run, not a conflict
+    assert main(t1=tmp_path / "a.mgz", sd=tmp_path, sid="sub") == 0
+
+
+def test_a_different_image_under_the_same_extension_stops_the_run(tmp_path):
+    """The extension says nothing about the image, so the archive is compared byte for byte."""
+    assert main(t1=mgh(tmp_path / "a.mgz"), sd=tmp_path, sid="sub") == 0
+
+    assert main(t1=mgh(tmp_path / "b.mgz", dtype=np.int16), sd=tmp_path, sid="sub") == 1
+    assert filecmp.cmp(tmp_path / "a.mgz", tmp_path / "sub" / "mri" / "orig" / "001.mgz",
+                       shallow=False), "the first archive is untouched"
+
+
+def test_rawavg_only_writes_no_archive(tmp_path):
+    """What --base and --long need: their input is built by the pipeline, not passed by the user."""
+    t1 = scaled_nifti(tmp_path / "t1.nii.gz")
+
+    assert main(t1=t1, sd=tmp_path, sid="sub", rawavg_only=True) == 0
+
+    mri = tmp_path / "sub" / "mri"
+    assert (mri / RAWAVG_PATH).is_file()
+    assert not (mri / "orig").exists()
+
+
+def test_every_part_of_a_multi_file_image_is_copied(tmp_path):
+    """An Analyze .hdr without its .img is not an image, so both are copied and both keep the stem."""
+    data = np.arange(np.prod(SHAPE), dtype=np.int16).reshape(SHAPE)
+    nib.save(nib.Nifti1Pair(data, np.diag([1.0, 1.0, 1.0, 1.0])), tmp_path / "input.img")
+
+    assert main(t1=tmp_path / "input.img", sd=tmp_path, sid="sub") == 0
+
+    orig_dir = tmp_path / "sub" / "mri" / "orig"
+    assert sorted(p.name for p in orig_dir.iterdir()) == ["001.hdr", "001.img"]
+    assert np.array_equal(np.asanyarray(nib.load(orig_dir / "001.img").dataobj), data)
+    # and a second run of the same input recognises both parts rather than reporting a conflict
+    assert main(t1=tmp_path / "input.hdr", sd=tmp_path, sid="sub") == 0
 
 
 def test_a_nifti_t2_is_archived_and_converted(tmp_path):

--- a/test/image/test_copy_input.py
+++ b/test/image/test_copy_input.py
@@ -108,8 +108,8 @@ def test_rerunning_replaces_an_existing_rawavg(tmp_path):
     assert rawavg.is_symlink()
 
 
-def test_a_t2_gets_the_same_pair(tmp_path):
-    """N4 reads the T2 rawavg, so both halves have to be there."""
+def test_a_nifti_t2_is_archived_and_converted(tmp_path):
+    """N4 reads mri/orig/T2raw.mgz, the path recon-all also converts a -T2 input to."""
     t1 = mgh(tmp_path / "t1.mgz")
     t2 = scaled_nifti(tmp_path / "t2.nii.gz")
 
@@ -117,10 +117,22 @@ def test_a_t2_gets_the_same_pair(tmp_path):
 
     mri = tmp_path / "sub" / "mri"
     assert filecmp.cmp(t1, mri / "orig" / "001.mgz", shallow=False)
-    assert filecmp.cmp(t2, mri / "orig" / "T2.001.nii.gz", shallow=False)
+    assert filecmp.cmp(t2, mri / "orig" / "T2raw.nii.gz", shallow=False)
     assert (mri / RAWAVG_NAME).is_symlink(), "the T1 was an mgz"
-    assert (mri / T2_RAWAVG_NAME).exists() and not (mri / T2_RAWAVG_NAME).is_symlink()
     assert nib.load(mri / T2_RAWAVG_NAME).get_data_dtype() == np.dtype(">f4")
+
+
+def test_an_mgz_t2_needs_only_one_file(tmp_path):
+    """Its archival copy already sits at the name the tools read, so there is nothing to convert."""
+    t1 = scaled_nifti(tmp_path / "t1.nii.gz")
+    t2 = mgh(tmp_path / "t2.mgz")
+
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=t2) == 0
+
+    t2raw = tmp_path / "sub" / "mri" / T2_RAWAVG_NAME
+    assert t2raw == tmp_path / "sub" / "mri" / "orig" / "T2raw.mgz"
+    assert not t2raw.is_symlink(), "it is the copy, not a link to one"
+    assert filecmp.cmp(t2, t2raw, shallow=False)
 
 
 def test_a_missing_input_is_reported(tmp_path):
@@ -129,5 +141,5 @@ def test_a_missing_input_is_reported(tmp_path):
     assert not (tmp_path / "sub").exists()
 
     t1 = mgh(tmp_path / "t1.mgz")
-    assert main(t1=t1, sd=tmp_path, sid="sub", t2=tmp_path / "absent.nii.gz") == 1
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=tmp_path / "absent.mgz") == 1
     assert not (tmp_path / "sub").exists(), "the T1 is not copied when the T2 is missing"

--- a/test/image/test_copy_input.py
+++ b/test/image/test_copy_input.py
@@ -1,0 +1,133 @@
+"""Tests for the input copies FastSurfer places in the subject directory.
+
+``mri/orig/001.<ext>`` is a byte-for-byte copy of the input, so a re-encoding of it would not do:
+a scaled NIfTI carries its scale factor and its own data type, and an .mgz cannot hold either.
+
+``mri/rawavg.mgz`` is the copy FreeSurfer's tools read, ``pctsurfcon`` in particular, which builds
+that path itself. It has to be an MGH file whatever arrived, and it has to carry the field of view,
+which a plain nibabel write leaves at 0.
+"""
+
+import filecmp
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from FastSurferCNN.copy_input import (
+    RAWAVG_NAME,
+    T2_RAWAVG_NAME,
+    archive_input,
+    image_suffix,
+    main,
+    write_rawavg,
+)
+
+SHAPE = (12, 14, 16)
+
+
+def scaled_nifti(path, dtype=np.int16, slope=0.001):
+    """A NIfTI that reads back as float64, as scanner conversion routinely produces."""
+    affine = np.diag([0.8, 0.9, 1.0, 1.0])
+    data = np.arange(np.prod(SHAPE), dtype=dtype).reshape(SHAPE)
+    image = nib.Nifti1Image(data, affine)
+    image.header.set_slope_inter(slope, 0.0)
+    nib.save(image, path)
+    return path
+
+
+def mgh(path, dtype=np.uint8):
+    affine = np.diag([1.0, 1.0, 1.0, 1.0])
+    data = np.arange(np.prod(SHAPE), dtype=np.int64).reshape(SHAPE) % 200
+    nib.save(nib.MGHImage(data.astype(dtype), affine), path)
+    return path
+
+
+def test_image_suffix():
+    """A compound extension has to survive, or the copy silently changes format."""
+    from pathlib import Path
+    assert image_suffix(Path("T1.nii.gz")) == ".nii.gz"
+    assert image_suffix(Path("T1.mgz")) == ".mgz"
+    assert image_suffix(Path("T1.nii")) == ".nii"
+    assert image_suffix(Path("sub-01_T1w.RMS.nii.gz")) == ".nii.gz"
+    assert image_suffix(Path("T1.mgh")) == ".mgh"
+
+
+@pytest.mark.parametrize("maker", [scaled_nifti, mgh], ids=["nii.gz", "mgz"])
+def test_the_archival_copy_is_byte_for_byte(maker, tmp_path):
+    """Nothing about the input may change, including the parts an .mgz could not represent."""
+    source = maker(tmp_path / f"input{'.nii.gz' if maker is scaled_nifti else '.mgz'}")
+
+    copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
+
+    assert copy.name == f"001{image_suffix(source)}"
+    assert filecmp.cmp(source, copy, shallow=False), "the copy differs from the input"
+
+
+def test_rawavg_from_a_nifti_is_a_converted_mgz(tmp_path):
+    """The values carry over and the field of view is set, which a plain nibabel write leaves at 0."""
+    source = scaled_nifti(tmp_path / "input.nii.gz")
+    copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
+    rawavg = tmp_path / "sub" / "mri" / RAWAVG_NAME
+
+    write_rawavg(copy, rawavg)
+
+    written = nib.load(rawavg)
+    assert not rawavg.is_symlink(), "a converted rawavg is a real file"
+    assert written.get_data_dtype() == np.dtype(">f4"), "float64 is not storable, float32 is"
+    expected_fov = max(n * z for n, z in zip(SHAPE, written.header.get_zooms()[:3], strict=True))
+    assert float(written.header["fov"]) == pytest.approx(expected_fov)
+    assert np.allclose(np.asanyarray(written.dataobj), np.asanyarray(nib.load(source).dataobj))
+
+
+def test_rawavg_from_an_mgz_is_a_relative_symlink(tmp_path):
+    """The bytes are already right, so a second copy would only be a second copy."""
+    source = mgh(tmp_path / "input.mgz")
+    copy = archive_input(source, tmp_path / "sub" / "mri" / "orig")
+    rawavg = tmp_path / "sub" / "mri" / RAWAVG_NAME
+
+    write_rawavg(copy, rawavg)
+
+    assert rawavg.is_symlink()
+    assert rawavg.readlink().as_posix() == "orig/001.mgz", "relative, so the directory can move"
+    assert filecmp.cmp(source, rawavg, shallow=False)
+
+
+def test_rerunning_replaces_an_existing_rawavg(tmp_path):
+    """A second run must not fail on the symlink or the file the first one left."""
+    orig_dir = tmp_path / "sub" / "mri" / "orig"
+    rawavg = tmp_path / "sub" / "mri" / RAWAVG_NAME
+
+    write_rawavg(archive_input(mgh(tmp_path / "a.mgz"), orig_dir), rawavg)
+    assert rawavg.is_symlink()
+    # now the other way round, so the symlink has to give way to a real file
+    write_rawavg(archive_input(scaled_nifti(tmp_path / "b.nii.gz"), orig_dir), rawavg)
+    assert not rawavg.is_symlink()
+    # and back again
+    write_rawavg(archive_input(mgh(tmp_path / "c.mgz"), orig_dir), rawavg)
+    assert rawavg.is_symlink()
+
+
+def test_a_t2_gets_the_same_pair(tmp_path):
+    """N4 reads the T2 rawavg, so both halves have to be there."""
+    t1 = mgh(tmp_path / "t1.mgz")
+    t2 = scaled_nifti(tmp_path / "t2.nii.gz")
+
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=t2) == 0
+
+    mri = tmp_path / "sub" / "mri"
+    assert filecmp.cmp(t1, mri / "orig" / "001.mgz", shallow=False)
+    assert filecmp.cmp(t2, mri / "orig" / "T2.001.nii.gz", shallow=False)
+    assert (mri / RAWAVG_NAME).is_symlink(), "the T1 was an mgz"
+    assert (mri / T2_RAWAVG_NAME).exists() and not (mri / T2_RAWAVG_NAME).is_symlink()
+    assert nib.load(mri / T2_RAWAVG_NAME).get_data_dtype() == np.dtype(">f4")
+
+
+def test_a_missing_input_is_reported(tmp_path):
+    """And reported before anything is written, so a typo does not leave a half-built directory."""
+    assert main(t1=tmp_path / "absent.mgz", sd=tmp_path, sid="sub") == 1
+    assert not (tmp_path / "sub").exists()
+
+    t1 = mgh(tmp_path / "t1.mgz")
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=tmp_path / "absent.nii.gz") == 1
+    assert not (tmp_path / "sub").exists(), "the T1 is not copied when the T2 is missing"

--- a/test/image/test_copy_input.py
+++ b/test/image/test_copy_input.py
@@ -171,6 +171,8 @@ def test_rerunning_a_nifti_t2_is_not_a_conflict(tmp_path):
     # but a different T2 still is a conflict, and the converted rawavg must not hide the old archive
     assert main(t1=t1, sd=tmp_path, sid="sub", t2=scaled_nifti(tmp_path / "other.nii.gz", slope=0.5)) == 1
     assert filecmp.cmp(t2, orig_dir / "T2raw.nii.gz", shallow=False), "the first archive is intact"
+    # and the archive the error names is one the caller can pass straight back in
+    assert main(t1=t1, sd=tmp_path, sid="sub", t2=orig_dir / "T2raw.nii.gz") == 0
 
 
 def test_an_mgz_t2_needs_only_one_file(tmp_path):

--- a/test/image/test_mgh_dtype.py
+++ b/test/image/test_mgh_dtype.py
@@ -143,7 +143,7 @@ def int64_of(*values):
     ids=["small", "signed", "large", "float64"],
 )
 def test_storable_dtype_writes_the_archival_copy(data, expected, tmp_path):
-    """mri/orig/001.mgz, whose type belongs to whoever produced the input file.
+    """mri/rawavg.mgz, whose type belongs to whoever produced the input file.
 
     int64 is the default integer width in numpy and float64 is what a scaled NIfTI reads back as,
     and MGH stores neither. Such data has to land on a type the format has: the narrowest that holds

--- a/test/quicktest/data/expected-files.yaml
+++ b/test/quicktest/data/expected-files.yaml
@@ -66,7 +66,6 @@ files:
   - "mri/aparc.DKTatlas+aseg.mgz"
   - "mri/aparc+aseg.mgz"
   - "mri/wmparc.mgz"
-  - "mri/rawavg.mgz"
   - "mri/transforms/talairach_avi.log"
   - "mri/transforms/talairach.auto.xfm"
   - "mri/transforms/talairach.auto.xfm.lta"

--- a/test/quicktest/data/expected-files.yaml
+++ b/test/quicktest/data/expected-files.yaml
@@ -1,3 +1,8 @@
+# Globs, for outputs whose name depends on the input. The archival copy of the input keeps the
+# input's own extension, so it is 001.mgz for an MGH input and 001.nii.gz for a NIfTI one.
+file_patterns:
+  - "mri/orig/001.*"
+
 files:
   - "scripts/deep-seg.log"
   - "scripts/build.log"
@@ -61,7 +66,7 @@ files:
   - "mri/aparc.DKTatlas+aseg.mgz"
   - "mri/aparc+aseg.mgz"
   - "mri/wmparc.mgz"
-  - "mri/orig/001.mgz"
+  - "mri/rawavg.mgz"
   - "mri/transforms/talairach_avi.log"
   - "mri/transforms/talairach.auto.xfm"
   - "mri/transforms/talairach.auto.xfm.lta"

--- a/test/quicktest/test_file_existence.py
+++ b/test/quicktest/test_file_existence.py
@@ -55,7 +55,11 @@ def test_file_existence(
     missing_files = expected_files - files_for_test_subject
     assert files_for_test_subject >= expected_files, f"Files {tuple(missing_files)} do not exist in test subject."
 
-    unmatched = [p for p in expected_patterns if not any(Path(test_subject.path).glob(p))]
+    # condition again, so a directory or a touch file cannot satisfy a pattern that asks for output
+    unmatched = [
+        pattern for pattern in expected_patterns
+        if not any(condition(match) for match in Path(test_subject.path).glob(pattern))
+    ]
     assert unmatched == [], f"Patterns {tuple(unmatched)} match no file in test subject."
 
     logger.debug("All files present.")

--- a/test/quicktest/test_file_existence.py
+++ b/test/quicktest/test_file_existence.py
@@ -15,7 +15,18 @@ def expected_files() -> set[str]:
         return set(yaml.safe_load(fp)["files"])
 
 
-def test_file_existence(test_subject: SubjectDefinition, expected_files: set[str]):
+@pytest.fixture(scope="session")
+def expected_patterns() -> list[str]:
+    """Globs, for the outputs whose name depends on the input, see the yaml."""
+    with open(Path(__file__).parent / "data/expected-files.yaml") as fp:
+        return list(yaml.safe_load(fp).get("file_patterns", []))
+
+
+def test_file_existence(
+        test_subject: SubjectDefinition,
+        expected_files: set[str],
+        expected_patterns: list[str],
+):
     """
     Test the existence of files for the subject test_subject.
 
@@ -25,6 +36,8 @@ def test_file_existence(test_subject: SubjectDefinition, expected_files: set[str
         Definition of the test subject.
     expected_files : set of str
         The set of files expected to be present in the subject.
+    expected_patterns : list of str
+        Globs that each have to match at least one file in the subject.
 
     Raises
     ------
@@ -41,5 +54,8 @@ def test_file_existence(test_subject: SubjectDefinition, expected_files: set[str
     # Check if each file in the reference list exists in the test list
     missing_files = expected_files - files_for_test_subject
     assert files_for_test_subject >= expected_files, f"Files {tuple(missing_files)} do not exist in test subject."
+
+    unmatched = [p for p in expected_patterns if not any(Path(test_subject.path).glob(p))]
+    assert unmatched == [], f"Patterns {tuple(unmatched)} match no file in test subject."
 
     logger.debug("All files present.")


### PR DESCRIPTION
`mri/orig/001.mgz` was written by `run_prediction.py` through nibabel, re-encoding the input
into MGH. For a scaled NIfTI that write raised inside a discarded `Future`, so the file was
silently absent; otherwise it was a lossy record of what had been processed. `mri/rawavg.mgz`
did not exist, so `recon-surf.sh` linked it to the conformed `orig.mgz` and `pctsurfcon`
measured the gray/white contrast on the conformed image instead of on the input.

Two files now, with distinct jobs:

- `mri/orig/001.<ext>` is a byte-for-byte copy of the input, under the extension it arrived
  with, placed by `run_fastsurfer.sh`. Nothing reads it back. Formats spread over several
  files, such as an Analyze `.hdr` and `.img` pair, are copied whole. A T2 is copied the same
  way as `mri/orig/T2raw.<ext>`, the name recon-all uses.
- `mri/rawavg.mgz` is what the tools read. It is a relative symlink to the archival copy when
  the input is already an `.mgz`, and a conversion through `save_image` otherwise, which sets
  `fov`. The T2 equivalent is `mri/orig/T2raw.mgz`, which N4 now reads.

Also in this PR:

- The copy runs for both pipelines, so a seg-only run leaves behind the rawavg a later
  surf-only run needs, and before the LIT module, so the contrast is measured on real tissue
  rather than on inpainted voxels.
- An archive of a different image stops the run. The comparison is byte for byte, so a
  different image under the same extension is caught too. One subject directory belongs to one
  input.
- `--base` writes neither file, since its input is the template the pipeline built and it skips
  `pctsurfcon`. `--long` writes rawavg only.
- `long_prepare_template.sh` imports each time point through `copy_input.py` rather than
  `mri_convert`, so the only copy the longitudinal stream keeps of a time point input is
  verbatim. Both consumers read the resulting `rawavg.mgz`.
- `run_prediction.py` holds the conformed-image write in a deque the main loop drains, so a
  failure in the pool reaches the exit code.
- `SubjectDirectory.copy_orig_name` and its plumbing are removed.

Known consequences:

- `?h.w-g.pct.stats` is now measured on the input. With a zero minimum, conform's rescale is a
  pure multiplication that the contrast cancels, leaving quantisation noise.
- Base directories no longer contain `mri/rawavg.mgz`.
- Re-running into a directory that already holds an archive of a different image fails instead
  of overwriting. The message names the archived copy to pass in order to reprocess the same
  input, and asks for a subject id of its own for a different image.

Tests: `test/image/test_copy_input.py` covers the verbatim copy, both rawavg paths, multi-file
inputs, the two conflict cases and `--rawavg_only`. `expected-files.yaml` gained a glob section
for outputs whose name depends on the input.