### PR TITLE
Fix the broken API source links, and mark and cross-link the documentation trees

### DIFF
--- a/doc/_static/doc-version-link.js
+++ b/doc/_static/doc-version-link.js
@@ -1,15 +1,17 @@
 // Point the links in the announcement bar at the sibling documentation tree.
 //
 // The bar is one HTML string shared by every page, so a relative path would resolve differently
-// depending on how deep the page is. Sphinx renders rel="index" relative to the tree root on every
-// page, so resolving it gives the root, and the sibling tree is one level up from there. That keeps
-// this independent of the domain and of the path prefix the site is served under.
+// depending on how deep the page is. Every page loads its assets from _static at the tree root, so
+// resolving any of those gives the root, and the sibling tree is one level up from there. That
+// keeps this independent of the domain, of the path prefix the site is served under, and of any
+// theme or config option: without _static there would be no stylesheet and no page to read.
 window.addEventListener("DOMContentLoaded", function () {
-    var index = document.querySelector('link[rel="index"]');
-    if (!index) {
-        return;  // no index to anchor on, leave the fallback href in place
+    var asset = document.querySelector('link[href*="_static/"], script[src*="_static/"]');
+    if (!asset) {
+        return;  // nothing to anchor on, leave the fallback href in place
     }
-    var root = new URL("./", new URL(index.getAttribute("href"), window.location.href));
+    var url = new URL(asset.getAttribute("href") || asset.getAttribute("src"), window.location.href);
+    var root = new URL(url.pathname.slice(0, url.pathname.lastIndexOf("_static/")), url);
     document.querySelectorAll("a[data-doc-tree]").forEach(function (link) {
         link.href = new URL("../" + link.dataset.docTree + "/", root).href;
     });

--- a/doc/_static/doc-version-link.js
+++ b/doc/_static/doc-version-link.js
@@ -1,0 +1,16 @@
+// Point the links in the announcement bar at the sibling documentation tree.
+//
+// The bar is one HTML string shared by every page, so a relative path would resolve differently
+// depending on how deep the page is. Sphinx renders rel="index" relative to the tree root on every
+// page, so resolving it gives the root, and the sibling tree is one level up from there. That keeps
+// this independent of the domain and of the path prefix the site is served under.
+window.addEventListener("DOMContentLoaded", function () {
+    var index = document.querySelector('link[rel="index"]');
+    if (!index) {
+        return;  // no index to anchor on, leave the fallback href in place
+    }
+    var root = new URL("./", new URL(index.getAttribute("href"), window.location.href));
+    document.querySelectorAll("a[data-doc-tree]").forEach(function (link) {
+        link.href = new URL("../" + link.dataset.docTree + "/", root).href;
+    });
+});

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -146,12 +146,26 @@ html_theme_options = {
 publish_ref = os.environ.get("GITHUB_REF_NAME", "")
 documents_a_release = publish_ref == "stable" or re.fullmatch(r"v\d+\..+", publish_ref) is not None
 
-# Every other build, the dev tree included, describes code ahead of the newest release, so it says
-# so in a bar above the page content.
-if not documents_a_release:
+# The announcement bar is the only site-wide notice furo offers, so it also carries the link to the
+# other published tree. The href here is a fallback that is only correct at the tree root;
+# doc-version-link.js rewrites it for the page it actually ends up on.
+html_js_files = ["doc-version-link.js"]
+_other_tree = "dev" if documents_a_release else "stable"
+_other_link = (
+    f'<a href="../{_other_tree}/" data-doc-tree="{_other_tree}">{_other_tree} documentation</a>'
+)
+
+if documents_a_release:
+    html_theme_options["announcement"] = (
+        f"This documents the latest release. The {_other_link} covers changes that are not "
+        "released yet."
+    )
+else:
+    # Every other build, the dev tree included, describes code ahead of the newest release.
     html_theme_options["announcement"] = (
         "You are reading the documentation of the development version. It may describe features "
-        "and options that are not part of a release yet."
+        f"and options that are not part of a release yet. See the {_other_link} for the latest "
+        "release."
     )
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,6 +8,8 @@
 
 import importlib
 import io
+import os
+import re
 import sys
 from pathlib import Path
 
@@ -135,6 +137,20 @@ html_theme_options = {
         },
     ],
 }
+
+# doc.yml publishes each build to gh-pages under the ref it was built from, so that ref is what
+# says whether this tree documents a release. It is read from the environment rather than from git,
+# because actions/checkout leaves a detached HEAD and `git branch --show-current` is empty there.
+publish_ref = os.environ.get("GITHUB_REF_NAME", branch)
+documents_a_release = publish_ref == "stable" or re.fullmatch(r"v\d+\..+", publish_ref) is not None
+
+# Every other build, the dev tree included, describes code ahead of the newest release, so it says
+# so in a bar above the page content.
+if not documents_a_release:
+    html_theme_options["announcement"] = (
+        "You are reading the documentation of the development version. It may describe features "
+        "and options that are not part of a release yet."
+    )
 
 
 # -- autosummary -------------------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,8 +32,9 @@ _version_info(file=_streambuf)
 _version_dict = parse_build_file(_streambuf)
 
 # the commit, not the branch: `git_branch` needs a non-empty `sections` to be filled in at all, and
-# actions/checkout leaves a detached HEAD where `git branch --show-current` is empty anyway
-commit = _version_dict["git_hash"]
+# actions/checkout leaves a detached HEAD where `git branch --show-current` is empty anyway. The
+# hash is optional in the version line, so fall back to a ref that exists rather than to nothing.
+commit = _version_dict["git_hash"] or "dev"
 version = _version_dict["version"]
 
 # -- General configuration ---------------------------------------------------
@@ -120,6 +121,7 @@ default_role = "py:obj"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 html_theme = "furo"
 html_static_path = ["_static"]
+html_js_files = ["doc-version-link.js"]  # points the announcement bar at the sibling doc tree
 html_title = project
 html_show_sphinx = False
 
@@ -143,13 +145,15 @@ html_theme_options = {
 # doc.yml publishes each build to gh-pages under the ref it was built from, so that ref is what
 # says whether this tree documents a release. It is read from the environment rather than from git,
 # because actions/checkout leaves a detached HEAD and `git branch --show-current` is empty there.
+# The tag pattern matches the release tags this project actually uses, all of them X.Y.Z. A tag
+# with a suffix falls through to the development wording, which is the safe way round. doc.yml
+# publishes no tags today, so only "stable" reaches this in practice.
 publish_ref = os.environ.get("GITHUB_REF_NAME", "")
-documents_a_release = publish_ref == "stable" or re.fullmatch(r"v\d+\..+", publish_ref) is not None
+documents_a_release = publish_ref == "stable" or re.fullmatch(r"v\d+\.\d+\.\d+", publish_ref) is not None
 
 # The announcement bar is the only site-wide notice furo offers, so it also carries the link to the
 # other published tree. The href here is a fallback that is only correct at the tree root;
 # doc-version-link.js rewrites it for the page it actually ends up on.
-html_js_files = ["doc-version-link.js"]
 _other_tree = "dev" if documents_a_release else "stable"
 _other_link = (
     f'<a href="../{_other_tree}/" data-doc-tree="{_other_tree}">{_other_tree} documentation</a>'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,9 @@ _streambuf = io.StringIO()
 _version_info(file=_streambuf)
 _version_dict = parse_build_file(_streambuf)
 
-branch = _version_dict["git_branch"]
+# the commit, not the branch: `git_branch` needs a non-empty `sections` to be filled in at all, and
+# actions/checkout leaves a detached HEAD where `git branch --show-current` is empty anyway
+commit = _version_dict["git_hash"]
 version = _version_dict["version"]
 
 # -- General configuration ---------------------------------------------------
@@ -141,7 +143,7 @@ html_theme_options = {
 # doc.yml publishes each build to gh-pages under the ref it was built from, so that ref is what
 # says whether this tree documents a release. It is read from the environment rather than from git,
 # because actions/checkout leaves a detached HEAD and `git branch --show-current` is empty there.
-publish_ref = os.environ.get("GITHUB_REF_NAME", branch)
+publish_ref = os.environ.get("GITHUB_REF_NAME", "")
 documents_a_release = publish_ref == "stable" or re.fullmatch(r"v\d+\..+", publish_ref) is not None
 
 # Every other build, the dev tree included, describes code ahead of the newest release, so it says
@@ -251,7 +253,9 @@ def import_from_path(module_name, file_path):
     spec.loader.exec_module(module)
     return module
 
-linkcode_resolve = LinkCodeResolver(gh_url, branch)
+# linking at the commit rather than at a branch keeps the line numbers in each link matching the
+# code that was documented, however far the branch moves afterwards
+linkcode_resolve = LinkCodeResolver(gh_url, commit)
 
 _re_script_dirs = "fastsurfercnn|cerebnet|recon_surf|hypvinn|corpuscallosum"
 _up = "^/\\.\\./"

--- a/doc/sphinx_ext/resolve_links.py
+++ b/doc/sphinx_ext/resolve_links.py
@@ -7,14 +7,22 @@ _logger = logging.getLogger("fastsurfer.doc.linkcode_resolve")
 
 class LinkCodeResolver:
 
-    def __init__(self, url, branch="dev"):
-        self._gh_url = url
-        self._branch = branch
+    def __init__(self, url, ref="dev"):
+        """
+        Resolve source links into the GitHub repository at `url`.
+
+        `ref` is anything GitHub accepts in a blob path, a branch, a tag or a commit hash. An empty
+        one is rejected rather than silently producing `/blob//...`, which GitHub answers with a 404.
+        """
+        if not ref:
+            raise ValueError("LinkCodeResolver needs a git ref to link to, got an empty one.")
+        self._gh_url = url.rstrip("/")
+        self._ref = ref
 
     @property
     def base_path(self):
         # Base URL to the GitHub repository where the source code is hosted
-        return f"{self._gh_url}/blob/{self._branch}"
+        return f"{self._gh_url}/blob/{self._ref}"
 
     def __call__(self, domain, info):
         # Check if the domain is Python, if not return None
@@ -72,9 +80,6 @@ class LinkCodeResolver:
 
         # Replace "." with "/" in the module name to construct the file path
         filename = quote(info["module"].replace(".", "/"))
-        # If the filename doesn't start with "tests", add a "/" at the beginning
-        if not filename.startswith("tests"):
-            filename = "/" + filename
 
         # Construct the URL that points to the source code of the object on GitHub
-        return f"{self.base_path}{filename}.py#L{first_line}-L{first_line + len(lines) - 1}"
+        return f"{self.base_path}/{filename}.py#L{first_line}-L{first_line + len(lines) - 1}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ full = [
 
 [project.urls]
 homepage = 'https://fastsurfer.org'
-documentation = 'https://fastsurfer.org'
+documentation = 'https://deep-mi.org/FastSurfer/stable'
 source = 'https://github.com/Deep-MI/FastSurfer'
 tracker = 'https://github.com/Deep-MI/FastSurfer/issues'
 

--- a/tools/Docker/Dockerfile
+++ b/tools/Docker/Dockerfile
@@ -58,7 +58,7 @@
 #   - default: "<no repository set>"
 # - DOC_URL:
 #   The documentation URL of fastsurfer to include in image labels.
-#   - default: "https://fastsurfer.org/fastsurfer/dev"
+#   - default: "https://deep-mi.org/FastSurfer/dev"
 # - VENDOR:
 #   The vendor string to include in image labels.
 #   - default: "Image Analysis Lab, DZNE https://deep-mi.org/"
@@ -98,7 +98,7 @@ ARG FREESURFER_URL="not set"
 ARG FASTSURFER_VERSION="dev"
 ARG GIT_HASH=""
 ARG REPOSITORY_URL="<no repository set>"
-ARG DOC_URL="https://fastsurfer.org/fastsurfer/dev"
+ARG DOC_URL="https://deep-mi.org/FastSurfer/dev"
 ARG VENDOR="Image Analysis Lab, DZNE https://deep-mi.org/"
 ARG AUTHOR="FastSurfer Developers <https://github.com/Deep-MI/FastSurfer>"
 ARG BUILDKIT_SBOM_SCAN_CONTEXT="true"

--- a/tools/Docker/build.py
+++ b/tools/Docker/build.py
@@ -734,7 +734,8 @@ def main(
     if has_git():
         kwargs["build_arg"].append(f"GIT_HASH={build_info['git_hash']}")
         if build_info["git_branch"] == "stable":
-            kwargs["build_arg"].append("DOC_URL=https://deep-mi.org/fastsurfer/stable")
+            # the path is case sensitive, /fastsurfer/ is a 404
+            kwargs["build_arg"].append("DOC_URL=https://deep-mi.org/FastSurfer/stable")
     kwargs["build_arg"].extend([
         f"FASTSURFER_VERSION={build_info['version_tag']}",
         f"REPOSITORY_URL={repository_url}",


### PR DESCRIPTION
**Every `[source]` link in the API documentation was a 404.** `doc/conf.py` passed
`_version_dict["git_branch"]` to `LinkCodeResolver`, but that value is always empty:
`_version_info()` is called with the default `sections=""`, and `version.py` only queries
the branch when `sections` is non-empty. So the links were built as
`https://github.com/Deep-MI/FastSurfer/blob//CerebNet/apply_warp.py#L29-L53`, note the
double slash, which GitHub answers with 404. Confirmed live on both published trees.

They now use the commit hash, which is populated, always resolves, and unlike a branch
keeps the line numbers matching the code that was documented. `resolve_links.py` rejects
an empty ref instead of silently producing `blob//`, and joins the path with exactly one
slash.

**`DOC_URL` pointed at a page that does not exist.** The OCI label baked into every
published image was `https://fastsurfer.org/fastsurfer/dev`, a 404, and
`tools/Docker/build.py` used `https://deep-mi.org/fastsurfer/stable`, also a 404 because
the path is case sensitive. Both now point at `https://deep-mi.org/FastSurfer/...`, as the
issue templates already did. `pyproject.toml`'s `documentation` URL pointed at the research
landing page rather than the documentation.

**The two published trees are now marked and cross-linked.** A bar above the page content
says whether you are reading a release or the development version, and links to the other
tree. The condition uses `GITHUB_REF_NAME`, the same value `doc.yml` uses for
`destination_dir`, so the banner and the publish location cannot disagree.
`doc/_static/doc-version-link.js` resolves the sibling tree from `rel="index"` rather than
from a hardcoded path, because the bar is one string shared by every page and a relative
path would break on nested ones.

Verified by building with `-WT --keep-going` for both `dev` and `stable`, checking the
generated links from a nested page, and confirming the new link shape returns 200 against a
pushed commit.