### PR TITLE
Fix the CerebNet checkpoint URL, which pointed at a superseded b2share deposit

### DIFF
--- a/CerebNet/config/checkpoint_paths.yaml
+++ b/CerebNet/config/checkpoint_paths.yaml
@@ -1,5 +1,7 @@
+# both hosts serve the published models, record 582b5b7ab6304dc8b3cf15310a365267 on b2share and
+# record 10390742 on zenodo, with matching checksums
 url:
-- "https://b2share.fz-juelich.de/api/files/c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5"
+- "https://b2share.fz-juelich.de/api/files/864b2ed5-e91e-4c2c-aa7a-c16b7c751b35"
 - "https://zenodo.org/records/10390742/files"
 
 checkpoint:


### PR DESCRIPTION
b2share holds two versions of the CerebNet checkpoints with the same name. Our code (yaml) was not updated with the weights in 2023 and therefore still downloads the old version from b2shre (and the new version from Zenodo). So depending on which server a user hits, they get different Networks and different results. Worse: our Releases differ depending on what server was used (e.g. 2.5 latest uses the old weights). 


`CerebNet/config/checkpoint_paths.yaml` listed b2share bucket
`c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5` as the first download host. That bucket is not the
file bucket of the published record. It holds a different set of models:


c6cf7bc6-2ae5-4d0e-814d-2a3cf0e1a8c5 uploaded 2023-02-16
21714150 md5:625a4b79... CerebNet_axial_v1.0.0.pkl
21714150 md5:619578f4... CerebNet_coronal_v1.0.0.pkl
21705766 md5:8e9ebc9a... CerebNet_sagittal_v1.0.0.pkl

864b2ed5-e91e-4c2c-aa7a-c16b7c751b35 uploaded 2023-03-01, published record
21714342 md5:b62511c3... CerebNet_axial_v1.0.0.pkl 582b5b7ab6304dc8b3cf15310a365267
21714342 md5:840f87fa... CerebNet_coronal_v1.0.0.pkl
21705894 md5:eb836ed9... CerebNet_sagittal_v1.0.0.pkl

The second bucket's checksums match the zenodo record, so the two hosts do agree once the
URL points at the right place. This PR changes that one URL.

The two sets are different trained models, not two serialisations of one. All 205 tensors
differ, `mean|d| = 0.26` and `max|d| = 3.5`, and the checkpoint metadata says why:

| | old bucket | published |
|---|---|---|
| axial epoch | 63 | 69 |
| coronal epoch | 62 | 69 |
| experiment | `train_val/CerebNet_Augm_Aux05_<plane>` | `final_model/CerebNet_Augm_Aux10_<plane>` |
| training data | `train_val/Native_Manual_Auxiliary_train.hdf5` | `train_test/Native_Manual_Auxiliary_train.hdf5` |
| `BIAS_FIELD_COEFFICIENTS` | `0.5` | `[-0.5, 0.5]` |

Both records were uploaded in early 2023 and neither has been modified since, so this has
been the case from the start rather than being a recent change.

## Effect on results

`download_checkpoint` takes the first URL that answers, so which weights a build ends up
with depended on which host it reached. Comparing `scripts/build.log` across runs of the
quicktest subjects:

- The released `deepmi/fastsurfer:cpu-v2.5.4` image carries the old bucket's checksums.
- The v2.3.3 reference and CI builds of both the v2.5.4 tag and `dev` carry the published ones.

On those two subjects the difference in `mri/cerebellum.CerebNet.nii.gz` is 13044 voxels at
1.0mm, 10.40% of labelled cerebellum, and 9778 at 0.8mm, 6.67%. `orig.mgz` and
`aparc.DKTatlas+aseg.deep.mgz`, the two inputs CerebNet reads, are bit identical between
those runs, so the checkpoints are the whole difference. The other three modules are
unaffected: the aparc_vinn, HypVINN and FastSurferCC checksums are the same in every run.

Builds that reached zenodo, including CI, were already using the published weights and will
not change. Anything built against the old bucket will now produce a different cerebellum.

## Verification

- The published bucket listing was fetched from the b2share API and matches the table above.
- The axial and coronal files were downloaded in full from both hosts and hashed. They agree.
- The sagittal file was not downloaded from zenodo directly. Its checksum matches what the
  reference and CI builds recorded through the zenodo fallback, which is the same source, but
  a direct check is still worth one run.